### PR TITLE
Feat: `#if` `#elif`,`defined()`  + function prototype updates

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -13,6 +13,10 @@
 
 AstType *ast_u8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=0};
 AstType *ast_i8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=1};
+AstType *ast_i16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=1};
+AstType *ast_u16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=0};
+AstType *ast_i32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=1};
+AstType *ast_u32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=0};
 AstType *ast_int_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=1};
 AstType *ast_uint_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=0};
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -239,6 +239,10 @@ extern AstType *ast_u8_type;
 extern AstType *ast_i8_type;
 extern AstType *ast_float_type;
 extern AstType *ast_void_type;
+extern AstType *ast_i16_type;
+extern AstType *ast_u16_type;
+extern AstType *ast_i32_type;
+extern AstType *ast_u32_type;
 extern Ast *placeholder_arg;
 
 Ast *AstNew(void);

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -244,9 +244,14 @@ lexeme *CctrlTokenGet(Cctrl *cc) {
 void CctrlTokenExpect(Cctrl *cc, long expected) {
     lexeme *tok = CctrlTokenGet(cc);
     if (!TokenPunctIs(tok, expected)) {
-        loggerPanic("Syntax error in on line %d: expected '%c' got: %.*s\n",
-                tok->line, (char)expected,
-                tok->len, tok->start);
+        if (!tok) {
+            lexemePrintList(cc->tkit->tokens->next);
+            loggerPanic("line %ld: Ran out of tokens\n",cc->lineno);
+        } else {
+            loggerPanic("line %d: Syntax error in on line expected '%c' got: %.*s\n",
+                    tok->line, (char)expected,
+                    tok->len, tok->start);
+        }
     }
 }
 

--- a/src/compile.c
+++ b/src/compile.c
@@ -78,10 +78,10 @@ int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     tokens = ListNew();
     builtin_path = aoStrDupRaw("/usr/local/include/tos.HH",25); //aoStrNew();
 
-    lexerInit(&l,NULL);
-    l.flags |= lexer_flags;
+    lexerInit(&l,NULL,CCF_PRE_PROC);
     l.seen_files = seen_files;
     l.lineno = 1;
+    lexerSetBuiltinRoot(&l,"/usr/local/include/");
 
     /* library files */
     lexPushFile(&l,aoStrDupRaw(entrypath,strlen(entrypath)));
@@ -100,18 +100,11 @@ int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     return 1;
 }
 
-aoStr *CompileFile(Cctrl *cc, char *file_path) {
-    aoStr *asm_str;
-    CompileToAst(cc,file_path,CCF_PRE_PROC);
-    asm_str = CompileToAsm(cc);
-    return asm_str;
-}
-
 aoStr *CompileCode(Cctrl *cc, char *code, int lexer_flags) {
     aoStr *asm_str;
     List *tokens;
     lexer l;
-    lexerInit(&l,code);
+    lexerInit(&l,code,lexer_flags);
     tokens = lexToLexemes(cc->macro_defs,&l);
     CctrlInitTokenIter(cc,tokens);
     ParseToAst(cc);

--- a/src/compile.h
+++ b/src/compile.h
@@ -6,9 +6,7 @@
 
 int CompileToToAst(Cctrl *cc, char *file_path, int lexer_flags);
 aoStr *CompileToAsm(Cctrl *cc);
-aoStr *CompileCode(Cctrl *cc, char *code, int lexer_flags);
 void CompileAssembleToFile(aoStr *asmbuf, char *filename);
-aoStr *CompileFile(Cctrl *cc, char *file_path);
 void CompilePrintTokens(Cctrl *cc);
 void CompilePrintAst(Cctrl *cc);
 int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags);

--- a/src/holyc-lib/json.HC
+++ b/src/holyc-lib/json.HC
@@ -68,7 +68,7 @@ class Json
     U8 *str;
     U8 *strnum;
     F64 f64;
-    I64 int;
+    I64 i64;
     Bool boolean;
   };
 };
@@ -276,7 +276,7 @@ static U0 JsonParseNumber(JsonParser *p)
   }
 
   if (num_len == 1) {
-    current->int = JsonPeek(p)-'0';
+    current->i64 = JsonPeek(p)-'0';
     current->type = JSON_INT;
     JsonAdvance(p);
     return;
@@ -291,7 +291,7 @@ static U0 JsonParseNumber(JsonParser *p)
     } else {
       res = strtoll(ptr,&endptr);
     }
-    current->int = res;
+    current->i64 = res;
     current->type = JSON_INT;
     JsonUnsafeAdvanceBy(p, num_len);
     return;
