### PR TITLE
Fixes: link lm & remove intermediary assembly files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -77,6 +77,8 @@ add_custom_target(unit-test
     USES_TERMINAL
 )
 
+target_link_libraries(hcc m)
+
 # Install the executable
 install(TARGETS hcc DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 

--- a/src/main.c
+++ b/src/main.c
@@ -238,13 +238,13 @@ void emitFile(aoStr *asmbuf, hccOpts *opts) {
             char run_cmd[64];
             snprintf(run_cmd,sizeof(run_cmd),"./%s",opts->output_filename);
             system(run_cmd);
-            //unlink(opts->output_filename);
+            unlink(opts->output_filename);
         }
     }
     if (strnlen(opts->clibs,10) > 1) {
         free(opts->clibs);
     }
-    //remove(ASM_TMP_FILE);
+    remove(ASM_TMP_FILE);
     aoStrRelease(cmd);
     aoStrRelease(asmbuf);
 }


### PR DESCRIPTION
- Put back in the commented out code for deleting intermediary assembly files
- Link in the math library, caused the compiler to break on linux