### PR TITLE
Fix - hashtables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,26 @@ Run `make`, then run `make install` (`sudo make install` on linux) this will
 install the compiler and holyc libraries for strings, hashtables, I/O, maths,
 networking, JSON parsing etc... see ./src/holyc-lib/
  
+## Using the compiler
+Once the compiler has been compiled the following options are available, they 
+can be displayed by running `hcc --help`
+```
+HolyC Compiler 2024. UNSTABLE
+hcc [..OPTIONS] <..file>
+
+OPTIONS:
+  -ast     Print the ast and exit
+  -tokens  Print the tokens and exit
+  -S       Emit assembly only
+  -obj     Emit an objectfile
+  -lib     Emit a dynamic and static library
+  -clibs   Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`
+  -o       Output filename: hcc -o <name> ./<file>.HC
+  -g       Not implemented
+  -D<var>  Set a compiler #define (does not accept a value)
+  --help   Print this message
+```
+
 ## Differences
 - `auto` key word for type inference, an addition which makes it easier
   to write code.

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -323,3 +323,9 @@ AstType *CctrlGetKeyWord(Cctrl *cc, char *name, int len) {
 int CctrlIsKeyword(Cctrl *cc, char *name, int len) {
     return CctrlGetKeyWord(cc,name,len) != NULL;
 }
+
+void CctrlSetCommandLineDefines(Cctrl *cc, List *defines_list) {
+    ListForEach(defines_list) {
+        DictSet(cc->macro_defs,(char*)it->value,lexemeSentinal());
+    }
+}

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -108,6 +108,7 @@ lexeme *CctrlTokenPeek(Cctrl *cc);
 void CctrlTokenIterSetCur(Cctrl *cc, List *cur);
 void CctrlTokenRewind(Cctrl *cc);
 void CctrlTokenExpect(Cctrl *cc, long expected);
+void CctrlSetCommandLineDefines(Cctrl *cc, List *defines_list);
 
 Ast *CctrlGetVar(Cctrl *cc, char *varname, int len);
 int CctrlIsKeyword(Cctrl *cc, char *name, int len);

--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -47,7 +47,7 @@ public class StrMap
   U64 threashold; /* rebuild threashold */
   U0 (*_free_value)(U0 *_value); /* User defined callback for freeing values */
   U0 (*_free_key)(U0 *_key); /* User defined callback for freeing keys */
-  StrMapNode **entries; /* All of the entries, XXX: could this be IntMapNode *entries? */
+  StrMapNode **entries; /* All of the entries, XXX: could this be StrMapNode *entries? */
 };
 
 U64 RoundUpToNextPowerOf2(U64 v)
@@ -64,6 +64,7 @@ U64 RoundUpToNextPowerOf2(U64 v)
 }
 
 public Bool IntMapSet(IntMap *map, I64 key, U0 *value);
+public Bool IntMapHas(IntMap *map, I64 key);
 public IntMap *IntMapNew(U64 capacity=1<<8);
 public U0 IntMapSetFreeValue(IntMap *map, U0 (*_free_value)(U0 *value));
 public U0 IntMapRelease(IntMap *map);
@@ -146,6 +147,7 @@ public Bool IntMapResize(IntMap *map, U64 size)
 
   old_entries = map->entries;
   old_mask = map->mask;
+  old_indexes = map->indexes;
 
   new_capacity = map->capacity << 1;
   new_mask = new_capacity - 1;
@@ -163,6 +165,7 @@ public Bool IntMapResize(IntMap *map, U64 size)
 
   map->mask = new_mask;
   map->entries = new_entries;
+  map->indexes = new_indexes;
   map->capacity = new_capacity;
   new_size = 0;
 
@@ -172,7 +175,7 @@ public Bool IntMapResize(IntMap *map, U64 size)
     if (old->key != HT_DELETED) {
       auto new_idx = IntMapGetNextIdx(map,old->key,&is_free);
       new_indexes[new_size] = new_idx;
-      new_indexes[new_idx] = old;
+      new_entries[new_idx] = old;
       new_size++;
     } else {
       Free(old);
@@ -181,8 +184,7 @@ public Bool IntMapResize(IntMap *map, U64 size)
 
   Free(old_entries);
   Free(old_indexes);
-  map->indexes = new_indexes;
-  map->threashold = (map->capacity * HT_LOAD)(U64);
+  map->threashold = (new_capacity * HT_LOAD)(U64);
   map->size = new_size;
   return TRUE;
 }
@@ -272,7 +274,6 @@ public U0 *IntMapGet(IntMap *map, I64 key)
 public Bool IntMapIter(IntMap *map, I64 *_idx, IntMapNode **_node)
 {
   I64 idx = *_idx;
-  auto indexes = map->indexes;
   while (idx < map->size) {
     I64 index = map->indexes[idx];
     if (index != HT_DELETED) {
@@ -396,6 +397,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
   old_entries = map->entries;
   old_mask = map->mask;
   old_capacity = map->capacity;
+  old_indexes = map->indexes;
   new_capacity = map->capacity << 1;
   new_mask = new_capacity - 1;
 
@@ -413,6 +415,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
   map->mask = new_mask;
   map->entries = new_entries;
   map->capacity = new_capacity;
+  map->indexes = new_indexes;
   I64 new_size = 0;
   I64 old_size = map->size;
 
@@ -420,7 +423,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
     I64 idx = old_indexes[i];
     auto old = old_entries[idx];
     if (old->key != NULL) {
-      I64 new_idx = StrMapGetNextIdx(map,old->key,old->key_len,*is_free);
+      I64 new_idx = StrMapGetNextIdx(map,old->key,old->key_len,&is_free);
       new_indexes[new_size] = new_idx;
       new_entries[new_idx] = old;
       new_size++;
@@ -430,8 +433,8 @@ public Bool StrMapResize(StrMap *map, U64 size)
   }
 
   Free(old_entries);
-  Free(map->indexes);
-  map->indexes = new_indexes;
+  Free(old_indexes);
+  map->size = new_size;
   map->threashold = (map->capacity * HT_LOAD)(U64);
   return TRUE;
 }
@@ -482,6 +485,7 @@ public Bool StrMapDelete(StrMap *map, U8 *key)
       if (free_key)   free_key(cur->key);
       if (free_value) free_value(cur->value);
       cur->value = cur->key = NULL;
+      cur->key_len = 0;
       map->indexes[idx] = HT_DELETED;
       map->size--;
       return TRUE;
@@ -515,14 +519,36 @@ public U0 *StrMapGet(StrMap *map, U8 *key)
   return NULL;
 }
 
+public Bool StrMapHas(StrMap *map, U8 *key)
+{
+  I64 len = StrLen(key);
+  U64 mask = map->mask;
+  U64 probe = 1;
+  U64 idx = StrHash(key) & mask;
+  StrMapNode **entries = map->entries;
+  StrMapNode *cur = NULL;
+
+  while ((cur = map->entries[idx])) {
+    if (cur->key == NULL) {
+      return FALSE;
+    }
+    if (cur->key_len == len && !StrNCmp(cur->key,key,len)) {
+      return TRUE;
+    }
+    idx = (idx + HT_PROBE_1 * probe + HT_PROBE_3 * probe * probe) & mask;
+    probe++;
+  }
+  return FALSE;
+}
+
+
 public Bool StrMapIter(StrMap *map, I64 *_idx, StrMapNode **_node)
 {
   I64 idx = *_idx;
-  auto indexes = map->indexes;
-  while (idx < indexes->len) {
+  while (idx < map->size) {
     I64 index = map->indexes[idx];
     if (index != HT_DELETED) {
-      *_idx = idx+1;
+      *_idx = idx + 1;
       *_node = map->entries[index];
       return TRUE;
     }
@@ -551,7 +577,7 @@ public Bool StrMapKeyIter(StrMap *map, I64 *_idx, U8 **_key)
   return FALSE;
 }
 
-#ifdef HOLY_C_HT_TEST
+#ifdef HOLYC_HT_TEST
 U0 IntMapTests(U0)
 {
   IntMap *map = IntMapNew(8);
@@ -567,13 +593,15 @@ U0 IntMapTests(U0)
     "owl"
   };
   I64 len = sizeof(strs)/sizeof(strs[0]);
+
   for (I64 i = 0; i < len; i++) {
     IntMapSet(map,i,strs[i]);
   }
 
   for (I64 i = 0; i < len; i++) {
-    if (IntMapGet(map,i) != strs[i]) {
-      "Failed IntMapTests -> IntMapGet\n";
+    U8 *value = IntMapGet(map,i);
+    if (value != strs[i]) {
+      "Failed IntMapTests -> IntMapGet: %d=>%s\n",i,value;
       Exit;
     }
   }
@@ -587,8 +615,9 @@ U0 IntMapTests(U0)
 
   /* Inorder iteration */
   for (I64 i = 0; IntMapIter(map,&i,&n);) {
-    if (i != n->key || str[i] != n->value) {
-      "Failed IntMapTests -> IntMapIter\n";
+    if (strs[i-1] != n->value) {
+      "Failed IntMapTests -> IntMapIter i=%d key=%d => value=%s str = %s\n",
+        i,n->key,n->value,strs[i];
       Exit;
     }
   }
@@ -601,6 +630,7 @@ U0 IntMapTests(U0)
   }
 
   IntMapRelease(map);
+  "PASS IntMap\n";
 }
 
 U0 StrMapTests(U0)
@@ -627,7 +657,10 @@ U0 StrMapTests(U0)
     "dog",
     "owl"
   };
+
   I64 len = sizeof(strs)/sizeof(strs[0]);
+
+
   for (I64 i = 0; i < len; i++) {
     StrMapSet(map,keys[i],strs[i]);
   }
@@ -648,7 +681,7 @@ U0 StrMapTests(U0)
 
   /* Inorder iteration */
   for (I64 i = 0; StrMapIter(map,&i,&n);) {
-    if (keys[i] != n->key || str[i] != n->value) {
+    if (keys[i-1] != n->key || strs[i-1] != n->value) {
       "Failed StrMapTests -> StrMapIter\n";
       Exit;
     }
@@ -662,9 +695,10 @@ U0 StrMapTests(U0)
   }
 
   StrMapRelease(map);
+  "PASS StrMap\n";
 }
 
-U0 Main()
+U0 Main(U0)
 {
   IntMapTests;
   StrMapTests;

--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -8,13 +8,6 @@
 #define HT_PROBE_1 1
 #define HT_PROBE_3 3
 
-public class MapIndex
-{
-  I64 capacity;
-  I64 len;
-  I64 *entries;
-};
-
 class IntMapNode
 {
   I64 key;
@@ -34,9 +27,9 @@ public class IntMap
   U64 capacity; /* How much capacity we have in the entries array */
   U64 mask;     /* Used for hashing, as the capacity is always a power of 2
                  * we can use fast modulo of `<int> & capacity-1`. */
-  MapIndex *indexes; /* Where all of the values are in the entries array, in 
-                      * insertion order. Means we can iterate over the HashTable 
-                      * quickly at the cost of memory */
+  I64 *indexes; /* Where all of the values are in the entries array, in 
+                 * insertion order. Means we can iterate over the HashTable 
+                 * quickly at the cost of memory */
   U64 threashold; /* rebuild threashold */
   U0 (*_free_value)(U0 *value); /* User defined callback for freeing values */
   IntMapNode **entries; /* All of the entries, XXX: could this be IntMapNode *entries? */
@@ -48,9 +41,9 @@ public class StrMap
   U64 capacity; /* How much capacity we have in the entries array */
   U64 mask;     /* Used for hashing, as the capacity is always a power of 2
                  * we can use fast modulo of `<int> & capacity-1`. */
-  MapIndex *indexes; /* Where all of the values are in the entries array, in 
-                      * insertion order. Means we can iterate over the HashTable 
-                      * quickly at the cost of memory */
+  I64 *indexes; /* Where all of the values are in the entries array, in 
+                 * insertion order. Means we can iterate over the HashTable 
+                 * quickly at the cost of memory */
   U64 threashold; /* rebuild threashold */
   U0 (*_free_value)(U0 *_value); /* User defined callback for freeing values */
   U0 (*_free_key)(U0 *_key); /* User defined callback for freeing keys */
@@ -70,28 +63,6 @@ U64 RoundUpToNextPowerOf2(U64 v)
   return v;
 }
 
-MapIndex *MapIndexNew(I64 capacity=1000)
-{
-  I64 offset = (sizeof(I64)*2)+sizeof(I64*);
-  U0 *memory = MAlloc(offset+sizeof(MapIndex) * (sizeof(I64)*capacity));
-  MapIndex *idx = memory;
-  idx->len = 0;
-  idx->capacity = capacity;
-  idx->entries = memory+offset;
-  return idx;
-}
-
-MapIndex *MapIndexReAlloc(MapIndex *idx)
-{// Reallocate the whole structure 
-  I64 new_capacity = idx->capacity * 4;
-  MapIndex *new = MapIndexNew(new_capacity);
-  MemCpy(new->entries,idx->entries,
-      idx->capacity*sizeof(I64));
-  new->capacity = new_capacity;
-  new->len = idx->len;
-  return new;
-}
-
 public Bool IntMapSet(IntMap *map, I64 key, U0 *value);
 public IntMap *IntMapNew(U64 capacity=1<<8);
 public U0 IntMapSetFreeValue(IntMap *map, U0 (*_free_value)(U0 *value));
@@ -109,10 +80,10 @@ IntMap *IntMapNew(U64 capacity)
   map->capacity = RoundUpToNextPowerOf2(capacity);
   map->mask = capacity-1;
   map->size = 0;
-  map->indexes = MapIndexNew(capacity);
-  map->threashold = (HT_LOAD * map->capacity)(U64);
+  map->indexes = CAlloc(sizeof(I64) * capacity);
+  map->threashold = (HT_LOAD * capacity)(U64);
   map->_free_value = NULL;
-  map->entries = CAlloc(map->capacity * sizeof(IntMapNode *));
+  map->entries = CAlloc(capacity * sizeof(IntMapNode *));
   return map;
 }
 
@@ -136,6 +107,7 @@ static U64 IntMapGetNextIdx(IntMap *map, I64 key, Bool *_is_free)
   U64 probe = 1;
   IntMapNode *cur;
   *_is_free = FALSE;
+
   while ((cur = map->entries[idx]) != NULL) {
     if (cur->key == key || cur->key == HT_DELETED) {
       *_is_free = FALSE;
@@ -169,20 +141,17 @@ public Bool IntMapResize(IntMap *map, U64 size)
 {// Resize the hashtable, will return false if OMM
   U64 new_capacity,old_capacity,new_mask,old_mask;
   IntMapNode **new_entries, **old_entries;
-  MapIndex *new_indexes;
-  Bool is_free;
-
-  auto old_indexes_len = map->indexes->len;
-  auto old_indexes = map->indexes->entries;
+  Bool is_free = 0;
+  I64 *new_indexes, *old_indexes, new_size;
 
   old_entries = map->entries;
   old_mask = map->mask;
-  old_capacity = map->capacity;
+
   new_capacity = map->capacity << 1;
   new_mask = new_capacity - 1;
 
   /* OOM */
-  if ((new_indexes = MapIndexNew(map->indexes->capacity)) == NULL) {
+  if ((new_indexes = CAlloc(new_capacity * sizeof(I64))) == NULL) {
     return FALSE;
   }
 
@@ -195,26 +164,26 @@ public Bool IntMapResize(IntMap *map, U64 size)
   map->mask = new_mask;
   map->entries = new_entries;
   map->capacity = new_capacity;
+  new_size = 0;
 
-
-  for (auto i = 0; i < old_capacity; ++i) {
-      IntMapNode *old = old_entries[i];
-      if (old) {
-        I64 key = old->key;
-        if (key != HT_DELETED) {
-          U64 idx = IntMapGetNextIdx(map,key,&is_free);
-          new_entries[idx] = old;
-          new_indexes->entries[new_indexes->len++] = idx;
-        } else {
-          Free(old);
-        }
-      }
+  for (auto i = 0; i < map->size; ++i) {
+    auto idx = old_indexes[i];
+    auto old = old_entries[idx];
+    if (old->key != HT_DELETED) {
+      auto new_idx = IntMapGetNextIdx(map,old->key,&is_free);
+      new_indexes[new_size] = new_idx;
+      new_indexes[new_idx] = old;
+      new_size++;
+    } else {
+      Free(old);
+    }
   }
 
   Free(old_entries);
-  Free(map->indexes);
+  Free(old_indexes);
   map->indexes = new_indexes;
   map->threashold = (map->capacity * HT_LOAD)(U64);
+  map->size = new_size;
   return TRUE;
 }
 
@@ -232,11 +201,8 @@ auto IntMapSet(IntMap *map, I64 key, U0 *value)
   U64 idx = IntMapGetNextIdx(map,key,&is_free);
   if (is_free) {
     auto n = IntMapNodeNew(key,value); 
+    map->indexes[map->size] = idx;
     map->entries[idx] = n;
-    if (map->indexes->len + 1 >= map->indexes->capacity) {
-      map->indexes = MapIndexReAlloc(map->indexes);
-    }
-    map->indexes->entries[map->indexes->len++] = idx;
     map->size++;
     return TRUE;
   } else {
@@ -258,10 +224,26 @@ public Bool IntMapDelete(IntMap *map, I64 key)
   while ((cur = entries[idx])) {
     if (cur->key == key) {
       cur->key = HT_DELETED;
-      map->indexes->entries[idx] = HT_DELETED;
+      map->indexes[idx] = HT_DELETED;
       map->size--;
       return TRUE;
     }
+    idx = (idx + HT_PROBE_1 * probe + HT_PROBE_3 * probe * probe) & mask;
+    probe++;
+  }
+  return FALSE;
+}
+
+public Bool IntMapHas(IntMap *map, I64 key)
+{
+  U64 idx, mask, probe;
+  IntMapNode **entries = map->entries;
+  IntMapNode *cur;
+  mask = map->mask;
+  probe = 1;
+  idx = IntMapHashFunction(key,mask);
+  while ((cur = entries[idx])) {
+    if (cur->key == key) return TRUE;
     idx = (idx + HT_PROBE_1 * probe + HT_PROBE_3 * probe * probe) & mask;
     probe++;
   }
@@ -291,10 +273,10 @@ public Bool IntMapIter(IntMap *map, I64 *_idx, IntMapNode **_node)
 {
   I64 idx = *_idx;
   auto indexes = map->indexes;
-  while (idx < indexes->len) {
-    I64 index = indexes->entries[idx];
+  while (idx < map->size) {
+    I64 index = map->indexes[idx];
     if (index != HT_DELETED) {
-      *_idx = idx+1;
+      *_idx = idx + 1;
       *_node = map->entries[index];
       return TRUE;
     }
@@ -336,11 +318,11 @@ StrMap *StrMapNew(U64 capacity)
   map->capacity = RoundUpToNextPowerOf2(capacity);
   map->mask = capacity-1;
   map->size = 0;
-  map->indexes = MapIndexNew(capacity);
-  map->threashold = (HT_LOAD * map->capacity)(U64);
+  map->indexes = CAlloc(capacity * sizeof(I64));
+  map->threashold = (HT_LOAD * capacity)(U64);
   map->_free_value = NULL;
   map->_free_key = NULL;
-  map->entries = CAlloc(map->capacity * sizeof(StrMapNode *));
+  map->entries = CAlloc(capacity * sizeof(StrMapNode *));
   return map;
 }
 
@@ -408,11 +390,8 @@ public Bool StrMapResize(StrMap *map, U64 size)
 {// Resize the hashtable, will return false if OMM
   U64 new_capacity,old_capacity,new_mask,old_mask;
   StrMapNode **new_entries, **old_entries;
-  MapIndex *new_indexes;
+  I64 *new_indexes, *old_indexes;
   Bool is_free;
-
-  auto old_indexes_len = map->indexes->len;
-  auto old_indexes = map->indexes->entries;
 
   old_entries = map->entries;
   old_mask = map->mask;
@@ -421,7 +400,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
   new_mask = new_capacity - 1;
 
   /* OOM */
-  if ((new_indexes = MapIndexNew(map->indexes->capacity)) == NULL) {
+  if ((new_indexes = CAlloc(sizeof(I64) * new_capacity)) == NULL) {
     return FALSE;
   }
 
@@ -434,20 +413,20 @@ public Bool StrMapResize(StrMap *map, U64 size)
   map->mask = new_mask;
   map->entries = new_entries;
   map->capacity = new_capacity;
+  I64 new_size = 0;
+  I64 old_size = map->size;
 
-
-  for (auto i = 0; i < old_capacity; ++i) {
-      StrMapNode *old = old_entries[i];
-      if (old) {
-        U8 *key = old->key;
-        if (key != NULL) {
-          U64 idx = StrMapGetNextIdx(map,key,old->key_len,&is_free);
-          new_entries[idx] = old;
-          new_indexes->entries[new_indexes->len++] = idx;
-        } else {
-          Free(old);
-        }
-      }
+  for (I64 i = 0; i < old_size; ++i) {
+    I64 idx = old_indexes[i];
+    auto old = old_entries[idx];
+    if (old->key != NULL) {
+      I64 new_idx = StrMapGetNextIdx(map,old->key,old->key_len,*is_free);
+      new_indexes[new_size] = new_idx;
+      new_entries[new_idx] = old;
+      new_size++;
+    } else {
+      Free(old);
+    }
   }
 
   Free(old_entries);
@@ -474,11 +453,8 @@ Bool StrMapSet(StrMap *map, U8 *key, U0 *value)
   U64 idx = StrMapGetNextIdx(map,key,key_len,&is_free);
   if (is_free) {
     auto n = StrMapNodeNew(key,key_len,value); 
+    map->indexes[map->size] = idx;
     map->entries[idx] = n;
-    if (map->indexes->len + 1 >= map->indexes->capacity) {
-      map->indexes = MapIndexReAlloc(map->indexes);
-    }
-    map->indexes->entries[map->indexes->len++] = idx;
     map->size++;
     return TRUE;
   } else {
@@ -506,7 +482,7 @@ public Bool StrMapDelete(StrMap *map, U8 *key)
       if (free_key)   free_key(cur->key);
       if (free_value) free_value(cur->value);
       cur->value = cur->key = NULL;
-      map->indexes->entries[idx] = HT_DELETED;
+      map->indexes[idx] = HT_DELETED;
       map->size--;
       return TRUE;
     }
@@ -518,7 +494,7 @@ public Bool StrMapDelete(StrMap *map, U8 *key)
 
 public U0 *StrMapGet(StrMap *map, U8 *key)
 {
-  U64 idx,mask, probe;
+  U64 idx, mask, probe;
   I64 len = StrLen(key);
   StrMapNode **entries = map->entries;
   StrMapNode *cur;
@@ -544,7 +520,7 @@ public Bool StrMapIter(StrMap *map, I64 *_idx, StrMapNode **_node)
   I64 idx = *_idx;
   auto indexes = map->indexes;
   while (idx < indexes->len) {
-    I64 index = indexes->entries[idx];
+    I64 index = map->indexes[idx];
     if (index != HT_DELETED) {
       *_idx = idx+1;
       *_node = map->entries[index];
@@ -574,3 +550,123 @@ public Bool StrMapKeyIter(StrMap *map, I64 *_idx, U8 **_key)
   }
   return FALSE;
 }
+
+#ifdef HOLY_C_HT_TEST
+U0 IntMapTests(U0)
+{
+  IntMap *map = IntMapNew(8);
+  IntMapNode *n;
+  U8 *strs[] = {
+    "hello",
+    "world",
+    "foo",
+    "bar",
+    "baz",
+    "cat",
+    "dog",
+    "owl"
+  };
+  I64 len = sizeof(strs)/sizeof(strs[0]);
+  for (I64 i = 0; i < len; i++) {
+    IntMapSet(map,i,strs[i]);
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (IntMapGet(map,i) != strs[i]) {
+      "Failed IntMapTests -> IntMapGet\n";
+      Exit;
+    }
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (!IntMapHas(map,i)) {
+      "Failed IntMapTests -> IntMapHas\n";
+      Exit;
+    }
+  }
+
+  /* Inorder iteration */
+  for (I64 i = 0; IntMapIter(map,&i,&n);) {
+    if (i != n->key || str[i] != n->value) {
+      "Failed IntMapTests -> IntMapIter\n";
+      Exit;
+    }
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (!IntMapDelete(map,i)) {
+      "Failed IntMapTests -> IntMapDelete\n";
+      Exit;
+    }
+  }
+
+  IntMapRelease(map);
+}
+
+U0 StrMapTests(U0)
+{
+  StrMap *map = StrMapNew(8);
+  StrMapNode *n;
+  U8 *keys[] = {
+    "card",
+    "can",
+    "will",
+    "shill",
+    "cup",
+    "mug",
+    "glass",
+    "tin"
+  };
+  U8 *strs[] = {
+    "hello",
+    "world",
+    "foo",
+    "bar",
+    "baz",
+    "cat",
+    "dog",
+    "owl"
+  };
+  I64 len = sizeof(strs)/sizeof(strs[0]);
+  for (I64 i = 0; i < len; i++) {
+    StrMapSet(map,keys[i],strs[i]);
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (StrMapGet(map,keys[i]) != strs[i]) {
+      "Failed StrMapTests -> StrMapGet\n";
+      Exit;
+    }
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (!StrMapHas(map,keys[i])) {
+      "Failed StrMapTests -> StrMapHas\n";
+      Exit;
+    }
+  }
+
+  /* Inorder iteration */
+  for (I64 i = 0; StrMapIter(map,&i,&n);) {
+    if (keys[i] != n->key || str[i] != n->value) {
+      "Failed StrMapTests -> StrMapIter\n";
+      Exit;
+    }
+  }
+
+  for (I64 i = 0; i < len; i++) {
+    if (!StrMapDelete(map,keys[i])) {
+      "Failed StrMapTests -> StrMapDelete\n";
+      Exit;
+    }
+  }
+
+  StrMapRelease(map);
+}
+
+U0 Main()
+{
+  IntMapTests;
+  StrMapTests;
+}
+#endif

--- a/src/holyc-lib/memory.HC
+++ b/src/holyc-lib/memory.HC
@@ -4,111 +4,111 @@
 
 asm {
 _MALLOC::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    SUB     RSP,16
-    MOV     -8[RBP], RDI
-    ADD     RDI, 8
-    CALL    malloc
-    MOV     RCX, -8[RBP]
-    MOV     [RAX], RCX
-    ADD     RAX, 8
+    PUSHQ  RBP
+    MOVQ   RBP, RSP 
+    SUB    RSP,16
+    MOV    -8[RBP], RDI
+    ADD    RDI, 8
+    CALL   malloc
+    MOV    RCX, -8[RBP]
+    MOV    [RAX], RCX
+    ADD    RAX, 8
     LEAVE
     RET
 
 // RDI = size
 // Different from c's calloc
 _CALLOC::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    SUB     RSP,16
-    MOV     -8[RBP],RDI
-    CALL    _MALLOC
-    MOV     -16[RBP], RAX
-    MOV     RDI, -16[RBP]
-    MOV     RSI, 0
-    MOV     RDX, -8[RBP]
-    CALL    _MEMSET
-    MOV     RAX, -16[RBP]
+    PUSHQ  RBP
+    MOVQ   RBP, RSP 
+    SUB    RSP,16
+    MOV    -8[RBP],RDI
+    CALL   _MALLOC
+    MOV    -16[RBP], RAX
+    MOV    RDI, -16[RBP]
+    MOV    RSI, 0
+    MOV    RDX, -8[RBP]
+    CALL   _MEMSET
+    MOV    RAX, -16[RBP]
     LEAVE
     RET
 
 // RDI = U0 *ptr
 // RSI = U64 size
 _REALLOC::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    SUB     RSP, 32
-    TEST    RDI, RDI
-    JZ      @@1
-    MOV     -8[RBP], RDI
-    MOV     -16[RBP],RSI
-    MOV     RDI, -16[RBP]
-    CALL    _MALLOC
-    MOV     -24[RBP], RAX
-    MOV     RSI, -8[RBP]
-    MOV     RDI, -24[RBP]
-    MOV     RDX, -16[RBP]
-    CALL    _MEMCPY
-    MOV     RDI, -8[RBP]
-    CALL    _FREE
-    MOV     RAX, -24[RBP]
-    JMP     @@2
+    PUSHQ  RBP
+    MOVQ   RBP, RSP 
+    SUB    RSP, 32
+    TEST   RDI, RDI
+    JZ     @@1
+    MOV    -8[RBP], RDI
+    MOV    -16[RBP],RSI
+    MOV    RDI, -16[RBP]
+    CALL   _MALLOC
+    MOV    -24[RBP], RAX
+    MOV    RSI, -8[RBP]
+    MOV    RDI, -24[RBP]
+    MOV    RDX, -16[RBP]
+    CALL   _MEMCPY
+    MOV    RDI, -8[RBP]
+    CALL   _FREE
+    MOV    RAX, -24[RBP]
+    JMP    @@2
 @@1: // If pointer is NULL
-    MOV     RDI, RSI
-    CALL    _MALLOC
+    MOV    RDI, RSI
+    CALL   _MALLOC
 @@2:
     LEAVE
     RET
 
 /* How many bytes were allocated */
 _MSIZE::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    TEST    RDI, RDI
-    JZ      @@2/* NULL CHECK */
-    SUB     RDI, 8
-    MOV     RAX, [RDI]
+    PUSHQ  RBP
+    MOVQ   RBP, RSP 
+    TEST   RDI, RDI
+    JZ     @@2/* NULL CHECK */
+    SUB    RDI, 8
+    MOV    RAX, [RDI]
 @@1:
     LEAVE
     RET
 @@2:
-    MOVQ    RAX, 0
+    MOVQ   RAX, 0
     LEAVE
     RET
 
 /* Gets to the start of the actual allocated buffer 
  * And then calls free */
 _FREE::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    TEST    RDI,RDI
-    JZ      @@1
-    SUB     RDI, 8
-    CALL    free
+    PUSHQ  RBP
+    MOVQ   RBP, RSP 
+    TEST   RDI,RDI
+    JZ     @@1
+    SUB    RDI, 8
+    CALL   free
 @@1:
     LEAVE
     RET
 
 _MEMSET::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP 
-    MOVQ    RCX, RDX
-    MOVB    AL,  SIL
-	CLD
-	REP     STOSB
-	MOVQ	RDI, RAX
+    PUSHQ RBP
+    MOVQ  RBP, RSP 
+    MOVQ  RCX, RDX
+    MOVB  AL,  SIL
+    CLD
+    REP   STOSB
+    MOVQ  RDI, RAX
     LEAVE
     RET
 
 _MEMCPY::
-	PUSHQ   RBP
-	MOV     RBP, RSP 
-    MOVQ    RCX, RDX 
-	CLD
-	REP     MOVSB
+    PUSHQ  RBP
+    MOV    RBP, RSP 
+    MOVQ   RCX, RDX 
+    CLD
+    REP    MOVSB
     LEAVE
-	RET 
+    RET 
 }
 
 public extern "c" U0 *memchr(U0 *__s, I32 __c, U64 __n);

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -64,47 +64,47 @@ asm {
 // 'a'=97, 'z'=122
 // 'A'=65, 'Z'=90
 _STRNICMP::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP
-    MOVQ    RCX, RDX
+    PUSHQ  RBP
+    MOVQ   RBP, RSP
+    MOVQ   RCX, RDX
 @@3:
-    TEST    RCX, RCX
-    JZ      @@2
-    DECQ    RCX
+    TEST   RCX, RCX
+    JZ     @@2
+    DECQ   RCX
     LODSB
-    TEST    AL,AL
-    JZ      @@6
-    CMP     AL, 97
-    JB      @@22
-    CMP     AL, 122
-    JA      @@22
-    SUB     AL, 32
+    TEST   AL,AL
+    JZ     @@6
+    CMP    AL, 97
+    JB     @@22
+    CMP    AL, 122
+    JA     @@22
+    SUB    AL, 32
 @@22:
-    MOV     BL, [RDI]
-    INCQ    RDI
-    TEST    BL,BL
-    JZ      @@6
-    CMP     BL, 97
-    JB      @@23
-    CMP     BL, 122
-    JA      @@23
-    SUB     BL, 32
+    MOV    BL, [RDI]
+    INCQ   RDI
+    TEST   BL,BL
+    JZ     @@6
+    CMP    BL, 97
+    JB     @@23
+    CMP    BL, 122
+    JA     @@23
+    SUB    BL, 32
 @@23:
-    CMP     AL, BL
-    JE      @@3
+    CMP    AL, BL
+    JE     @@3
 @@6:
-    SUBQ    RSI, RDI
-    MOVQ    RAX, RSI
+    SUBQ   RSI, RDI
+    MOVQ   RAX, RSI
     LEAVE
     RET
 @@2:
-    XORQ    RAX, RAX
+    XORQ   RAX, RAX
     LEAVE
     RET
 
 _STRNCMP::
-	PUSHQ	RBP
-	MOVQ	RBP, RSP
+    PUSHQ   RBP
+    MOVQ    RBP, RSP
     MOVQ    RCX, RDX
     TEST    RCX, RCX
     JZ      @@2
@@ -122,21 +122,21 @@ _STRNCMP::
     RET
 
 _STRCMP::
-	PUSH	RBP
-	MOV	RBP,RSP
+    PUSH  RBP
+    MOV   RBP,RSP
 @@2:
     LODSB
     SCASB
-    JNE     @@1
-    TEST AL, AL
-    JNZ @@2
-    XOR RAX, RAX
-    JMP @@3
+    JNE    @@1
+    TEST   AL, AL
+    JNZ    @@2
+    XOR    RAX, RAX
+    JMP    @@3
 @@1:
     SUB     RDI, 1
-    MOVZX RAX, AL
-    MOVZBQ  RDX,[RDI]
-    SUB RAX, RDX
+    MOVZX   RAX, AL
+    MOVZBQ  RDX, [RDI]
+    SUB     RAX, RDX
 @@3:
     LEAVE
     RET
@@ -153,51 +153,51 @@ _STRLEN_FAST::
 
 // @TempleOS - only slight tweaks
 _STRCPY:: 
-	PUSH	RBP
-	MOVQ    RBP,RSP
-	TEST    RDI,RDI
-	JZ      @@15
-	TEST    RSI, RSI
-	JNZ     @@05
-	XOR     RAX,RAX
-	JMP     @@10
+    PUSH  RBP
+    MOVQ  RBP,RSP
+    TEST  RDI,RDI
+    JZ    @@15
+    TEST  RSI, RSI
+    JNZ   @@05
+    XOR   RAX,RAX
+    JMP   @@10
 @@05:
-	LODSB
+    LODSB
 @@10:
-	STOSB
-	TEST    AL,AL
-	JNZ	@@05
+    STOSB
+    TEST  AL,AL
+    JNZ	  @@05
 @@15:
     LEAVE
-	RET
+    RET
 
 // RDI= char to convert
 _TOUPPER::
-	PUSH	RBP
-	MOVQ    RBP,RSP
-    MOVQ    RAX,RDI
-    CMP     AL, 'a'
-    JB      @@1
-    CMP     AL, 'z'
-    JA      @@1
-    SUB     AL, 32
+    PUSH  RBP
+    MOVQ  RBP,RSP
+    MOVQ  RAX,RDI
+    CMP   AL, 'a'
+    JB    @@1
+    CMP   AL, 'z'
+    JA    @@1
+    SUB   AL, 32
 @@1:
     LEAVE
-	RET
+    RET
 
 // RDI= char to convert
 _TOLOWER::
-	PUSH	RBP
-	MOVQ    RBP,RSP
-    MOVQ    RAX,RDI
-    CMP     AL, 'A'
-    JB      @@1
-    CMP     AL, 'Z'
-    JA      @@1
-    ADD     AL, 32
+    PUSH  RBP
+    MOVQ  RBP,RSP
+    MOVQ  RAX,RDI
+    CMP   AL, 'A'
+    JB    @@1
+    CMP   AL, 'Z'
+    JA    @@1
+    ADD   AL, 32
 @@1:
     LEAVE
-	RET
+    RET
 
 /* RDI= U8 character */
 _ISSPACE::

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -191,7 +191,6 @@ public Bool StrMapKeyIter(StrMap *map, I64 *_idx, U8 **_key);
 public Bool IntMapSet(IntMap *map, I64 key, U0 *value);
 public Bool IntMapHas(IntMap *map, I64 key);
 public U0 *IntMapGet(IntMap *map, I64 key);
-public Bool IntMapHas(IntMap *map, I64 key);
 public IntMap *IntMapNew(U64 capacity = 1 << 8);
 public U0 IntMapSetFreeValue(IntMap *map, U0 (*_free_value)(U0 *value));
 public U0 IntMapRelease(IntMap *map);

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -133,53 +133,51 @@ public CDate Now();
 #define HT_PROBE_1 1
 #define HT_PROBE_3 3
 
-public class MapIndex {
-  I64 capacity;
-  I64 len;
-  I64 *entries;
-};
-
-public class IntMapNode {
+public class IntMapNode
+{
   I64 key;
   U0 *value;
 };
 
-public class StrMapNode {
+public class StrMapNode
+{
   U8 *key;
   I64 key_len;
   U0 *value;
 };
 
-public class IntMap {
-  U64 size;   /* How many entries are in the hashtable */
+public class IntMap
+{
+  U64 size;     /* How many entries are in the hashtable */
   U64 capacity; /* How much capacity we have in the entries array */
-  U64 mask;   /* Used for hashing, as the capacity is always a power of 2
-           * we can use fast modulo of `<int> & capacity-1`. */
-  MapIndex *indexes; /* Where all of the values are in the entries array, in
-            * insertion order. Means we can iterate over the
-            * HashTable quickly at the cost of memory */
-  U64 threashold;  /* rebuild threashold */
+  U64 mask;     /* Used for hashing, as the capacity is always a power of 2
+                 * we can use fast modulo of `<int> & capacity-1`. */
+  I64 *indexes; /* Where all of the values are in the entries array, in 
+                 * insertion order. Means we can iterate over the HashTable 
+                 * quickly at the cost of memory */
+  U64 threashold; /* rebuild threashold */
   U0 (*_free_value)(U0 *value); /* User defined callback for freeing values */
-  IntMapNode **entries; /* All of the entries, XXX: could this be IntMapNode
-               *entries? */
+  IntMapNode **entries; /* All of the entries, XXX: could this be IntMapNode *entries? */
 };
 
-public class StrMap {
-  U64 size;   /* How many entries are in the hashtable */
+
+public class StrMap
+{
+  U64 size;     /* How many entries are in the hashtable */
   U64 capacity; /* How much capacity we have in the entries array */
-  U64 mask;   /* Used for hashing, as the capacity is always a power of 2
-           * we can use fast modulo of `<int> & capacity-1`. */
-  MapIndex *indexes; /* Where all of the values are in the entries array, in
-            * insertion order. Means we can iterate over the
-            * HashTable quickly at the cost of memory */
-  U64 threashold;  /* rebuild threashold */
-  U0 (*_free_value)(U0 *_value);        /* User defined callback for freeing values */
+  U64 mask;     /* Used for hashing, as the capacity is always a power of 2
+                 * we can use fast modulo of `<int> & capacity-1`. */
+  I64 *indexes; /* Where all of the values are in the entries array, in 
+                 * insertion order. Means we can iterate over the HashTable 
+                 * quickly at the cost of memory */
+  U64 threashold; /* rebuild threashold */
+  U0 (*_free_value)(U0 *_value); /* User defined callback for freeing values */
   U0 (*_free_key)(U0 *_key); /* User defined callback for freeing keys */
-  StrMapNode **entries; /* All of the entries, XXX: could this be IntMapNode
-               *entries? */
+  StrMapNode **entries; /* All of the entries, XXX: could this be IntMapNode *entries? */
 };
 
 public Bool StrMapSet(StrMap *map, U8 *key, U0 *value);
+public Bool StrMapHas(StrMap *map, U8 *key);
 public U0 *StrMapGet(StrMap *map, U8 *key);
 public StrMap *StrMapNew(U64 capacity = 1 << 8);
 public U0 StrMapSetFreeValue(StrMap *map, U0 (*_free_value)(U0 *value));
@@ -191,6 +189,7 @@ public Bool StrMapValueIter(StrMap *map, I64 *_idx, U0 **_value);
 public Bool StrMapKeyIter(StrMap *map, I64 *_idx, U8 **_key);
 
 public Bool IntMapSet(IntMap *map, I64 key, U0 *value);
+public Bool IntMapHas(IntMap *map, I64 key);
 public U0 *IntMapGet(IntMap *map, I64 key);
 public Bool IntMapHas(IntMap *map, I64 key);
 public IntMap *IntMapNew(U64 capacity = 1 << 8);

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -192,6 +192,7 @@ public Bool StrMapKeyIter(StrMap *map, I64 *_idx, U8 **_key);
 
 public Bool IntMapSet(IntMap *map, I64 key, U0 *value);
 public U0 *IntMapGet(IntMap *map, I64 key);
+public Bool IntMapHas(IntMap *map, I64 key);
 public IntMap *IntMapNew(U64 capacity = 1 << 8);
 public U0 IntMapSetFreeValue(IntMap *map, U0 (*_free_value)(U0 *value));
 public U0 IntMapRelease(IntMap *map);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -194,7 +194,6 @@ char *lexemeTypeToString(int tk_type) {
     case TK_CHAR_CONST: return "TK_CHAR_CONST";
     case TK_STR:   return "TK_STR";
     }
-    loggerDebug("%d\n",tk_type);
     return "UNKNOWN";
 }
 
@@ -521,7 +520,9 @@ int lexIdentifier(lexer *l, char ch) {
 
 finish:
     l->cur_strlen = i;
-    lexRewindChar(l);
+    if (ch != '\0') {
+        lexRewindChar(l);
+    }
     return TK_IDENT;
 }
 
@@ -1215,7 +1216,9 @@ void lexExpandAndCollect(lexer *l, Dict *macro_defs, List *tokens, int should_co
     int endif_count = 1;
 
     do {
-        if (!lex(l,&next)) break;
+        if (!lex(l,&next)) {
+            break;
+        }
         if (TokenPunctIs(&next,'#')) {
             lex(l,&next);
             if (next.tk_type == TK_KEYWORD) {
@@ -1289,10 +1292,7 @@ void lexExpandAndCollect(lexer *l, Dict *macro_defs, List *tokens, int should_co
                                next.line,next.len,next.start);
 
                 }
-            } else if (TokenIdentIs(&next,"error",5)) {
-                lex(l,&next);
-                loggerPanic("line %d: %.*s",next.line,next.len,next.start);
-            } 
+            }
         } else {
             if (should_collect) {
                 ListAppend(tokens,lexemeCopy(&next));
@@ -1482,6 +1482,9 @@ List *lexUntil(Dict *macro_defs, lexer *l, char to) {
                         loggerPanic("line %d: #%.*s invalid \n",next.line,
                                 next.len,next.start);
                 }
+            } else if (TokenIdentIs(&next,"error",5)) {
+                lex(l,&next);
+                loggerPanic("line %d: %.*s",next.line,next.len,next.start);
             }
         } else {
             copy = lexemeCopy(&le);

--- a/src/main.c
+++ b/src/main.c
@@ -311,6 +311,8 @@ void parseCliOptions(hccOpts *opts, int argc, char **argv) {
             ptr = argv[i];
             ptr += 2;
             tmp = strndup(ptr,128);
+            /*@Leak who owns this memory? This list or the macro_defs hashtable
+             * on Cctrl? */
             ListAppend(opts->defines_list,tmp);
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "compile.h"
 #include "cctrl.h"
 #include "lexer.h"
+#include "list.h"
 #include "util.h"
 
 #define ASM_TMP_FILE "/tmp/holyc-asm.s"
@@ -32,6 +33,7 @@ typedef struct hccOpts {
     char *lib_name;
     char *output_filename;
     char *clibs;
+    List *defines_list;
 } hccOpts;
 
 typedef struct hccLib {
@@ -243,6 +245,7 @@ void usage(void) {
             "  -clibs   Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`\n"
             "  -o       Output filename: hcc -o <name> ./<file>.HC\n"
             "  -g       Not implemented\n"
