### PR TITLE
fix: for floating point parsing

### DIFF
--- a/tests/26_f64.HC
+++ b/tests/26_f64.HC
@@ -3,7 +3,7 @@
 Bool FloatAddition()
 {
   I64 tests = 6, correct = 0;
-  F64 f1 = 0.0000001 + 0.0000002;
+  F64 f1 = .0000001 + .0000002;
   if (f1 == 0.0000003) correct++;
 
 


### PR DESCRIPTION
- Fixes parsing a number like: `.32` so the compiler can now handle `.32` and `0.32`.
- Updated a floating point test to reflect this change.