### PR TITLE
x86.c: mark stack read implies execute false and pop stack on exiting

### DIFF
--- a/src/x86.c
+++ b/src/x86.c
@@ -2290,7 +2290,9 @@ void asmInitaliser(Cctrl *cc, aoStr *buf) {
     listForEach(cc->initalisers) {
         asmExpression(cc,buf,it->value);
     }
-    aoStrCatPrintf(buf, "leave\n\tret\n");
+    aoStrCatPrintf(buf, "pop   %%rbp\n\tret\n\t");
+    aoStrCatPrintf(buf,
+		   ".section .note.GNU-stack,\"\",@progbits\n");
 }
 
 /* Create assembly */


### PR DESCRIPTION
Binary files don't mark their stack non-executable if GNU stack isn't set to non-executable (or read implies executable value to false). As a result, every memory segments in the binary file will be treated as executable, even they shouldn't be. This isn't yet fixed in the binutils (at least they don't force to mark stack as non-executable), but deprecated.
And also, `pop` the stack instead using `leave` instruction. Both does the same task, except later one copies frame pointer to the stack pointer which frees the stack.
