### PR TITLE
fix/variable-assignment-typechecking

### DIFF
--- a/src/aostr.c
+++ b/src/aostr.c
@@ -114,6 +114,10 @@ void aoStrCatLen(aoStr *buf, const void *d, size_t len) {
     buf->data[buf->len] = '\0';
 }
 
+void aoStrCatAoStr(aoStr *buf, aoStr *s2) {
+    aoStrCatLen(buf, s2->data, s2->len);
+}
+
 void aoStrCat(aoStr *buf, const void *d) {
     size_t len = strlen(d);
     aoStrCatLen(buf, d, len);

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -33,6 +33,7 @@ aoStr *aoStrDup(aoStr *buf);
 char *aoStrMove(aoStr *buf);
 
 void aoStrCatLen(aoStr *buf, const void *d, size_t len);
+void aoStrCatAoStr(aoStr *buf, aoStr *s2);
 void aoStrCat(aoStr *buf, const void *d);
 void aoStrCatRepeat(aoStr *buf, char *str, int times);
 void aoStrCatPrintf(aoStr *b, const char *fmt, ...);

--- a/src/ast.c
+++ b/src/ast.c
@@ -90,12 +90,14 @@ static void astFreeUnaryOperator(Ast *ast) {
 Ast *astBinaryOp(long operation, Ast *left, Ast *right) {
     Ast *ast = astNew();
     ast->type = astGetResultType(operation,left->type,right->type);  
+
     if (ast->type == NULL) {
         loggerPanic("Incompatiable operands: %s: "ESC_GREEN"%s %s"ESC_RESET"\n",
                 astKindToString(operation),
                 astToString(left),
                 astToString(right));
     }
+
     ast->kind = operation;
     if (operation != '=' &&
             astConvertArray(left->type)->kind != AST_TYPE_POINTER &&
@@ -897,6 +899,7 @@ AstType *astTypeCheck(AstType *expected, Ast *ast) {
 
     AstType *original_actual = ast->type;
     AstType *actual;
+
     if (original_actual == NULL) {
         original_actual = ast_void_type;
         actual = original_actual;
@@ -1016,13 +1019,13 @@ int astIsLabelMatch(Ast *ast, aoStr *goto_label) {
            aoStrCmp(goto_label, astHackedGetLabel(ast));
 }
 
-char *astTypeToString(AstType *type) {
+static aoStr *astTypeToAoStrInternal(AstType *type) {
     aoStr *str = aoStrNew();
 
     switch (type->kind) {
     case AST_TYPE_VOID:
         aoStrCatPrintf(str, "U0");
-        return aoStrMove(str);
+        return str;
     
     case AST_TYPE_INT:
         switch (type->size) {
@@ -1049,25 +1052,27 @@ char *astTypeToString(AstType *type) {
             default: loggerPanic("Unknown integer size: %d\n", type->size);
 
         }
-        return aoStrMove(str);
+        return str;
     
     case AST_TYPE_CHAR:
         if (type->issigned) aoStrCatPrintf(str, "I8");
         else                aoStrCatPrintf(str, "U8");
-        return aoStrMove(str);
+        return str;
 
     case AST_TYPE_FLOAT:
-        aoStrCatPrintf(str, "F64");
-        return aoStrMove(str);
+        aoStrCatLen(str,str_lit("F64"));
+        return str;
 
     case AST_TYPE_POINTER: {
-        aoStrCatPrintf(str, "%s*", astTypeToString(type->ptr));
-        return aoStrMove(str);
+        aoStr *ptr_type = astTypeToAoStrInternal(type->ptr);
+        aoStrCatPrintf(str, "%s*", ptr_type->data);
+        aoStrRelease(ptr_type);
+        return str;
     }
 
     case AST_TYPE_ARRAY: {
-        aoStrCatPrintf(str, "array %s[%d]", astTypeToString(type->ptr), type->size);
-        return aoStrMove(str);
+        aoStrCatPrintf(str, "%s[%d]", astTypeToString(type->ptr), type->size);
+        return str;
     }
 
     case AST_TYPE_UNION:
@@ -1081,39 +1086,102 @@ char *astTypeToString(AstType *type) {
         }
 
         aoStrCatPrintf(str, "%s",clsname);
-        return aoStrMove(str);
+        return str;
     }
 
     case AST_TYPE_FUNC: {
-        aoStrCatPrintf(str, "<fn> %s", astTypeToString(type->rettype));
-        return aoStrMove(str);
+        aoStr *return_type = astTypeToAoStrInternal(type->rettype);
+        aoStrCatPrintf(str, "<fn> %s", return_type->data);
+        aoStrRelease(return_type);
+        return str;
     }
 
     case AST_TYPE_AUTO:
-        aoStrCatPrintf(str, "auto");
-        return aoStrMove(str);
+        aoStrCatPrintf(str,str_lit("auto"));
+        return str;
 
     default:
         loggerPanic("Unknown type: %d\n", type->kind);
     }
 }
 
-char *astTypeToColorString(AstType *type) {
-    char *str = astTypeToString(type);
+aoStr *astTypeToAoStr(AstType *type) {
+    aoStr *str_type = astTypeToAoStrInternal(type);
+    if (str_type->data[str_type->len - 1] == '*') {
+        /* move the stars to the end of the string
+         * 
+         * 'SomeType**' -> 'SomeType **'
+         *  1) 'SomeType** '
+         *  2) 'SomeType** '
+         *              ^--- move cursor here
+         * */
+        ssize_t idx = str_type->len - 1;
+        ssize_t end = idx + 1;
+        /* Move the stars to the end */
+        aoStrPutChar(str_type, ' ');
+        while (str_type->data[idx] == '*') {
+            str_type->data[end--] = '*';
+            str_type->data[idx] = ' ';
+            idx--;
+        }
+    }
+    return str_type;
+}
+
+char *astTypeToString(AstType *type) {
+    aoStr *str_type = astTypeToAoStr(type);
+    return aoStrMove(str_type);
+}
+
+aoStr *astTypeToColorAoStr(AstType *type) {
+    aoStr *str = astTypeToAoStr(type);
     if (!isatty(STDOUT_FILENO)) {
         return str;
     }
+
     aoStr *buf = aoStrNew();
-    aoStrCatPrintf(buf,"\033[0;32m%s\033[0m",str);
-    free(str);
-    return aoStrMove(buf);
+    int star_count = 0;
+    if (str->data[str->len-1] == '*') {
+        ssize_t idx = str->len - 1;
+        while (str->data[idx] == '*') {
+            idx--;
+            star_count++;
+        }
+        str->len = idx;
+        str->data[str->len] = '\0';
+    }
+
+    aoStrCatPrintf(buf,"\033[0;34m%s\033[0m",str->data);
+    if (star_count) {
+        aoStrPutChar(buf, ' ');
+        while (star_count > 0) {
+            aoStrPutChar(buf, '*');
+            star_count--;
+        }
+    }
+    aoStrRelease(str);
+    return buf;
+}
+
+char *astTypeToColorString(AstType *type) {
+    aoStr *color_type = astTypeToColorAoStr(type);
+    return aoStrMove(color_type);
 }
 
 char *astFunctionNameToString(AstType *rettype, char *fname, int len) {
     aoStr *str = aoStrNew();
-    char *tmp = astTypeToColorString(rettype);
-    aoStrCatPrintf(str,"%s %.*s()",tmp,len,fname);
-    free(tmp);
+    aoStr *tmp = astTypeToColorAoStr(rettype);
+
+    /* Add type definition */
+    aoStrCatLen(str,tmp->data,tmp->len);
+    if (tmp->data[tmp->len - 1] != '*') {
+        aoStrPutChar(str,' ');
+    }
+
+    /* Add the actual function name */
+    aoStrCatLen(str,fname,len);
+
+    aoStrRelease(tmp);
     return aoStrMove(str);
 }
 
@@ -1169,11 +1237,15 @@ static char *astParamsToString(List *params) {
 
 static char *astFunctionToStringInternal(Ast *func, AstType *type) {
     aoStr *str = aoStrNew();
-    char *tmp,*strparams = NULL;
+    char *strparams = NULL;
 
-    tmp = astTypeToColorString(type);
-    aoStrCatPrintf(str,"%s %s",tmp,func->fname->data);
-    free(tmp);
+    aoStr *tmp = astTypeToColorAoStr(type);
+    if (tmp->data[tmp->len - 1] == '*') {
+        aoStrCatPrintf(str,"%s%s",tmp->data,func->fname->data);
+    } else {
+        aoStrCatPrintf(str,"%s %s",tmp->data,func->fname->data);
+    }
+    aoStrRelease(tmp);
 
     switch (func->kind) {
         case AST_FUNCALL:
@@ -1213,11 +1285,18 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
     char *tmp;
 
     switch(ast->kind) {
-        case AST_LITERAL:
+        case AST_LITERAL: {
             aoStrCatPrintf(str,"<ast_literal> ");
             switch (ast->type->kind) {
             case AST_TYPE_VOID:  aoStrCatPrintf(str, "<U0>"); break;
-            case AST_TYPE_INT:   aoStrCatPrintf(str, "<I64> %ld", ast->i64); break;
+            case AST_TYPE_INT: {
+                if (!isatty(STDOUT_FILENO)) {
+                    aoStrCatPrintf(str, "<integer> %ld", ast->i64);
+                } else {
+                    aoStrCatPrintf(str, "<integer> \033[0;35m%ld\033[0m", ast->i64);
+                }
+                break;
+            }    
             case AST_TYPE_CHAR:  {
                 char buf[9];
                 unsigned long ch = ast->i64;
@@ -1230,49 +1309,86 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
                 buf[6] = ((unsigned long)ch) >> 48 & 0xFF;
                 buf[7] = ((unsigned long)ch) >> 56 & 0xFF;
                 buf[8] = '\0';
-                aoStrCatPrintf(str, "<CONST_CHAR> '%s'", buf);
+                if (!isatty(STDOUT_FILENO)) {
+                    aoStrCatPrintf(str, "<const_char> '%s'", buf);
+                } else {
+                    aoStrCatPrintf(str, "\033[0;35m%s\033[0m", buf);
+                }
                 break;
             }
-            case AST_TYPE_FLOAT: aoStrCatPrintf(str, "<F64> %g", ast->f64); break;
+            case AST_TYPE_FLOAT: {
+                if (!isatty(STDOUT_FILENO)) {
+                    aoStrCatPrintf(str, "<float> %g", ast->f64);
+                } else {
+                    aoStrCatPrintf(str, "\033[0;35m%g\033[0m", ast->f64);
+                }
+                break;
+            }
             default:
                 loggerPanic("Unhandled type: %d\n", ast->type->kind);
             }
             break;
 
-        case AST_STRING:
+        case AST_STRING: {
             escaped = aoStrEscapeString(ast->sval);
-            aoStrCatPrintf(str, "<string> \"%s\"", escaped->data);
+            if (!isatty(STDOUT_FILENO)) {
+                aoStrCatPrintf(str, "<string> \"%s\"", escaped->data);
+            } else {
+                aoStrCatPrintf(str, "<string> \033[0;35m\"%s\"\033[0m", escaped->data);
+            }
             aoStrRelease(escaped);
             break;
-    
-    case AST_LVAR:
-        tmp = astTypeToString(ast->type);
-        aoStrCatPrintf(str, "<lvar> %s %s\n", tmp,
-                ast->lname->data);
-        free(tmp);
-        break;
-    
-    case AST_DECL:
-        tmp = astTypeToString(ast->declvar->type);
-        if (ast->declvar->kind == AST_FUNPTR) {
-            aoStrCatPrintf(str,"<decl> %s %s\n", tmp, ast->declvar->fname->data);
-        } else if (ast->declvar->kind == AST_LVAR) {
-            aoStrCatPrintf(str,"<decl> %s %s\n", tmp, ast->declvar->lname->data);
-        } else if (ast->declvar->kind == AST_GVAR) {
-            if (ast->declvar->is_static) {
-                aoStrCatPrintf(str,"<decl> static %s %s\n", tmp, ast->declvar->gname->data);
-            } else {
-                aoStrCatPrintf(str,"<decl> %s %s\n", tmp, ast->declvar->gname->data);
-            }
-        } else {
-            loggerPanic("Unhandled declaration: %s\n", tmp);
         }
-        free(tmp);
+    }
+    case AST_LVAR: {
+        aoStr *type_str = astTypeToColorAoStr(ast->type);
+
+        aoStrCatLen(str, str_lit("<lvar> "));
+        
+        aoStrCatAoStr(str, type_str);
+        if (type_str->data[type_str->len - 1] != '*') {
+            aoStrPutChar(str, ' ');
+        }
+
+        aoStrCatAoStr(str,ast->lname);
+
+        aoStrRelease(type_str);
+        break;
+    }    
+    
+    case AST_DECL: {
+        aoStr *type_color = astTypeToColorAoStr(ast->declvar->type);
+
+        /* type declaration sorted */
+        aoStrCatLen(str, str_lit("<decl> "));
+
+        if (ast->declvar->kind == AST_GVAR && ast->declvar->is_static) {
+            aoStrCatLen(str, str_lit("static "));
+        }
+
+        aoStrCatAoStr(str, type_color);
+        if (type_color->data[type_color->len-1] != '*') {
+            aoStrPutChar(str, ' ');
+        }
+
+        if (ast->declvar->kind == AST_FUNPTR) {
+            aoStrCatAoStr(str, ast->declvar->fname);
+        } else if (ast->declvar->kind == AST_LVAR) {
+            aoStrCatAoStr(str, ast->declvar->lname);
+        } else if (ast->declvar->kind == AST_GVAR) {
+            aoStrCatAoStr(str, ast->declvar->gname);
+        } else {
+            loggerPanic("Unhandled declaration: %s\n", type_color->data);
+        }
+
+        aoStrRelease(type_color);
+        aoStrPutChar(str, '\n');
         if (ast->declinit) {
             _astToString(str,ast->declinit,depth+1);
             astStringEndStmt(str);
         }
         break;
+    }
 
     case AST_GVAR:
         aoStrCatPrintf(str, "<gvar> %s", ast->gname->data);
@@ -1542,9 +1658,12 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
                 aoStrCatRepeat(str, "  ", depth+1);
 
                 if (!astIsClassPointer(field_type)) {
-                    tmp = astTypeToColorString(field_type);
-                    aoStrCatPrintf(str, "%s ", tmp);
-                    free(tmp);
+                    aoStr *color_type = astTypeToColorAoStr(field_type);
+                    aoStrCatLen(str, color_type->data, color_type->len);
+                    if (color_type->data[color_type->len - 1] != '*') {
+                        aoStrPutChar(str, ' ');
+                    } 
+                    aoStrRelease(color_type);
                 } else {
                     tmp = astTypeToColorString(field_type);
                     aoStrCatPrintf(str, "<class> %s ",tmp);

--- a/src/ast.h
+++ b/src/ast.h
@@ -371,8 +371,10 @@ Ast *astMakeLoopSentinal(void);
 int astIsLabelMatch(Ast *ast, aoStr *goto_label);
 
 /* For debugging */
+aoStr *astTypeToAoStr(AstType *type);
 char *astTypeToString(AstType *type);
 char *astTypeToColorString(AstType *type);
+aoStr *astTypeToColorAoStr(AstType *type);
 char *astKindToString(int kind);
 char *astFunctionToString(Ast *func);
 char *astFunctionNameToString(AstType *rettype, char *fname, int len);

--- a/src/ast.h
+++ b/src/ast.h
@@ -354,7 +354,7 @@ AstType *astClassType(Dict *fields, aoStr *clsname, int size, int is_intrinsic);
 Ast *astCast(Ast *var, AstType *to);
 
 AstType *astGetResultType(long op, AstType *a, AstType *b);
-AstType *astTypeCheck(AstType *expected, Ast *ast);
+AstType *astTypeCheck(AstType *expected, Ast *ast, long op);
 
 aoStr *astMakeLabel(void);
 aoStr *astMakeTmpName(void);
@@ -380,6 +380,7 @@ char *astFunctionToString(Ast *func);
 char *astFunctionNameToString(AstType *rettype, char *fname, int len);
 char *astToString(Ast *ast);
 char *astLValueToString(Ast *ast, unsigned long lexme_flags);
+aoStr *astLValueToAoStr(Ast *ast, unsigned long lexeme_flags);
 void astPrint(Ast *ast);
 void astTypePrint(AstType *type);
 void astKindPrint(int kind);

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -528,7 +528,7 @@ public U0 StrReverse(U8 *buf, I64 length)
 { // Reverse a string inplace
   I64 start = 0, end = length - 1;
   while (start < end) {
-    U8 *temp = buf[start];
+    U8 temp = buf[start];
     buf[start] = buf[end];
     buf[end] = temp;
     start++;
@@ -769,7 +769,7 @@ U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
           F64 n;
           U64 m;
           I64 k = 0, idx = 0;
-          farg = argv[sp++]; // XXX: this should require a cast?
+          farg = argv[sp++](F64); // XXX: this should require a cast?
           if (farg < 0) {
             flags |= PRTF_NEG;
             farg=-farg;
@@ -788,7 +788,7 @@ U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
           } else {
             n = 0;
           }
-          m = round(farg);
+          m = round(farg)(U64);
           if (dec_len) {
             buf[k++]='.';
           }

--- a/src/parser.c
+++ b/src/parser.c
@@ -471,6 +471,14 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
     if (var->kind == AST_GVAR && var->type->kind == AST_TYPE_INT) {
         init = astI64Type(evalIntConstExpr(init));
     }
+
+    if (var->type->kind == AST_TYPE_AUTO) {
+        var->type = init->type;
+    }
+    AstType *ok = astTypeCheck(var->type,init,'=');
+    if (!ok) {
+        typeCheckWarn(cc,'=',var,init);
+    }
     return astDecl(var,init);
 }
 
@@ -892,7 +900,7 @@ Ast *parseReturnStatement(Cctrl *cc) {
         return astReturn(retval,cc->tmp_rettype);
     }
 
-    AstType *ok = astTypeCheck(cc->tmp_rettype,retval);
+    AstType *ok = astTypeCheck(cc->tmp_rettype,retval,'\0');
     if (!ok) {
         Ast *func = dictGet(cc->global_env,cc->tmp_fname->data);
         typeCheckReturnTypeWarn(cc,lineno,func,check,retval);

--- a/src/parser.c
+++ b/src/parser.c
@@ -697,7 +697,8 @@ Ast *parseRangeLoop(Cctrl *cc, AstType *type, Ast *iteratee) {
 
         return parseCreateForRange(cc, iteratee, container, size_ref, entries_ref);
     }
-    loggerPanic("Can only handle lvars and class references at this time got: %s\n", astKindToString(container->kind));
+    loggerPanic("Can only handle lvars, arrays and class references at this time got: %s %s\n",
+                astKindToString(container->kind), astToString(container));
 }
 
 /* Either parse the initialiser or a range loop. Range loop is experimental */
@@ -891,27 +892,10 @@ Ast *parseReturnStatement(Cctrl *cc) {
         return astReturn(retval,cc->tmp_rettype);
     }
 
-    AstType *t = astTypeCheck(cc->tmp_rettype,retval);
-    if (!t) {
+    AstType *ok = astTypeCheck(cc->tmp_rettype,retval);
+    if (!ok) {
         Ast *func = dictGet(cc->global_env,cc->tmp_fname->data);
-        char *fstring, *expected, *got, *ast_str;
-
-        if (func) {
-            fstring = astFunctionToString(func);
-        } else {
-            fstring = astFunctionNameToString(cc->tmp_rettype,
-                    cc->tmp_fname->data,cc->tmp_fname->len);
-        }
-
-        expected = astTypeToColorString(cc->tmp_rettype);
-        got = astTypeToColorString(check);
-        ast_str = astLValueToString(retval,0);
-        loggerWarning("line %ld: %s expected return type %s got %s %s\n",
-                lineno,fstring,expected,got,ast_str);
-        free(fstring);
-        free(expected);
-        free(got);
-        free(ast_str);
+        typeCheckReturnTypeWarn(cc,lineno,func,check,retval);
     }
     return astReturn(retval,cc->tmp_rettype);
 }

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -842,9 +842,19 @@ Ast *parseExpr(Cctrl *cc, int prec) {
         }
 
         if (compound_assign) {
+            AstType *ok = astTypeCheck(LHS->type,RHS);
+            if (!ok) {
+                typeCheckWarn(cc,LHS->type,RHS->type);
+            }
             LHS = astBinaryOp('=', LHS, 
                     astBinaryOp(compound_assign, LHS, RHS));
         } else {
+            if (tok->i64 == '=') {
+                AstType *ok = astTypeCheck(LHS->type,RHS);
+                if (!ok) {
+                    typeCheckWarn(cc,LHS->type,RHS->type);
+                }
+            }
             LHS = astBinaryOp(tok->i64,LHS,RHS);
         }
     }

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -49,6 +49,7 @@ AstType *parseReturnAuto(Cctrl *cc, Ast *retval) {
         case AST_TYPE_FLOAT:
         case AST_TYPE_POINTER:
         case AST_TYPE_VOID:
+        case AST_LITERAL:
         case '+':
         case '-':
         case '*':
@@ -426,7 +427,7 @@ List *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
         } else {
             /* Does a distinctly adequate job of type checking function parameters */
             if (param && param->kind != AST_DEFAULT_PARAM) {
-                if ((check = astTypeCheck(param->type,ast)) == NULL) {
+                if ((check = astTypeCheck(param->type,ast,'=')) == NULL) {
                     Ast *func = findFunctionDecl(cc,fname,len);
                     char *fstring, *expected, *got, *ast_str;
                     if (func) {
@@ -842,17 +843,17 @@ Ast *parseExpr(Cctrl *cc, int prec) {
         }
 
         if (compound_assign) {
-            AstType *ok = astTypeCheck(LHS->type,RHS);
+            AstType *ok = astTypeCheck(LHS->type,RHS,compound_assign);
             if (!ok) {
-                typeCheckWarn(cc,LHS->type,RHS->type);
+                typeCheckWarn(cc,compound_assign,LHS,RHS);
             }
             LHS = astBinaryOp('=', LHS, 
                     astBinaryOp(compound_assign, LHS, RHS));
         } else {
             if (tok->i64 == '=') {
-                AstType *ok = astTypeCheck(LHS->type,RHS);
+                AstType *ok = astTypeCheck(LHS->type,RHS,'=');
                 if (!ok) {
-                    typeCheckWarn(cc,LHS->type,RHS->type);
+                    typeCheckWarn(cc,'=',LHS,RHS);
                 }
             }
             LHS = astBinaryOp(tok->i64,LHS,RHS);

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -236,3 +236,36 @@ void assertUniqueSwitchCaseLabels(PtrVec *case_vector, Ast *case_) {
         loggerPanic("Duplicate case value: %ld\n",case_->case_begin);
     }
 }
+
+void typeCheckWarn(Cctrl *cc, AstType *expected, AstType *actual) {
+    char *expected_color = astTypeToColorString(expected);
+    char *actual_color = astTypeToColorString(actual);
+    loggerWarning("line %ld: Incompatible types type '%s' is not assignable to type '%s'\n",
+            cc->lineno, actual_color, expected_color);
+    free(expected_color);
+    free(actual_color);
+}
+
+void typeCheckReturnTypeWarn(Cctrl *cc, long lineno, Ast *maybe_func, 
+                             AstType *check, Ast *retval)
+{
+    char *fstring, *expected, *ast_str;
+    if (maybe_func) {
+        fstring = astFunctionToString(maybe_func);
+    } else {
+        fstring = astFunctionNameToString(cc->tmp_rettype,
+                cc->tmp_fname->data,cc->tmp_fname->len);
+    }
+
+    expected = astTypeToColorString(cc->tmp_rettype);
+    aoStr *got = astTypeToColorAoStr(check);
+    ast_str = astLValueToString(retval,0);
+
+    loggerWarning("line %ld: %s unexpected return value '%s' of type '%s' expected '%s'\n",
+            lineno,fstring,ast_str,got->data,expected);
+    
+    free(fstring);
+    free(expected);
+    free(ast_str);
+    aoStrRelease(got);
+}

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -1,3 +1,4 @@
+#include <string.h>
 #include "ast.h"
 #include "lexer.h"
 #include "prsutil.h"
@@ -237,19 +238,71 @@ void assertUniqueSwitchCaseLabels(PtrVec *case_vector, Ast *case_) {
     }
 }
 
-void typeCheckWarn(Cctrl *cc, AstType *expected, AstType *actual) {
-    char *expected_color = astTypeToColorString(expected);
-    char *actual_color = astTypeToColorString(actual);
-    loggerWarning("line %ld: Incompatible types type '%s' is not assignable to type '%s'\n",
-            cc->lineno, actual_color, expected_color);
-    free(expected_color);
-    free(actual_color);
+
+void repeatRedSquiggles(aoStr *str, int count) {
+    aoStrCatLen(str, str_lit(ESC_BOLD_RED));
+    aoStrCatRepeat(str, "~", count);
+    aoStrCatLen(str, str_lit(ESC_RESET));
+}
+
+void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual) {
+    aoStr *expected_type_color = astTypeToColorAoStr(expected->type);
+    aoStr *expected_type = astTypeToAoStr(expected->type);
+    aoStr *actual_type = astTypeToAoStr(actual->type);
+    aoStr *expected_variable = astLValueToAoStr(expected,0);
+    aoStr *actual_variable = astLValueToAoStr(actual,0);
+
+    char *operation = lexemePunctToString(op);
+    if (operation[0] != '=') {
+        operation[1] = '=';
+    }
+    
+    aoStr *str = aoStrNew();
+    aoStrCatPrintf(str, "%4ld |    %s", cc->lineno, expected_type_color->data);
+
+    int ends_with_star = expected_type->data[expected_type->len - 1] == '*';
+    if (!ends_with_star) {
+        aoStrPutChar(str, ' ');
+    }
+
+    aoStrCatAoStr(str, expected_variable);
+    aoStrCatPrintf(str, " %s ", operation);
+
+    aoStrCatLen(str, str_lit(ESC_BOLD_RED));
+    aoStrCatAoStr(str, actual_variable);
+    aoStrCatLen(str, str_lit(ESC_RESET));
+
+    aoStrCat(str, ";\n");
+    aoStrCatLen(str, str_lit("     |    "));
+    for (int i = 0; i < expected_type->len; ++i) {
+        aoStrPutChar(str, ' ');
+    }
+    if (!ends_with_star) {
+        aoStrPutChar(str, ' ');
+    }
+
+    aoStrCatLen(str, str_lit(ESC_GREEN));
+    aoStrPutChar(str, '^');
+    aoStrCatLen(str, str_lit(ESC_RESET));
+    aoStrCatRepeat(str, " ", expected_variable->len+1+strlen(operation));
+
+    repeatRedSquiggles(str,actual_variable->len);
+
+    loggerWarning("line %ld: Incompatible types '%s' is not assignable to type '%s'\n%s\n",
+            cc->lineno, actual_type->data, expected_type->data,str->data);
+
+    aoStrRelease(expected_variable);
+    aoStrRelease(actual_variable);
+    aoStrRelease(actual_type);
+    aoStrRelease(expected_type);
+    aoStrRelease(expected_type_color);
+    aoStrRelease(str);
 }
 
 void typeCheckReturnTypeWarn(Cctrl *cc, long lineno, Ast *maybe_func, 
                              AstType *check, Ast *retval)
 {
-    char *fstring, *expected, *ast_str;
+    char *fstring = NULL;
     if (maybe_func) {
         fstring = astFunctionToString(maybe_func);
     } else {
@@ -257,15 +310,33 @@ void typeCheckReturnTypeWarn(Cctrl *cc, long lineno, Ast *maybe_func,
                 cc->tmp_fname->data,cc->tmp_fname->len);
     }
 
-    expected = astTypeToColorString(cc->tmp_rettype);
+    char *expected = astTypeToColorString(cc->tmp_rettype);
     aoStr *got = astTypeToColorAoStr(check);
-    ast_str = astLValueToString(retval,0);
+    aoStr *ast_str = astLValueToAoStr(retval,0);
 
-    loggerWarning("line %ld: %s unexpected return value '%s' of type '%s' expected '%s'\n",
-            lineno,fstring,ast_str,got->data,expected);
+    aoStr *str = aoStrNew();
+
+    aoStrCatPrintf(str, "     | %s { \n", fstring);
+    aoStrCatLen(str, str_lit("     |    ... \n"));
+    aoStrCatPrintf(str, "%4ld |    return ", cc->lineno);
+    
+    aoStrCatLen(str, str_lit(ESC_BOLD_RED));
+    aoStrCatAoStr(str, ast_str);
+    aoStrCatLen(str, str_lit(ESC_RESET));
+
+    aoStrCatLen(str, str_lit(";\n"));
+    aoStrCatLen(str, str_lit("     | }  "));
+
+    aoStrCatRepeat(str, " ", 7);
+    repeatRedSquiggles(str,ast_str->len);
+
+
+    loggerWarning("line %ld: %s unexpected return value '%s' of type '%s' expected '%s'\n%s\n",
+            lineno,fstring,ast_str->data,got->data,expected,str->data);
     
     free(fstring);
     free(expected);
-    free(ast_str);
+    aoStrRelease(ast_str);
     aoStrRelease(got);
+    aoStrRelease(str);
 }

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -37,4 +37,7 @@ void assertIsInt(Ast *ast, long lineno);
 void assertIsFloat(Ast *ast, long lineno);
 void assertIsPointer(Ast *ast, long lineno);
 
+void typeCheckWarn(Cctrl *cc, AstType *expected, AstType *actual);
+void typeCheckReturnTypeWarn(Cctrl *cc, long lineno, Ast *maybe_func, 
+                             AstType *check, Ast *retval);
 #endif // PRS_UTIL

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -37,7 +37,7 @@ void assertIsInt(Ast *ast, long lineno);
 void assertIsFloat(Ast *ast, long lineno);
 void assertIsPointer(Ast *ast, long lineno);
 
-void typeCheckWarn(Cctrl *cc, AstType *expected, AstType *actual);
+void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual);
 void typeCheckReturnTypeWarn(Cctrl *cc, long lineno, Ast *maybe_func, 
                              AstType *check, Ast *retval);
 #endif // PRS_UTIL

--- a/src/util.h
+++ b/src/util.h
@@ -11,6 +11,7 @@
 #define ESC_GREEN  "\033[0;32m"
 #define ESC_BLACK  "\033[0;30m"
 #define ESC_RED    "\033[0;31m"
+#define ESC_BOLD_RED "\033[1;31m"
 #define ESC_GREEN  "\033[0;32m"
 #define ESC_YELLOW "\033[0;33m"
 #define ESC_BLUE   "\033[0;34m"

--- a/src/util.h
+++ b/src/util.h
@@ -33,7 +33,7 @@
 
 #define loggerWarning(...)                             \
     do {                                               \
-        fprintf(stderr, "\033[0;35mWARNING: \033[0m"); \
+        fprintf(stderr, "\033[0;33mWARNING: \033[0m"); \
         fprintf(stderr, __VA_ARGS__);                  \
     } while (0)
 


### PR DESCRIPTION
- Provides a warning when assigning a value to a variable of an incompatiable type
- Improved colours of the ast
- Improved error message for return type of function
- Changed warning colour from some derivation of purple to yellow for release builds
- Improves reporting of type errors (not great, but _much_ better and somewhat workable)