### PR TITLE
Fix: fixes for static floats and strings

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -62,7 +62,6 @@ typedef struct AstType AstType;
 typedef struct AstType {
     int kind;
     int size;
-    int is_static;
     int has_var_args;
 
     /* Alignment of a struct or union */
@@ -122,6 +121,7 @@ typedef struct Ast {
 
         /* Global variable */
         struct {
+            int is_static;
             aoStr *gname;
             aoStr *glabel;
         };
@@ -265,7 +265,7 @@ Ast *AstUnaryOperator(AstType *type, long kind, Ast *operand);
 
 /* Variable definitions */
 Ast *AstLVar(AstType *type, char *name, int len);
-Ast *AstGVar(AstType *type, char *name, int len, int local_file);
+Ast *AstGVar(AstType *type, char *name, int len, int is_static);
 
 /* More beefy data structures */
 Ast *AstArrayInit(List *init);

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -37,7 +37,7 @@ inline int ParseIsFunction(Ast *ast) {
     return 0;
 }
 
-inline int ParseIsFunctionCall(Ast *ast) {
+int ParseIsFunctionCall(Ast *ast) {
     return ast && (ast->type->kind == AST_FUNCALL || 
            ast->type->kind == AST_FUNPTR_CALL || 
            ast->type->kind == AST_ASM_FUNCALL);

--- a/src/x86.c
+++ b/src/x86.c
@@ -1961,7 +1961,7 @@ void AsmGlobalVar(Dict *seen_globals, aoStr *buf, Ast* ast) {
         if (declinit->kind == AST_ARRAY_INIT) {
             Ast *head = (Ast *)declinit->arrayinit->next->value;
             if (head->kind == AST_STRING) {
-                aoStrCatPrintf(buf,".align 3\n");
+                aoStrCatPrintf(buf,".align 4\n");
             }
         }
 
@@ -2018,7 +2018,7 @@ void AsmDataSection(Cctrl *cc, aoStr *buf) {
             aoStrCatPrintf(buf,
                     ".string \"%s\\0\"\n\t"
                     ".data\n\t"
-                    ".align 3\n"
+                    ".align 4\n"
                     , escaped->data);
         }
         aoStrRelease(escaped);


### PR DESCRIPTION
# Description
- Static floats supported
- Static strings also supported
- `static auto str = "string";`, support for auto keyword with static variables.
- Fix for `is_static` being on a type, this would mutate the types in `ast.c` thus making _all_ int's static. 