### PR TITLE
fixes: macos

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ converting the AST to x86_64 assembly code which is fed into gcc to assemble.
 ## Compatability
 Currently the this will compile x86_64 assembly and works on linux and intel
 macs.
+This has been tested on an intel mac and linux ubuntu on amd. Most `x86_64`
+architectures should be supported. Creating an `IR` and compiling to `ARM`
+is high on the TODO list.
 
 ## Building
 Run `make`, then run `make install` (`sudo make install` on linux) this will 
@@ -38,8 +41,11 @@ etc... see ./src/holyc-lib/
 - You can call any libc code with `extern "c" <type> <function_name>`
 
 ## Bugs
-This is a non exhuastive list of things that are buggy
+This is a non exhuastive list of things that are buggy, if you find somethings
+please open an issue or open a pr.
 - using `%f` for string formatting floats not work
+- memory management for the compiler is virtually non-existant, presently all
+  the tokens are made before compiling which is very slow.
 - line number in error messages is sometimes off and does not report the file
 - function pointers in a parameter list have to come at the end
 - Variable arguments are all passed on the stack

--- a/src/holyc-lib/threads.HC
+++ b/src/holyc-lib/threads.HC
@@ -232,7 +232,6 @@ U0 ThreadPoolWait(ThreadPool *pool)
 {//Wait for all jobs in the queue to be complete
   pthread_mutex_lock(&pool->lock);
   while (!ListEmpty(pool->jobs) || pool->active_threads != 0) {
-    "listcnt: %d active: %d\n",ListCount(pool->jobs),pool->active_threads;
     pthread_cond_wait(&pool->no_work,&pool->lock);
   }
   pthread_mutex_unlock(&pool->lock);

--- a/src/main.c
+++ b/src/main.c
@@ -53,19 +53,6 @@ int hccLibInit(hccLib *lib, hccOpts *opts, char *name) {
     aoStr *dylibcmd = aoStrNew();
     aoStr *stylibcmd = aoStrNew();
     aoStr *installcmd = aoStrNew();
-
-    /*
-     *
-     *
-     *cp -pPR ./tos.dylib /usr/local/lib/tos.0.0.1.dylib
-cp -pPR ./tos.a /usr/local/lib/
-cp ../../holyc-lang-website/website/lexer.HC ./scripts/
-cp ./tos.HH /usr/local/include/
-cp ./holyc-lib/tos.HH ~/.holyc-lib/
-cp /Users/jamesbarford-evans/.holyc-lib/tos.HH ./holyc-lib/
-ln -sf ./tos.0.0.1.dylib ./tos.dylib
-     *
-     * */
     
 #if IS_BSD
     snprintf(lib->stylib_name,LIB_BUFSIZ,"%s.a",name);
@@ -196,7 +183,7 @@ void emitFile(aoStr *asmbuf, hccOpts *opts) {
     } else if (opts->emit_dylib) {
         writeAsmToTmp(asmbuf);
         hccLibInit(&lib,opts,opts->lib_name);
-        aoStrCatPrintf(cmd, "gcc -fPIC -c %s -lpthread -lsqlite3 -lc -lm -o ./%s",
+        aoStrCatPrintf(cmd, "gcc -fPIC -c %s -o ./%s",
                 ASM_TMP_FILE,opts->obj_outfile);
         fprintf(stderr,"%s\n",cmd->data);
         system(cmd->data);


### PR DESCRIPTION
- README tweaks
- Remove comment
- Remove linking flags when compiling with `-fPIC`