+            "  -D<var>  Set a compiler #define (does not accept a value)\n"
             "  --help   Print this message\n");
     exit(1);
 }
@@ -253,6 +256,9 @@ void parseCliOptions(hccOpts *opts, int argc, char **argv) {
     }
 
     char *infile = argv[argc-1];
+    char *ptr = NULL;
+    char *tmp = NULL;
+
     getASMFileName(opts,infile);
     opts->infile = infile;
     for (int i = 1; i < argc - 1; ++i) {
@@ -279,7 +285,7 @@ void parseCliOptions(hccOpts *opts, int argc, char **argv) {
             const char *error = "Invalid compile command, -clibs must be followed "
                 "by a list of libraries in single quotes for example "
                 "-clibs=\'-lxml2 ....\'.";
-            char *ptr = argv[i];
+            ptr = argv[i];
             ptr += 6;
             loggerDebug("%s\n",ptr);
             if (*ptr != '=' && *(ptr + 1) != '\'') {
@@ -298,6 +304,14 @@ void parseCliOptions(hccOpts *opts, int argc, char **argv) {
             loggerPanic("--g not implemented\n");
         } else if (!strncmp(argv[i],"--help",6)) {
             usage();
+        } else if (!strncmp(argv[i],"-D",2)) {
+            if (opts->defines_list == NULL) {
+                opts->defines_list = ListNew();
+            }
+            ptr = argv[i];
+            ptr += 2;
+            tmp = strndup(ptr,128);
+            ListAppend(opts->defines_list,tmp);
         }
     }
 }
@@ -316,28 +330,33 @@ int main(int argc, char **argv) {
 
     memset(&opts,0,sizeof(opts));
     opts.clibs = "";
+    opts.defines_list = NULL;
     opts.output_filename = "a.out";
     /* now parse cli options */
     parseCliOptions(&opts,argc,argv);
-    
+
     cc = CctrlNew();
+    if (opts.defines_list) {
+        CctrlSetCommandLineDefines(cc,opts.defines_list);
+    }
 
     if (opts.print_tokens) {
         List *tokens = compileToTokens(cc,opts.infile,lexer_flags);
         lexemePrintList(tokens);
         lexemeListRelease(tokens);
-    } else if (opts.print_ast) {
-        compileToAst(cc,opts.infile,lexer_flags);
-        compilePrintAst(cc);
-    }
-
-    if (opts.print_tokens || opts.print_ast) {
         return 0;
     }
 
     compileToAst(cc,opts.infile,lexer_flags);
+    if (opts.print_ast) {
+        compilePrintAst(cc);
+        return 0;
+    }
+
     asmbuf = compileToAsm(cc);
 
-
     emitFile(asmbuf, &opts);
+    if (opts.defines_list) {
+        ListRelease(opts.defines_list,NULL);
+    }
 }


### PR DESCRIPTION
# Description
- Fix the ordering of the entries after resizing
- Removed `MapIndex`
- Added tests.
- Re-formatted assembly.
- Feature can now do `-DSOME_VARIABLE`, implemented this so I could write tests in the holyc file
- Fixed bug with lexer for when the last token is a indentifier.
- Fixed bug with lexer for `#error`.

## Thought
Might want to differentiate between preprocessor keywords and runtime keywords?