### PR TITLE
Fix/memory allocation

### DIFF
--- a/src/compile.c
+++ b/src/compile.c
@@ -13,7 +13,7 @@
 #include "parser.h"
 #include "util.h"
 
-void CompilePrintTokens(Cctrl *cc) {
+void compilePrintTokens(Cctrl *cc) {
     if (!cc->tkit->tokens || 
             cc->tkit->tokens == cc->tkit->tokens->next) {
         loggerWarning("No tokens to print\n");
@@ -22,7 +22,7 @@ void CompilePrintTokens(Cctrl *cc) {
     lexemePrintList(cc->tkit->tokens);
 }
 
-void CompilePrintAst(Cctrl *cc) {
+void compilePrintAst(Cctrl *cc) {
     List *it;
     Ast *ast;
     //DictNode *dn;
@@ -58,7 +58,7 @@ void CompilePrintAst(Cctrl *cc) {
     }
 }
 
-aoStr *CompileToAsm(Cctrl *cc) {
+aoStr *compileToAsm(Cctrl *cc) {
     if (cc->ast_list == NULL) {
         loggerWarning("Create AST before compiling AST\n");
         return NULL;
@@ -68,7 +68,7 @@ aoStr *CompileToAsm(Cctrl *cc) {
     return asmbuf;
 }
 
-int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
+List *compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags) {
     List *tokens;
     lexer l;
     aoStr *builtin_path;
@@ -89,6 +89,33 @@ int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     lexPushFile(&l,builtin_path);
 
     tokens = lexToLexemes(cc->macro_defs,&l);
+    lexemePrintList(tokens);
+    DictRelease(seen_files);
+    return tokens;
+}
+
+int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
+    List *tokens;
+    lexer l;
+    aoStr *builtin_path;
+    Dict *seen_files;
+
+    seen_files = DictNew(&default_table_type);
+    tokens = ListNew();
+    builtin_path = aoStrDupRaw("/usr/local/include/tos.HH",25); //aoStrNew();
+
+    lexerInit(&l,NULL,CCF_PRE_PROC);
+    l.seen_files = seen_files;
+    l.lineno = 1;
+    lexerSetBuiltinRoot(&l,"/usr/local/include/");
+
+    /* library files */
+    lexPushFile(&l,aoStrDupRaw(entrypath,strlen(entrypath)));
+    /* the structure is a stack so this will get popped first */
+    lexPushFile(&l,builtin_path);
+
+    tokens = lexToLexemes(cc->macro_defs,&l);
+
     DictRelease(seen_files);
     CctrlInitTokenIter(cc,tokens);
     ParseToAst(cc);
@@ -100,7 +127,7 @@ int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     return 1;
 }
 
-aoStr *CompileCode(Cctrl *cc, char *code, int lexer_flags) {
+aoStr *compileCode(Cctrl *cc, char *code, int lexer_flags) {
     aoStr *asm_str;
     List *tokens;
     lexer l;
@@ -108,7 +135,7 @@ aoStr *CompileCode(Cctrl *cc, char *code, int lexer_flags) {
     tokens = lexToLexemes(cc->macro_defs,&l);
     CctrlInitTokenIter(cc,tokens);
     ParseToAst(cc);
-    asm_str = CompileToAsm(cc);
+    asm_str = compileToAsm(cc);
     lexemeListRelease(tokens);
     free(l.files);
     return asm_str;

--- a/src/compile.h
+++ b/src/compile.h
@@ -4,11 +4,13 @@
 #include "aostr.h"
 #include "cctrl.h"
 
-int CompileToToAst(Cctrl *cc, char *file_path, int lexer_flags);
-aoStr *CompileToAsm(Cctrl *cc);
-void CompileAssembleToFile(aoStr *asmbuf, char *filename);
-void CompilePrintTokens(Cctrl *cc);
-void CompilePrintAst(Cctrl *cc);
-int CompileToAst(Cctrl *cc, char *entrypath, int lexer_flags);
+int compileToToAst(Cctrl *cc, char *file_path, int lexer_flags);
+aoStr *compileToAsm(Cctrl *cc);
+void compileAssembleToFile(aoStr *asmbuf, char *filename);
+void compilePrintTokens(Cctrl *cc);
+void compilePrintAst(Cctrl *cc);
+
+int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags);
+List *compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags);
 
 #endif // !COMPILE_H

--- a/src/holyc-lib/memory.HC
+++ b/src/holyc-lib/memory.HC
@@ -46,11 +46,9 @@ _REALLOC::
     MOV     RDI, -16[RBP]
     CALL    _MALLOC
     MOV     -24[RBP], RAX
-    MOV     RDI, -8[RBP]
-    CALL    _MSIZE
-    MOV     RDX, RAX
     MOV     RSI, -8[RBP]
     MOV     RDI, -24[RBP]
+    MOV     RDX, -16[RBP]
     CALL    _MEMCPY
     MOV     RDI, -8[RBP]
     CALL    _FREE

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -270,9 +270,10 @@ U8 *StrNew(U8 *buf)
   U8 *res;
   I64 size;
   if (buf) {
-    size=StrLen(buf)+1;
-    res=MAlloc(size);
+    size = StrLen(buf)+1;
+    res = MAlloc(size);
     MemCpy(res,buf,size);
+    res[size-1] = '\0';
   } else {
     res=MAlloc(1);
     *res=0;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -194,6 +194,7 @@ char *lexemeTypeToString(int tk_type) {
     case TK_CHAR_CONST: return "TK_CHAR_CONST";
     case TK_STR:   return "TK_STR";
     }
+    loggerDebug("%d\n",tk_type);
     return "UNKNOWN";
 }
 
@@ -233,32 +234,31 @@ char *lexemeToString(lexeme *tok) {
     char *tmp;
     switch (tok->tk_type) {
         case TK_IDENT:
-            aoStrCatPrintf(str,"TK_IDENT\t%.*s",tok->len,tok->start);
+            aoStrCatPrintf(str,"TK_IDENT      %.*s",tok->len,tok->start);
             return aoStrMove(str);
         case TK_CHAR_CONST:
-            aoStrCatPrintf(str,"TK_CHAR_CONST\t%x",tok->i64);
+            aoStrCatPrintf(str,"TK_CHAR_CONST %x",tok->i64);
             return aoStrMove(str);
         case TK_PUNCT: {
-            aoStrCatPrintf(str,"TK_PUNCT\t");
             tmp = lexemePunctToString(tok->i64);
-            aoStrCatPrintf(str,"%s",tmp);
+            aoStrCatPrintf(str,"TK_PUNCT      %s", tmp);
             free(tmp);
             return aoStrMove(str);
         }
         case TK_I64:
-            aoStrCatPrintf(str,"TK_I64\t%lld",tok->i64);
+            aoStrCatPrintf(str,"TK_I64        %lld",tok->i64);
             return aoStrMove(str);
         case TK_F64:
-            aoStrCatPrintf(str,"TK_F64\t%g",tok->f64);
+            aoStrCatPrintf(str,"TK_F64        %g",tok->f64);
             return aoStrMove(str);
         case TK_STR:
-            aoStrCatPrintf(str,"TK_STR\t\"%.*s\"",tok->len,tok->start);
+            aoStrCatPrintf(str,"TK_STR        \"%.*s\"",tok->len,tok->start);
             return aoStrMove(str);
         case TK_EOF:
             aoStrCatPrintf(str,"TK_EOF");
             return aoStrMove(str);
         case TK_KEYWORD: {
-            aoStrCatPrintf(str,"TK_KEYWORD\t");
+            aoStrCatPrintf(str,"TK_KEYWORD    ");
             switch (tok->i64) {
                 case KW_CLASS:       aoStrCatPrintf(str,"class");   break;
                 case KW_UNION:       aoStrCatPrintf(str,"union");   break;

--- a/src/main.c
+++ b/src/main.c
@@ -321,22 +321,22 @@ int main(int argc, char **argv) {
     parseCliOptions(&opts,argc,argv);
     
     cc = CctrlNew();
-    
-    CompileToAst(cc,opts.infile,lexer_flags);
 
     if (opts.print_tokens) {
-        CompilePrintTokens(cc);
-    }
-
-    if (opts.print_ast) {
-        CompilePrintAst(cc);
+        List *tokens = compileToTokens(cc,opts.infile,lexer_flags);
+        lexemePrintList(tokens);
+        lexemeListRelease(tokens);
+    } else if (opts.print_ast) {
+        compileToAst(cc,opts.infile,lexer_flags);
+        compilePrintAst(cc);
     }
 
     if (opts.print_tokens || opts.print_ast) {
         return 0;
     }
 
-    asmbuf = CompileToAsm(cc);
+    compileToAst(cc,opts.infile,lexer_flags);
+    asmbuf = compileToAsm(cc);
 
 
     emitFile(asmbuf, &opts);

--- a/tests/run.HC
+++ b/tests/run.HC
@@ -1,8 +1,8 @@
 class StringArray
 {
-  U8 **entries;
   I64 len;
   I64 cap;
+  U8 **entries;
 };
 
 StringArray *StringArrayNew()
@@ -26,15 +26,18 @@ U0 StringArrayRelease(StringArray *arr)
 U0 StringArrayPush(StringArray *arr, U8 *str)
 {
   if (arr->len + 1 >= arr->cap) {
-    auto new_cap = arr->cap * 2;
-    arr->entries = ReAlloc(arr->entries,new_cap);
-    if (arr->entries == NULL) {
+    auto new_cap = arr->cap * 2 * sizeof(U8 *);
+    auto e = arr->entries;
+    auto new_entries = ReAlloc(e,new_cap);
+    if (new_entries == NULL) {
       "Failed to reallocate array\n";
       Exit;
     }
     arr->cap = new_cap;
+    arr->entries = new_entries;
   }
-  arr->entries[arr->len++] = str;
+  arr->entries[arr->len] = str;
+  arr->len++;
 }
 
 I64 CmpFileNames(U8 *str1, U8 *str2)
@@ -122,10 +125,15 @@ I32 Main(I32 argc, U8 **argv)
 
   while ((ent = readdir(dir)) != NULL) {
     if (ent->type & DT_REG) {
-      if (ShouldExclude(ent->name,StrLen(ent->name))) {
+      auto len = StrLen(ent->name);
+      auto res = FzF(ent->name,"HC$");
+
+      if (ShouldExclude(ent->name,len) || res == NULL) {
         continue;
       }
-      StringArrayPush(arr,StrNew(ent->name));
+      FzFPositionRelease(res);
+      auto str = StrNew(ent->name);
+      StringArrayPush(arr,str);
     }
   }
 


### PR DESCRIPTION
# Description

Tackles: #43 #42 

- Fixed memory allocation issue with `ReAlloc`
- Fixed issue with `StrNew()`
- Fixed printing tokens, something to do with adding the sentinal when initially setting up the `Cctrl` makes things go weird so I copy and pasted the token code out of `compileToAst` to return the tokens and then I print them... Might be nice to have the lexer independent of the `Cctrl` if possible.
- lower cased `Compile` to `compile`
- Only look for `.HC` files in `run.HC`