### PR TITLE
Fix: do-while & test

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -277,6 +277,8 @@ Ast *AstFor(Ast *init, Ast *cond, Ast *step, Ast *body, aoStr *for_begin,
 Ast *AstIf(Ast *cond, Ast *then, Ast *els);
 Ast *AstWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
         aoStr *while_end);
+Ast *AstDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin, 
+        aoStr *while_end);
 Ast *AstContinue(aoStr *continue_label);
 Ast *AstBreak(aoStr *break_label);
 Ast *AstCase(aoStr *case_label, long case_begin, long case_end);

--- a/src/parser.c
+++ b/src/parser.c
@@ -640,7 +640,7 @@ Ast *ParseDoWhileStatement(Cctrl *cc) {
     cc->localenv = cc->localenv->parent;
     cc->tmp_loop_begin = prev_begin;
     cc->tmp_loop_end = prev_end;
-    return AstWhile(whilecond,whilebody,while_begin, while_end);
+    return AstDoWhile(whilecond,whilebody,while_begin, while_end);
 }
 
 Ast *ParseBreakStatement(Cctrl *cc) {

--- a/tests/20_loops.HC
+++ b/tests/20_loops.HC
@@ -23,7 +23,6 @@ U0 TestForLoop()
   }
 
   PrintResult(passed,test_cases);
-  "=====\n";
 }
 
 U0 TestWhileLoop()
@@ -38,11 +37,24 @@ U0 TestWhileLoop()
     passed++;
   }
   PrintResult(passed,test_cases);
-  "=====\n";
+}
+
+U0 TestDoWhileLoop()
+{
+  "Testing do-while loop: ";
+  I64 i = 10;
+  do {
+    i = i + 1;
+
+  } while (i < 10);
+  PrintResult(i == 11, 1);
 }
 
 I32 Main()
 {
+  "Loop test suite\n";
   TestForLoop();
   TestWhileLoop();  
+  TestDoWhileLoop();
+  "=====\n";
 }


### PR DESCRIPTION
# Description
- Fixes `do-while`, the AST for a `while` was being used instead of `do-while` which meant it was not working
- Added a test for a `do-while` loop