### PR TITLE
Fix/type warning message

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -1169,7 +1169,7 @@ static char *astParamsToString(List *params) {
 
 static char *astFunctionToStringInternal(Ast *func, AstType *type) {
     aoStr *str = aoStrNew();
-    char *tmp,*strparams;
+    char *tmp,*strparams = NULL;
 
     tmp = astTypeToColorString(type);
     aoStrCatPrintf(str,"%s %s",tmp,func->fname->data);
@@ -1183,11 +1183,16 @@ static char *astFunctionToStringInternal(Ast *func, AstType *type) {
             break;
 
         case AST_FUNC:
+        case AST_FUN_PROTO:
             strparams = astParamsToString(func->params);
             break;
     }
 
-    aoStrCatPrintf(str,"(%s)",strparams);
+    if (strparams) {
+        aoStrCatPrintf(str,"(%s)",strparams);
+    } else {
+        aoStrCatPrintf(str,"(U0)");
+    }
     return aoStrMove(str);
 }
 

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -6,7 +6,7 @@
 #include "dict.h"
 #include "lexer.h"
 
-#define HCC_VERSION "beta-v0.0.5"
+#define HCC_VERSION "beta-v0.0.6"
 
 static const char *cctrlGetVersion(void) {
     return HCC_VERSION;


### PR DESCRIPTION
- Fix for printing warning when calling function prototypes with the incorrect types.
- Bump version