@@ -487,7 +487,7 @@ static U0 JsonToStringInternal(Json *J, JsonStringBuilder *js)
     if (J->key) js->buf = CatLenPrint(js->buf,&js->len,"\"%Q\": ",J->key);
     switch (J->type) {
       case JSON_INT:
-        js->buf = CatLenPrint(js->buf,&js->len,"%d",J->int);
+        js->buf = CatLenPrint(js->buf,&js->len,"%d",J->i64);
         break;
       case JSON_FLOAT:
         js->buf = CatLenPrint(js->buf,&js->len,"%f",J->f64);

--- a/src/holyc-lib/sqllite.HC
+++ b/src/holyc-lib/sqllite.HC
@@ -54,7 +54,7 @@ class SqlParam
   I64 type;
   union 
   {
-    I64 int;
+    I64 i64;
     F64 f64;
     U8 *str;
     class 
@@ -77,7 +77,7 @@ class SqlColumn
   I64 len;
   I64 type;
   union {
-    I64 int;
+    I64 i64;
     U8 *str;
     U0 *blob;
     F64 f64;
@@ -222,7 +222,7 @@ I32 SqlExecPrepared(SqlPreparedStmt *pstmt, SqlRow *row, SqlParam *params)
     SqlParam *param = &params[i];
     switch (param->type) {
       case SQL_INT:
-        sqlite3_bind_int64(pstmt->stmt, i + 1, param->int);
+        sqlite3_bind_int64(pstmt->stmt, i + 1, param->i64);
         break;
       case SQL_FLOAT:
         sqlite3_bind_double(pstmt->stmt, i + 1, param->f64);
@@ -272,7 +272,7 @@ static I32 SqlExecQuery(SqlCtx *ctx, SqlRow *row, U8 *sql, SqlParam *params,
       case SQL_INT:
         /* The leftmost SQL parameter has an index of 1 ref:
          * https://www.sqlite.org/c3ref/bind_blob.html */
-        rc = sqlite3_bind_int64(stmt, i + 1, params[i].int);
+        rc = sqlite3_bind_int64(stmt, i + 1, params[i].i64);
         break;
       case SQL_FLOAT:
         rc = sqlite3_bind_double(stmt, i + 1, params[i].f64);
@@ -357,7 +357,7 @@ static Bool SqlIterGeneric(SqlRow *row, I32 free_row)
     row->col[i].type = sqlite3_column_type(row->stmt,i);
     switch (row->col[i].type) {
       case SQLITE_INTEGER:
-        row->col[i].int = sqlite3_column_int64(row->stmt,i);
+        row->col[i].i64 = sqlite3_column_int64(row->stmt,i);
         break;
       case SQLITE_FLOAT:
         row->col[i].f64 = sqlite3_column_double(row->stmt,i);
@@ -373,7 +373,7 @@ static Bool SqlIterGeneric(SqlRow *row, I32 free_row)
       default:
         /* XXX: You may want to handle this case differently */
         row->col[i].str = NULL;
-        row->col[i].int = 0;
+        row->col[i].i64 = 0;
         row->col[i].f64 = 0;
         break;
     }

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -815,7 +815,7 @@ class Json
     Bool boolean;
     U8 *strnum;
     F64 f64;
-    I64 int;
+    I64 i64;
   };
 };
 #define JSON_OK 0
@@ -903,7 +903,7 @@ class SqlParam
   I64 type;
   union 
   {
-    I64 int;
+    I64 i64;
     F64 f64;
     U8 *str;
     class 
@@ -927,7 +927,7 @@ class SqlColumn
   I64 type;
   union
   {
-    I64 int;
+    I64 i64;
     U8 *str;
     U0 *blob;
     F64 f64;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -158,7 +158,8 @@ typedef struct lexer {
 lexeme *lexemeTokNew(char *start, int len, int line, long ch);
 lexeme *lexemeNew(char *start, int len);
 lexeme *lexemeSentinal(void);
-void lexerInit(lexer *l, char *source);
+void lexerSetBuiltinRoot(lexer *l, char *root);
+void lexerInit(lexer *l, char *source, int flag);
 void lexPushFile(lexer *l, aoStr *filename);
 int lex(lexer *l, lexeme *le);
 List *lexToLexemes(Dict *macro_defs, lexer *l);

--- a/src/main.c
+++ b/src/main.c
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "compile.h"
 #include "cctrl.h"
+#include "lexer.h"
 #include "util.h"
 
 #define ASM_TMP_FILE "/tmp/holyc-asm.s"
@@ -221,14 +222,14 @@ void usage(void) {
             "HolyC Compiler 2024. UNSTABLE\n"
             "hcc [..OPTIONS] <..file>\n\n"
             "OPTIONS:\n"
-            "  -ast     print the ast and exit\n"
-            "  -tokens  print the tokens and exit\n"
-            "  -S       emit assembly only\n"
-            "  -obj     emit an objectfile\n"
-            "  -lib     emit a dynamic and static library\n"
-            "  -clibs   link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`\n"
-            "  -g       not implemented\n"
-            "  --help   print this message\n");
+            "  -ast     Print the ast and exit\n"
+            "  -tokens  Print the tokens and exit\n"
+            "  -S       Emit assembly only\n"
+            "  -obj     Emit an objectfile\n"
+            "  -lib     Emit a dynamic and static library\n"
+            "  -clibs   Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`\n"
+            "  -g       Not implemented\n"
+            "  --help   Print this message\n");
     exit(1);
 }
 
@@ -291,7 +292,7 @@ int main(int argc, char **argv) {
         exit(EXIT_FAILURE);
     }
     hccOpts opts;
-
+    int lexer_flags = CCF_PRE_PROC;
     aoStr *asmbuf;
     Cctrl *cc;
     
@@ -302,7 +303,8 @@ int main(int argc, char **argv) {
     parseCliOptions(&opts,argc,argv);
     
     cc = CctrlNew();
-    CompileToAst(cc,opts.infile,CCF_PRE_PROC);
+    
+    CompileToAst(cc,opts.infile,lexer_flags);
 
     if (opts.print_tokens) {
         CompilePrintTokens(cc);

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -193,6 +193,7 @@ long EvalIntConstExpr(Ast *ast) {
             return ~ast->operand->i64;
         }
     }
+    case '!': return !EvalIntConstExpr(ast->operand);
     case TK_EQU_EQU: return EvalIntConstExpr(ast->left) == EvalIntConstExpr(ast->right);
     case TK_GREATER_EQU: return EvalIntConstExpr(ast->left) >= EvalIntConstExpr(ast->right);
     case TK_LESS_EQU: return EvalIntConstExpr(ast->left) <= EvalIntConstExpr(ast->right);

--- a/tests/29_macros.HC
+++ b/tests/29_macros.HC
@@ -16,9 +16,18 @@
 #define BAR 4
 #endif
 
+
+#if defined(__FOO__)
+#define _INTVAL (420)
+#elif defined(_SOME_STRING) && 32 && 1 && \
+  defined(_SOME_INT_MATHS)
+#define _INTVAL (42)
+#endif
+
+
 U0 Main()
 {
-  I64 correct = 0, tests = 5;
+  I64 correct = 0, tests = 6;
   "Test - Preprocessor: ";
 
   if (!StrCmp(_SOME_STRING,"Hello World")) correct++;
@@ -26,6 +35,8 @@ U0 Main()
   if (_SOME_FLOAT_MATHS == 18.64) correct++;
   if (FOO == 24) correct++;
   if (BAR == 32) correct++;
+  if (_INTVAL == 42) correct++;
   PrintResult(correct,tests);
   "====\n";
 }
+

--- a/tests/31_json.HC
+++ b/tests/31_json.HC
@@ -20,7 +20,7 @@ U0 Main()
 
   auto obj = JsonSelect(j,".hello:i");
   if (obj) {
-    if (obj->int == 10) correct++;
+    if (obj->i64 == 10) correct++;
   }
 
   U8 *str = JsonToString(j);
@@ -44,16 +44,16 @@ U0 Main()
   }
 
   if ((obj = JsonSelect(j,".array[0]:i"))) {
-    if (obj->int == 1) correct++;
+    if (obj->i64 == 1) correct++;
   }
   if ((obj = JsonSelect(j,".array[1]:i"))) {
-    if (obj->int == 30030303) correct++;
+    if (obj->i64 == 30030303) correct++;
   }
   if ((obj = JsonSelect(j,".array[2]"))) {
-    if (obj->int == 430) correct++;
+    if (obj->i64 == 430) correct++;
   }
   if ((obj = JsonSelect(j,".array[3]:i"))) {
-    if (obj->int == -14) correct++;
+    if (obj->i64 == -14) correct++;
   }
 
   JsonRelease(j);

--- a/tests/32_sql.HC
+++ b/tests/32_sql.HC
@@ -61,7 +61,7 @@ Bool TestSelect(SqlCtx *ctx)
   I64 count = 0;
   if (ok) {
     while (SqlIter(&row)) {
-      auto id = row.col[0].int;
+      auto id = row.col[0].i64;
       auto name = row.col[1].str;
       count++;
       switch (count) {


### PR DESCRIPTION
- allow for `#if` `#elif` & `defined`
- function prototypes no longer require named variables
- don't use `c` keywords for the name of anything
- `!` can be used in `EvalIntCostExpr`
- Update `29_macros.HC` tests
- Added other global definitions for int sizes