### PR TITLE
lexer uses a ring buffer, better error reporting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@ endif()
 
 # Optionally, add more flags or options depending on the build type
 # For example, optimization flags for Release builds:
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -g")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 
 set(SOURCES
@@ -89,8 +88,8 @@ install(TARGETS hcc DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 install(FILES ${CMAKE_SOURCE_DIR}/holyc-lib/tos.HH DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 
 # Custom installation step to run `hcc` during install
-#if (DEFINED HCC_LINK_SQLITE3)
-#    install(CODE "execute_process(COMMAND hcc -DHCC_LINK_SQLITE3 -lib tos ${CMAKE_SOURCE_DIR}/holyc-lib/all.HC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/holyc-lib)")
-#else()
-install(CODE "execute_process(COMMAND hcc -lib tos ${CMAKE_SOURCE_DIR}/holyc-lib/all.HC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/holyc-lib)")
-    #endif()
+if (DEFINED HCC_LINK_SQLITE3)
+    install(CODE "execute_process(COMMAND hcc -DHCC_LINK_SQLITE3 -lib tos ${CMAKE_SOURCE_DIR}/holyc-lib/all.HC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/holyc-lib)")
+else()
+    install(CODE "execute_process(COMMAND hcc -lib tos ${CMAKE_SOURCE_DIR}/holyc-lib/all.HC WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/holyc-lib)")
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,7 @@ endif()
 
 # Optionally, add more flags or options depending on the build type
 # For example, optimization flags for Release builds:
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -g")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 
 set(SOURCES

--- a/src/aostr.c
+++ b/src/aostr.c
@@ -372,10 +372,8 @@ error:
     return NULL;
 }
 
-/* Allocating printf */
-char *mprintf(const char *fmt, ...) {
-    va_list ap, copy;
-    va_start(ap,fmt);
+char *mprintVa(const char *fmt, va_list ap) {
+    va_list copy;
 
     int allocated = 256;
     int len = 0;
@@ -401,8 +399,16 @@ char *mprintf(const char *fmt, ...) {
         break;
     }
     buffer[len] = '\0';
-    va_end(ap);
     return buffer;
+}
+
+/* Allocating printf */
+char *mprintf(const char *fmt, ...) {
+    va_list ap;
+    va_start(ap,fmt);
+    char *buf = mprintVa(fmt, ap);
+    va_end(ap);
+    return buf;
 }
 
 aoStr *aoStrError(void) {

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -7,6 +7,7 @@
 #ifndef AOSTR_H
 #define AOSTR_H
 
+#include <stdarg.h>
 #include <stddef.h>
 
 typedef struct aoStr aoStr;
@@ -43,6 +44,7 @@ aoStr *aoStrEncode(aoStr *buf);
 void aoStrArrayRelease(aoStr **arr, int count);
 aoStr **aoStrSplit(char *to_split, char delimiter, int *count);
 char *mprintf(const char *fmt, ...);
+char *mprintVa(const char *fmt, va_list ap);
 aoStr *aoStrError(void);
 
 #endif

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -241,24 +241,20 @@ void tokenRingBufferPush(TokenRingBuffer *ring_buffer, lexeme *token) {
     ring_buffer->entries[ring_buffer->head] = token;
     ring_buffer->head = tokenRingBufferGetIdx(ring_buffer->head);
     if (ring_buffer->size == CCTRL_TOKEN_BUFFER_SIZE) {
-        printf("Moving tail\n");
         ring_buffer->tail = tokenRingBufferGetIdx(ring_buffer->tail);
     } else {
         ring_buffer->size++;
     }
-    //printf("PUSH: %ld\n",ring_buffer->size);
 }
 
 /* Take one token from the ring buffer */
 lexeme *tokenRingBufferPop(TokenRingBuffer *ring_buffer) {
     if (tokenRingBufferEmpty(ring_buffer)) {
-        printf(" EMPTY\n");
         return NULL;
     }
     lexeme *token = ring_buffer->entries[ring_buffer->tail];
     ring_buffer->tail = tokenRingBufferGetIdx(ring_buffer->tail);
     ring_buffer->size--;
-    //printf("POP: %ld %s\n",ring_buffer->size,lexemeToString(token));
     return token;
 }
 
@@ -275,7 +271,6 @@ int tokenRingBufferRewind(TokenRingBuffer *ring_buffer) {
     //    return 0;
     //}
     ring_buffer->tail = (ring_buffer->tail - 1 + CCTRL_TOKEN_BUFFER_SIZE) & CCTRL_TOKEN_BUFFER_MASK;
-    //printf("REWIND\n");
     ring_buffer->size++;
     return 1;
 }
@@ -415,7 +410,6 @@ void cctrlTokenExpect(Cctrl *cc, long expected) {
     lexeme *tok = cctrlTokenGet(cc);
     if (!tokenPunctIs(tok, expected)) {
         if (!tok) {
-            //lexemePrintList(cc->tkit->tokens->next);
             loggerPanic("line %ld: Ran out of tokens\n",cc->lineno);
         } else {
             cctrlRaiseException(cc,"Syntax error expected '%c' got: '%.*s'",

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -199,13 +199,166 @@ Cctrl *cctrlNew(void) {
 }
 
 void cctrlInitTokenIter(Cctrl *cc, List *tokens) {
+    cc->tkit->count = 0;
     cc->tkit->tokens = tokens;
     listPrepend(tokens,lexemeSentinal());
     cc->tkit->cur = tokens->next->next;
 }
 
-/* Have a look at the next lexeme but don't consume */
+static lexeme *token_ring_buffer[CCTRL_TOKEN_BUFFER_SIZE];
+
+TokenRingBuffer *tokenRingBufferStaticNew(void) {
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    ring_buffer->tail = 0;
+    ring_buffer->head = 0;
+    ring_buffer->size = 0;
+    ring_buffer->entries = token_ring_buffer;
+    for (ssize_t i = 0; i < CCTRL_TOKEN_BUFFER_SIZE; ++i) {
+        ring_buffer->entries[i] = NULL;
+    }
+    return ring_buffer;
+}
+
+TokenRingBuffer *tokenRingBufferNew(void) {
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    ring_buffer->tail = 0;
+    ring_buffer->head = 0;
+    ring_buffer->size = 0;
+    return ring_buffer;
+}
+
+ssize_t tokenRingBufferGetIdx(ssize_t idx) {
+    return (idx + 1) & CCTRL_TOKEN_BUFFER_MASK;
+}
+
+void tokenBufferPrint(TokenRingBuffer *ring_buffer) {
+    for (int i = 0, idx = ring_buffer->tail; i < ring_buffer->size;
+            i++, idx = tokenRingBufferGetIdx(idx)) {
+        printf(">> %s\n", lexemeToString(ring_buffer->entries[idx]));
+    }
+    printf("\n");
+}
+
+
+int tokenRingBufferEmpty(TokenRingBuffer *ring_buffer) {
+    return ring_buffer->size == 0;
+}
+
+
+/* Add a token to the ring buffer and remove the oldest element */
+void tokenRingBufferPush(TokenRingBuffer *ring_buffer, lexeme *token) {
+    ring_buffer->entries[ring_buffer->head] = token;
+    ring_buffer->head = tokenRingBufferGetIdx(ring_buffer->head);
+    if (ring_buffer->size == CCTRL_TOKEN_BUFFER_SIZE) {
+        printf("Moving tail\n");
+        ring_buffer->tail = tokenRingBufferGetIdx(ring_buffer->tail);
+    } else {
+        ring_buffer->size++;
+    }
+    //printf("PUSH: %ld\n",ring_buffer->size);
+}
+
+/* Take one token from the ring buffer */
+lexeme *tokenRingBufferPop(TokenRingBuffer *ring_buffer) {
+    if (tokenRingBufferEmpty(ring_buffer)) {
+        printf(" EMPTY\n");
+        return NULL;
+    }
+    lexeme *token = ring_buffer->entries[ring_buffer->tail];
+    ring_buffer->tail = tokenRingBufferGetIdx(ring_buffer->tail);
+    ring_buffer->size--;
+    //printf("POP: %ld %s\n",ring_buffer->size,lexemeToString(token));
+    return token;
+}
+
+lexeme *tokenRingBufferPeek(TokenRingBuffer *ring_buffer) {
+    /* we are out of tokens */
+    if (tokenRingBufferEmpty(ring_buffer)) {
+        return NULL;
+    }
+    return ring_buffer->entries[ring_buffer->tail];
+}
+
+int tokenRingBufferRewind(TokenRingBuffer *ring_buffer) {
+    //if (tokenRingBufferEmpty(ring_buffer)) { //|| ring_buffer->tail == ring_buffer->head) {
+    //    return 0;
+    //}
+    ring_buffer->tail = (ring_buffer->tail - 1 + CCTRL_TOKEN_BUFFER_SIZE) & CCTRL_TOKEN_BUFFER_MASK;
+    //printf("REWIND\n");
+    ring_buffer->size++;
+    return 1;
+}
+
+void cctrlInitParse(Cctrl *cc, lexer *lexer_) {
+    cc->lexer_ = lexer_;
+    cc->token_buffer = tokenRingBufferStaticNew();
+    for (int i = 0; i < CCTRL_TOKEN_BUFFER_SIZE; ++i) {
+        lexeme *token = lexToken(cc->macro_defs, cc->lexer_);
+        if (!token) break;
+        tokenRingBufferPush(cc->token_buffer,token);
+    }
+}
+
+void cctrlInitMacroProcessor(Cctrl *cc) {
+    cc->lexer_ = NULL;
+    /* The caller will tack on the entries and size */
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    ring_buffer->tail = 0;
+    ring_buffer->head = 0;
+    ring_buffer->size = 0;
+    cc->token_buffer = ring_buffer;
+}
+
+lexeme *cctrlMaybeExpandToken(Cctrl *cc, lexeme *token) {
+    if (token->tk_type != TK_IDENT) {
+        return token;
+    }
+
+    lexeme *maybe_define = strMapGetLen(cc->macro_defs, token->start, token->len);
+    if (maybe_define) {
+        return maybe_define;
+    }
+    return token; 
+}
+
 lexeme *cctrlTokenPeek(Cctrl *cc) {
+    lexeme *token = tokenRingBufferPeek(cc->token_buffer);
+    if (token) {
+        cc->lineno = token->line;
+        return cctrlMaybeExpandToken(cc,token);
+    }
+    return NULL;
+}
+
+void cctrlTokenRewind(Cctrl *cc) {
+    TokenRingBuffer *ring_buffer = cc->token_buffer;
+    if (!tokenRingBufferRewind(ring_buffer)) {
+        return;
+    }
+    //lexeme *token = ring_buffer->entries[ring_buffer->tail];
+    //cc->lineno = token->line;
+}
+
+lexeme *cctrlTokenGet(Cctrl *cc) {
+    lexeme *token = cctrlTokenPeek(cc);
+    if (token) {
+        tokenRingBufferPop(cc->token_buffer);
+        if (cc->token_buffer->size < 3 && cc->lexer_) {
+            for (ssize_t i = 0; i < 10; ++i) {
+                lexeme *new_token = lexToken(cc->macro_defs,cc->lexer_);
+                if (!new_token) {
+                    break;
+                }
+                tokenRingBufferPush(cc->token_buffer, new_token);
+            }
+        }
+        return token;
+    }
+    return NULL;
+}
+
+/* Have a look at the next lexeme but don't consume */
+lexeme *cctrlTokenPeek2(Cctrl *cc) {
     TokenIter *it = cc->tkit;
     lexeme *retval, *macro;
 
@@ -214,6 +367,7 @@ lexeme *cctrlTokenPeek(Cctrl *cc) {
     }
 
     retval = (lexeme *)it->cur->value;
+    if (!retval) return NULL;
     if (retval->tk_type == TK_IDENT) {
         if ((macro = strMapGetLen(cc->macro_defs,retval->start,retval->len)) != NULL) {
             return macro;
@@ -225,7 +379,7 @@ lexeme *cctrlTokenPeek(Cctrl *cc) {
 /** 
  * Get the current lexeme pointed to by cur and set cur to the 
  * next lexeme */
-lexeme *cctrlTokenGet(Cctrl *cc) {
+lexeme *cctrlTokenGet2(Cctrl *cc) {
     lexeme *tok;
     if ((tok = cctrlTokenPeek(cc)) != NULL) {
         cc->lineno = tok->line;
@@ -233,6 +387,76 @@ lexeme *cctrlTokenGet(Cctrl *cc) {
         return tok;
     }
     return NULL;
+}
+
+/* Go back one */
+void cctrlTokenRewind2(Cctrl *cc) {
+    cc->tkit->cur = cc->tkit->cur->prev;
+    lexeme *current = (lexeme *)cc->tkit->cur->value;
+    cc->lineno = current->line;
+}
+
+aoStr *cctrlCreateErrorLine(Cctrl *cc,
+                            ssize_t lineno, 
+                            char *msg)
+{
+    aoStr *buf = aoStrNew();
+
+    if (cc->lexer_) {
+        lexFile *file = cc->lexer_->cur_file;
+        aoStrCatPrintf(buf, "%s:%d ",
+                file->filename->data,
+                lineno);
+    } else {
+        aoStrCatPrintf(buf, "Parsing macro:%d ", lineno);
+    }
+
+    aoStrCatLen(buf,str_lit(ESC_BOLD_RED));
+    aoStrCatLen(buf,str_lit("error: "));
+    aoStrCatLen(buf,str_lit(ESC_RESET));
+    aoStrCatPrintf(buf,"%s",msg);
+    if (buf->data[buf->len - 1] != '\n') {
+        aoStrPutChar(buf,'\n');
+    }
+
+    if (cc->lexer_) {
+        const char *line_buffer = lexerReportLine(cc->lexer_,lineno);
+        aoStrCatPrintf(buf, "%4ld |    %s\n", lineno, line_buffer);
+    }
+    aoStrCatLen(buf, str_lit("     |\n"));
+    return buf;
+}
+
+void cctrlRaiseException(Cctrl *cc, char *fmt, ...) {
+    va_list ap;
+    va_start(ap,fmt);
+    char *msg = mprintVa(fmt, ap);
+    va_end(ap);
+
+    aoStr *bold_msg = aoStrNew();
+    aoStrCatPrintf(bold_msg, ESC_BOLD"%s"ESC_CLEAR_BOLD, msg);
+    aoStr *buf = cctrlCreateErrorLine(cc,cc->lineno,bold_msg->data);
+
+    fprintf(stderr,"%s",buf->data);
+    aoStrRelease(buf);
+    aoStrRelease(bold_msg);
+    free(msg);
+    exit(EXIT_FAILURE);
+}
+
+void cctrlIce(Cctrl *cc, char *fmt, ...) {
+    va_list ap;
+    va_start(ap,fmt);
+    char *msg = mprintVa(fmt, ap);
+    va_end(ap);
+    char *ice_msg = mprintf(ESC_BOLD_RED"INTERNAL COMPILER ERROR"ESC_RESET" - hcc %s\n",
+            cctrlGetVersion());
+    aoStr *error_line = cctrlCreateErrorLine(cc,cc->lineno,msg);
+    fprintf(stderr,"%s%s",ice_msg,error_line->data);
+    aoStrRelease(error_line);
+    free(ice_msg);
+    free(msg);
+    exit(EXIT_FAILURE);
 }
 
 /* assert the token we are currently pointing at is a TK_PUNCT and the 'i64'
@@ -244,19 +468,12 @@ void cctrlTokenExpect(Cctrl *cc, long expected) {
             //lexemePrintList(cc->tkit->tokens->next);
             loggerPanic("line %ld: Ran out of tokens\n",cc->lineno);
         } else {
-            loggerPanic("line %d: Syntax error in on line expected '%c' got: %.*s\n",
-                    tok->line, (char)expected,
-                    tok->len, tok->start);
+            cctrlRaiseException(cc,"Syntax error expected '%c' got: '%.*s'",
+                    (char)expected, tok->len, tok->start);
         }
     }
 }
 
-/* Go back one */
-void cctrlTokenRewind(Cctrl *cc) {
-    cc->tkit->cur = cc->tkit->cur->prev;
-    lexeme *current = (lexeme *)cc->tkit->cur->value;
-    cc->lineno = current->line;
-}
 
 /* Get variable either from the local or global scope */
 Ast *cctrlGetVar(Cctrl *cc, char *varname, int len) {

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -1,12 +1,16 @@
 #ifndef CCTRL_H
 #define CCTRL_H
 
+#include <sys/types.h>
+
 #include "aostr.h"
 #include "ast.h"
 #include "map.h"
 #include "lexer.h"
 
 #define HCC_VERSION "beta-v0.0.6"
+#define CCTRL_TOKEN_BUFFER_SIZE 16
+#define CCTRL_TOKEN_BUFFER_MASK CCTRL_TOKEN_BUFFER_SIZE-1
 
 static const char *cctrlGetVersion(void) {
     return HCC_VERSION;
@@ -17,7 +21,24 @@ typedef struct TokenIter {
     List *tokens;
     /* Current position in the list */
     List *cur;
+    ssize_t count;
 } TokenIter;
+
+typedef struct TokenRingBuffer {
+    ssize_t tail;
+    ssize_t head;
+    ssize_t size;
+    lexeme **entries;
+} TokenRingBuffer;
+
+TokenRingBuffer *tokenRingBufferNew(void);
+
+void tokenBufferPrint(TokenRingBuffer *ring_buffer);
+int tokenRingBufferEmpty(TokenRingBuffer *ring_buffer);
+void tokenRingBufferPush(TokenRingBuffer *ring_buffer, lexeme *token);
+lexeme *tokenRingBufferPop(TokenRingBuffer *ring_buffer);
+lexeme *tokenRingBufferPeek(TokenRingBuffer *ring_buffer);
+int tokenRingBufferRewind(TokenRingBuffer *ring_buffer);
 
 typedef struct Cctrl {
     /* The global environment for user defined types, functions and global
@@ -95,13 +116,15 @@ typedef struct Cctrl {
     TokenIter *tkit;
 
     /* current line number */
-    long lineno;
+    ssize_t lineno;
 
     long stack_local_space;
 
     /* Is the current type or function static,
      * with functions this has no real difference */
     int is_static;
+    TokenRingBuffer *token_buffer;
+    lexer *lexer_;
 } Cctrl;
 
 /* Instantiate a new compiler control struct */
@@ -111,12 +134,17 @@ Cctrl *ccMacroProcessor(StrMap *macro_defs);
 void cctrlInitTokenIter(Cctrl *cc, List *tokens);
 lexeme *cctrlTokenGet(Cctrl *cc);
 lexeme *cctrlTokenPeek(Cctrl *cc);
+void cctrlInitMacroProcessor(Cctrl *cc);
 void cctrlTokenRewind(Cctrl *cc);
 void cctrlTokenExpect(Cctrl *cc, long expected);
 void cctrlSetCommandLineDefines(Cctrl *cc, List *defines_list);
 
+void cctrlInitParse(Cctrl *cc, lexer *lexer_);
+
 Ast *cctrlGetVar(Cctrl *cc, char *varname, int len);
 int cctrlIsKeyword(Cctrl *cc, char *name, int len);
 AstType *cctrlGetKeyWord(Cctrl *cc, char *name, int len);
+[[noreturn]] void cctrlRaiseException(Cctrl *cc, char *fmt, ...);
+[[noreturn]] void cctrlIce(Cctrl *cc, char *fmt, ...);
 
 #endif // !CCTRL_H

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -16,14 +16,6 @@ static const char *cctrlGetVersion(void) {
     return HCC_VERSION;
 }
 
-typedef struct TokenIter {
-    /* All of the tokens */
-    List *tokens;
-    /* Current position in the list */
-    List *cur;
-    ssize_t count;
-} TokenIter;
-
 typedef struct TokenRingBuffer {
     ssize_t tail;
     ssize_t head;
@@ -112,9 +104,6 @@ typedef struct Cctrl {
     /* Temporary name of the function being parsed */
     aoStr *tmp_fname;
 
-    /* A list of tokens that have been through the lexer */
-    TokenIter *tkit;
-
     /* current line number */
     ssize_t lineno;
 
@@ -131,7 +120,6 @@ typedef struct Cctrl {
 Cctrl *cctrlNew(void);
 /* Slimmed down Cctrl, for expanding macros */
 Cctrl *ccMacroProcessor(StrMap *macro_defs);
-void cctrlInitTokenIter(Cctrl *cc, List *tokens);
 lexeme *cctrlTokenGet(Cctrl *cc);
 lexeme *cctrlTokenPeek(Cctrl *cc);
 void cctrlInitMacroProcessor(Cctrl *cc);

--- a/src/compile.c
+++ b/src/compile.c
@@ -5,23 +5,12 @@
 #include "aostr.h"
 #include "ast.h"
 #include "cctrl.h"
-#include "cfg-print.h"
-#include "cfg.h"
 #include "compile.h"
 #include "x86.h"
 #include "lexer.h"
 #include "list.h"
 #include "parser.h"
 #include "util.h"
-
-void compilePrintTokens(Cctrl *cc) {
-    if (!cc->tkit->tokens || 
-            cc->tkit->tokens == cc->tkit->tokens->next) {
-        loggerWarning("No tokens to print\n");
-        return;
-    }
-    lexemePrintList(cc->tkit->tokens);
-}
 
 void compilePrintAst(Cctrl *cc) {
     List *it;
@@ -69,78 +58,66 @@ aoStr *compileToAsm(Cctrl *cc) {
     return asmbuf;
 }
 
-List *compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags) {
-    List *tokens;
-    lexer l;
+void compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags) {
+    lexer *l = malloc(sizeof(lexer));
     aoStr *builtin_path;
     StrMap *seen_files;
 
     seen_files = strMapNew(32);
-    tokens = listNew();
+    
     builtin_path = aoStrDupRaw("/usr/local/include/tos.HH",25); //aoStrNew();
 
-    lexInit(&l,NULL,CCF_PRE_PROC);
-    l.seen_files = seen_files;
-    l.lineno = 1;
-    lexSetBuiltinRoot(&l,"/usr/local/include/");
+    lexInit(l,NULL,CCF_PRE_PROC);
+    l->seen_files = seen_files;
+    l->lineno = 1;
+    lexSetBuiltinRoot(l,"/usr/local/include/");
 
     /* library files */
-    lexPushFile(&l,aoStrDupRaw(entrypath,strlen(entrypath)));
+    lexPushFile(l,aoStrDupRaw(entrypath,strlen(entrypath)));
     /* the structure is a stack so this will get popped first */
-    lexPushFile(&l,builtin_path);
+    lexPushFile(l,builtin_path);
 
-    tokens = lexToLexemes(cc->macro_defs,&l);
-    lexemePrintList(tokens);
+    lexeme *token = NULL;
+
+    while ((token = lexToken(cc->macro_defs,l))) {
+        lexemePrint(token);
+        //free(token);
+    }
+
     strMapRelease(seen_files);
-    return tokens;
+    free(l);
 }
 
 int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
-    List *tokens;
-    lexer l;
+    lexer *l = malloc(sizeof(lexer));
     aoStr *builtin_path;
     StrMap *seen_files;
 
     seen_files = strMapNew(32);
-    tokens = listNew();
     builtin_path = aoStrDupRaw("/usr/local/include/tos.HH",25); //aoStrNew();
 
-    lexInit(&l,NULL,CCF_PRE_PROC);
-    l.seen_files = seen_files;
-    l.lineno = 1;
-    lexSetBuiltinRoot(&l,"/usr/local/include/");
+    lexInit(l,NULL,CCF_PRE_PROC);
+    l->seen_files = seen_files;
+    l->lineno = 1;
+    lexSetBuiltinRoot(l,"/usr/local/include/");
 
     /* library files */
-    lexPushFile(&l,aoStrDupRaw(entrypath,strlen(entrypath)));
+    lexPushFile(l,aoStrDupRaw(entrypath,strlen(entrypath)));
     /* the structure is a stack so this will get popped first */
-    lexPushFile(&l,builtin_path);
+    lexPushFile(l,builtin_path);
 
-    tokens = lexToLexemes(cc->macro_defs,&l);
+    cctrlInitParse(cc,l);
 
-    strMapRelease(seen_files);
-    cctrlInitTokenIter(cc,tokens);
     parseToAst(cc);
 
-    lexReleaseAllFiles(&l);
+    strMapRelease(seen_files);
+    lexReleaseAllFiles(l);
     aoStrRelease(builtin_path);
-    listRelease(l.files,NULL);
+    listRelease(l->files,NULL);
+    free(l);
 
     /* @Leak - Jamesbarford 2024/07/19, when should this be freed if at all? */
     // listRelease(code_list,free);
     // lexemelistRelease(tokens);
     return 1;
-}
-
-aoStr *compileCode(Cctrl *cc, char *code, int lexer_flags) {
-    aoStr *asm_str;
-    List *tokens;
-    lexer l;
-    lexInit(&l,code,lexer_flags);
-    tokens = lexToLexemes(cc->macro_defs,&l);
-    cctrlInitTokenIter(cc,tokens);
-    parseToAst(cc);
-    asm_str = compileToAsm(cc);
-    lexemelistRelease(tokens);
-    free(l.files);
-    return asm_str;
 }

--- a/src/compile.c
+++ b/src/compile.c
@@ -109,6 +109,8 @@ int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     cctrlInitParse(cc,l);
 
     parseToAst(cc);
+    
+    lexerPoolRelease();
 
     strMapRelease(seen_files);
     lexReleaseAllFiles(l);

--- a/src/compile.c
+++ b/src/compile.c
@@ -117,9 +117,5 @@ int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags) {
     aoStrRelease(builtin_path);
     listRelease(l->files,NULL);
     free(l);
-
-    /* @Leak - Jamesbarford 2024/07/19, when should this be freed if at all? */
-    // listRelease(code_list,free);
-    // lexemelistRelease(tokens);
     return 1;
 }

--- a/src/compile.h
+++ b/src/compile.h
@@ -7,10 +7,9 @@
 int compileToToAst(Cctrl *cc, char *file_path, int lexer_flags);
 aoStr *compileToAsm(Cctrl *cc);
 void compileAssembleToFile(aoStr *asmbuf, char *filename);
-void compilePrintTokens(Cctrl *cc);
 void compilePrintAst(Cctrl *cc);
 
 int compileToAst(Cctrl *cc, char *entrypath, int lexer_flags);
-List *compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags);
+void compileToTokens(Cctrl *cc, char *entrypath, int lexer_flags);
 
 #endif // !COMPILE_H

--- a/src/holyc-lib/defs.HH
+++ b/src/holyc-lib/defs.HH
@@ -26,3 +26,4 @@
 #define U8_MAX  0xFF
 #define I8_MAX  0x7F
 #define I8_MIN  0xFFFFFF80
+

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1677,7 +1677,7 @@ void lexemeFree(void *_le) {
 
 static void lexReleaseLexFile(lexFile *lex_file) {
     aoStrRelease(lex_file->filename);
-    free(lex_file->ptr);
+    aoStrRelease(lex_file->src);
     free(lex_file);
 }
 

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -66,6 +66,19 @@ static LexerTypes lexer_types[] = {
     {"defined", KW_DEFINED},
     {"undef", KW_UNDEF},
 
+    {"#if", KW_PP_IF},
+    {"#else", KW_PP_ELSE},
+    {"#define", KW_PP_DEFINE},
+    {"#ifndef", KW_PP_IF_NDEF},
+    {"#ifdef", KW_PP_IF_DEF},
+    {"#elifdef", KW_PP_ELIF_DEF},
+    {"#endif", KW_PP_ENDIF},
+    {"#elif", KW_PP_ELIF},
+    {"#defined", KW_PP_DEFINED},
+    {"#undef", KW_PP_UNDEF},
+    {"#error", KW_PP_ERROR},
+    {"#include", KW_PP_INCLUDE},
+
     {"cast", KW_CAST},
     {"sizeof", KW_SIZEOF},
     {"return", KW_RETURN},
@@ -78,7 +91,6 @@ static LexerTypes lexer_types[] = {
     {"class", KW_CLASS},
     {"union", KW_UNION},
 
-    {"include", KW_INCLUDE},
     {"static", KW_STATIC},
 };
 
@@ -157,6 +169,8 @@ void lexInit(lexer *l, char *source, int flags) {
     l->all_source = listNew();
     l->symbol_table = strMapNew(32);
     l->symbol_table->_free_key = NULL;
+    l->collecting = 1;
+    l->skip_else = 1;
     if (macro_proccessor == NULL) {
         macro_proccessor = ccMacroProcessor(NULL);
     }
@@ -367,7 +381,7 @@ char *lexemeToString(lexeme *tok) {
                 case KW_PUBLIC:      aoStrCatPrintf(str,"public");  break;
                 case KW_ATOMIC:      aoStrCatPrintf(str,"atomic");  break;
                 case KW_DEFINE:      aoStrCatPrintf(str,"define");  break;
-                case KW_INCLUDE:     aoStrCatPrintf(str,"include"); break;
+                case KW_PP_INCLUDE:     aoStrCatPrintf(str,"include"); break;
                 case KW_CAST:        aoStrCatPrintf(str,"cast"); break;
                 case KW_SIZEOF:      aoStrCatPrintf(str,"sizeof");  break;
                 case KW_RETURN:      aoStrCatPrintf(str,"return");  break;
@@ -397,6 +411,19 @@ char *lexemeToString(lexeme *tok) {
                 case KW_DO:          aoStrCatPrintf(str,"do");      break;
                 case KW_STATIC:      aoStrCatPrintf(str,"static");  break;
                 case KW_DEFINED:     aoStrCatPrintf(str,"defined"); break;
+
+                case KW_PP_IF: aoStrCatPrintf(str,"#if"); break;   
+                case KW_PP_ELSE: aoStrCatPrintf(str,"#else"); break;   
+                case KW_PP_DEFINE: aoStrCatPrintf(str,"#define"); break;  
+                case KW_PP_IF_NDEF: aoStrCatPrintf(str,"#ifndef"); break; 
+                case KW_PP_IF_DEF: aoStrCatPrintf(str,"#ifdef"); break;
+                case KW_PP_ELIF_DEF:aoStrCatPrintf(str,"#elifdef"); break;
+                case KW_PP_ENDIF: aoStrCatPrintf(str,"#endif"); break;   
+                case KW_PP_ELIF: aoStrCatPrintf(str,"#elif"); break;    
+                case KW_PP_DEFINED: aoStrCatPrintf(str,"#defined"); break; 
+                case KW_PP_UNDEF:  aoStrCatPrintf(str,"#undef"); break;  
+                case KW_PP_ERROR: aoStrCatPrintf(str,"#error"); break;   
+
                 default:
                     loggerPanic("line %d: Keyword %.*s: is not defined\n",
                             tok->line,tok->len,tok->start);
@@ -404,8 +431,8 @@ char *lexemeToString(lexeme *tok) {
             return aoStrMove(str);
         }
     }
-    loggerPanic("line %d: Unexpected type %s\n",
-            tok->line,lexemeTypeToString(tok->tk_type));
+    loggerPanic("line %d: Unexpected type %s |%.*s|\n",
+            tok->line,lexemeTypeToString(tok->tk_type),tok->len,tok->start);
 }
 
 /* Print one lexeme */
@@ -459,7 +486,7 @@ static char lexPeek(lexer *l) {
 }
 
 /* Read an entire file to a mallocated buffer */
-char *lexReadfile(char *path) {
+char *lexReadfile(char *path, ssize_t *_len) {
     char *buf;
     int fd,rbytes,len,size;
 
@@ -481,6 +508,7 @@ char *lexReadfile(char *path) {
         loggerPanic("Failed to read whole file\n");
     }
 
+    *_len = len;
     buf[len-1] = '\0';
     close(fd);
     return buf;
@@ -490,8 +518,15 @@ void lexPushFile(lexer *l, aoStr *filename) {
     /* We need to save what we are currently lexing and 
      * make the file we've just seen the file we want to lex */
     lexFile *f = malloc(sizeof(lexFile));
-    char *src = lexReadfile(filename->data);
-    f->ptr = src;
+    ssize_t file_len = 0;
+    char *src = lexReadfile(filename->data, &file_len);
+    aoStr *src_code = malloc(sizeof(aoStr));
+    src_code->data = src;
+    src_code->len = file_len;
+    src_code->capacity = 0;
+
+    f->ptr = src_code->data;
+    f->src = src_code;
     f->lineno = 1;
     f->filename = filename;
     strMapAdd(l->seen_files,filename->data,filename);
@@ -854,6 +889,18 @@ int lexNumeric(lexer *l, int _isfloat) {
     }
 }
 
+LexerTypes *lexPreProcDirective(lexer *l) {
+    lexeme le;
+    if (!lex(l,&le)) return 0;
+    char buffer[32];
+    ssize_t len = snprintf(buffer,sizeof(buffer),"#%.*s",le.len,le.start);
+    LexerTypes *type = strMapGetLen(l->symbol_table,buffer,len);
+    if (!type) {
+        loggerPanic("line %d: invalid preprocessor directive '%s'\n", le.line, buffer);
+    }
+    return type;
+}
+
 int lex(lexer *l, lexeme *le) {
     char ch, *start;
     int tk_type;
@@ -906,6 +953,8 @@ int lex(lexer *l, lexeme *le) {
             le->len = l->ptr - start;
             le->tk_type = tk_type;
             le->line = l->lineno;
+            le->start = start;
+            le->len = 0;
             if (tk_type == TK_F64) {
                 le->f64 = l->cur_f64;
             } else {
@@ -1130,7 +1179,13 @@ int lex(lexer *l, lexeme *le) {
             lexemeAssignOp(le,start,1,'\\',l->lineno);
             return 1;
 
-        case '#':
+        case '#': {
+            type = lexPreProcDirective(l);
+            le->tk_type = TK_KEYWORD;
+            le->i64 = type->kind;
+            return 1;
+        }
+
         case '~':
         case '(':
         case ')':
@@ -1186,7 +1241,6 @@ void lexInclude(lexer *l) {
 
     if (!lexHasFile(l,include_path)) {
         lexPushFile(l,include_path);
-        //List(l->files, include_path);
     } else {
         aoStrRelease(include_path);
     }
@@ -1194,18 +1248,19 @@ void lexInclude(lexer *l) {
 
 lexeme *lexDefine(StrMap *macro_defs, lexer *l) {
     int tk_type,iters;
-    List *macro_tokens;
+ //   List *macro_tokens;
     lexeme next,*start,*end,*expanded,*macro;
     aoStr *ident;
+    PtrVec *tokens = ptrVecNew();
 
 
     tk_type = -1;
-    macro_tokens = listNew();
     /* <ident> <value> */
     lex(l, &next);
     if (next.tk_type != TK_IDENT) {
         loggerPanic("line %d: Syntax is: #define <TK_IDENT> <value>\n",next.line);
     }
+
     ident = aoStrDupRaw(next.start, next.len);
     /* A define must be on one line a \n determines the end of a define */
     l->flags |= CCF_ACCEPT_NEWLINES;
@@ -1216,7 +1271,7 @@ lexeme *lexDefine(StrMap *macro_defs, lexer *l) {
 
         if (next.tk_type == TK_IDENT) {
             if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
-                listAppend(macro_tokens,lexemeCopy(macro));
+                ptrVecPush(tokens, lexemeCopy(macro));
                 tk_type = macro->tk_type;
                 continue;
             }
@@ -1233,18 +1288,18 @@ lexeme *lexDefine(StrMap *macro_defs, lexer *l) {
             }
         }
         if (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')) {
-            listAppend(macro_tokens,lexemeCopy(&next));
+            ptrVecPush(tokens, lexemeCopy(&next));
         }
     } while (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0'));
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
-    start = macro_tokens->next->value;
-    end = macro_tokens->prev->value;
+    start = tokens->entries[0]; 
+    end = tokens->entries[tokens->size - 1];
 
-    if (start==end && iters == 1) {
+    if (start == end && iters == 1) {
         strMapAdd(macro_defs,ident->data,lexemeSentinal());
-        listRelease(macro_tokens,NULL);
+        ptrVecRelease(tokens);
         return NULL;
     }
 
@@ -1253,38 +1308,54 @@ lexeme *lexDefine(StrMap *macro_defs, lexer *l) {
                 next.line,ident->data);
     }
 
-    start = macro_tokens->next->value;
-    end = macro_tokens->prev->value;
-
     if (start == end) {
         expanded = lexemeCopy(start);
         strMapAdd(macro_defs,ident->data,expanded);
     } else {
-        cctrlInitTokenIter(macro_proccessor,macro_tokens);
+        /* XXX: this is a hack as sometimes the number of tokens in a macro 
+         * will exceed what is allowed in our ring buffer. Conveniently PtrVec 
+         * has some fields we can use. */
+        cctrlInitMacroProcessor(macro_proccessor);
+        macro_proccessor->token_buffer->entries = (lexeme **)tokens->entries;
+        macro_proccessor->token_buffer->size = tokens->size;
+
         Ast *ast = parseExpr(macro_proccessor,16);
         expanded = lexemeNew(start->start,end->len-start->len);
         expanded->tk_type = tk_type;
         if (tk_type == TK_STR) {
-            if (ast->kind != TK_STR && ast->kind != AST_STRING) {
+            if (!ast && start->tk_type == TK_STR) {
+                expanded->start = strndup(start->start,start->len);
+                expanded->len = start->len;
+            } else if (ast && ast->kind != TK_STR && ast->kind != AST_STRING) {
                 loggerPanic("line %d: #define %s expected string but got: %s\n",
                         next.line,ident->data,astKindToString(ast->kind));
-            }
-            if (ast->kind == AST_STRING) {
+            } else if (ast && ast->kind == AST_STRING) {
                 /* Copy as we will free the AST which will free the string*/
                 expanded->start = strndup(ast->sval->data,ast->sval->len);
                 expanded->len = ast->sval->len;
+            } else {
+                loggerPanic("line: %d failed to parse #define %s\n",
+                        next.line, ident->data);
             }
         } else if (tk_type == TK_F64) {
             expanded->f64 = (long double)evalFloatExpr(ast);
             expanded->line = start->line;
         } else if (tk_type == TK_I64 || tk_type == TK_CHAR_CONST) {
-            expanded->i64 = evalIntConstExpr(ast);
+            if (ast) {
+                expanded->i64 = evalIntConstExpr(ast);
+            } else {
+                printf("Failed to expand: %s\n",ident->data);
+                expanded->i64 = -1;
+            }
             expanded->line = start->line;
         }
         strMapAdd(macro_defs,ident->data,expanded);
         astRelease(ast);
     }
-    lexemelistRelease(macro_tokens);
+    for (ssize_t i = 0; i < tokens->size; ++i) {
+        lexemeFree(tokens->entries[i]);
+    }
+    ptrVecRelease(tokens);
     return expanded;
 }
 
@@ -1315,25 +1386,25 @@ void lexExpandAndCollect(lexer *l, StrMap *macro_defs, List *tokens, int should_
             lex(l,&next);
             if (next.tk_type == TK_KEYWORD) {
                 switch (next.i64) {
-                    case KW_INCLUDE: {
+                    case KW_PP_INCLUDE: {
                         if (should_collect) {
                             lexInclude(l);
                         }
                         break;
                     }
-                    case KW_DEFINE: {
+                    case KW_PP_DEFINE: {
                         if (should_collect) {
                             lexDefine(macro_defs,l);
                         }
                         break;
                     }
-                    case KW_UNDEF: {
+                    case KW_PP_UNDEF: {
                         if (should_collect) {
                             lexUndef(macro_defs, l);
                         }
                         break;
                     }
-                    case KW_ELIF_DEF: {
+                    case KW_PP_ELIF_DEF: {
                         lex(l,&next);
                         should_collect = 0;
                         if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
@@ -1341,15 +1412,15 @@ void lexExpandAndCollect(lexer *l, StrMap *macro_defs, List *tokens, int should_
                         }
                         break;
                     }
-                    case KW_ELIF: {
+                    case KW_PP_ELIF: {
                         should_collect = lexPreProcIf(macro_defs,l);
                         break;
                     }
-                    case KW_IF: {
+                    case KW_PP_IF: {
                         should_collect = lexPreProcIf(macro_defs,l);
                         break;
                     }
-                    case KW_IF_DEF: {
+                    case KW_PP_IF_DEF: {
                         lex(l,&next);
                         should_collect = 0;
                         if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
@@ -1358,7 +1429,7 @@ void lexExpandAndCollect(lexer *l, StrMap *macro_defs, List *tokens, int should_
                         endif_count++;
                         break;
                     }
-                    case KW_IF_NDEF: {
+                    case KW_PP_IF_NDEF: {
                         lex(l,&next);
                         should_collect = 0;
                         if ((macro = strMapGetLen(macro_defs,next.start,next.len)) == NULL) {
@@ -1367,14 +1438,14 @@ void lexExpandAndCollect(lexer *l, StrMap *macro_defs, List *tokens, int should_
                         endif_count++;
                         break;
                     }
-                    case KW_ENDIF:
+                    case KW_PP_ENDIF:
                         endif_count--;
                         if (endif_count == 0) {
                             goto done;
                         }
                         break;
 
-                    case KW_ELSE: {
+                    case KW_PP_ELSE: {
                         if (should_collect) should_collect = 0;
                         else should_collect = 1;
                         break;
@@ -1397,12 +1468,12 @@ done:
 
 int lexPreProcIf(StrMap *macro_defs, lexer *l) {
     int tk_type,iters,should_collect;
-    List *macro_tokens;
+    PtrVec *macro_tokens;
     lexeme next,*start,*end,*expanded,*macro;
 
     tk_type = -1;
     should_collect = 0;
-    macro_tokens = listNew();
+    macro_tokens = ptrVecNew();
 
     /* An if must be on one line a \n determines the end of a define */
     l->flags |= CCF_ACCEPT_NEWLINES;
@@ -1426,7 +1497,7 @@ int lexPreProcIf(StrMap *macro_defs, lexer *l) {
 
         if (next.tk_type == TK_IDENT) {
             if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
-                listAppend(macro_tokens,lexemeCopy(macro));
+                ptrVecPush(macro_tokens,lexemeCopy(macro));
                 tk_type = macro->tk_type;
             }
             if (!lex(l,&next)) break;
@@ -1442,25 +1513,24 @@ int lexPreProcIf(StrMap *macro_defs, lexer *l) {
             }
         }
         if (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')) {
-            listAppend(macro_tokens,lexemeCopy(&next));
+            ptrVecPush(macro_tokens,lexemeCopy(&next));
         }
         if (!lex(l,&next)) break;
     }
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
-    start = macro_tokens->next->value;
-    end = macro_tokens->prev->value;
+    start = macro_tokens->entries[0];
+    end = macro_tokens->entries[macro_tokens->size-1];
 
     if (start == end && iters == 1) {
         loggerPanic("line %d: a #if must evaluate some expression\n",next.line);
         return 0;
     }
+    cctrlInitMacroProcessor(macro_proccessor);
+    macro_proccessor->token_buffer->entries = (lexeme **)macro_tokens->entries;
+    macro_proccessor->token_buffer->size = macro_tokens->size;
 
-    start = macro_tokens->next->value;
-    end = macro_tokens->prev->value;
-
-    cctrlInitTokenIter(macro_proccessor,macro_tokens);
     Ast *ast = parseExpr(macro_proccessor,16);
     expanded = lexemeNew(start->start,end->len-start->len);
     expanded->tk_type = tk_type;
@@ -1481,113 +1551,208 @@ int lexPreProcIf(StrMap *macro_defs, lexer *l) {
         expanded->line = start->line;
     }
     astRelease(ast);
-    lexemelistRelease(macro_tokens);
+    for (ssize_t i = 0; i < macro_tokens->size; ++i) {
+        lexemeFree(macro_tokens->entries[i]);
+    }
+    ptrVecRelease(macro_tokens);
+
     return should_collect;
 }
 
-List *lexUntil(StrMap *macro_defs, lexer *l, char to) {
-    List *tokens; 
+/* Decide if we should collect tokens or not */
+int lexPreProcBoolean(lexer *l, StrMap *macro_defs, lexeme *le, int can_collect) {
+    lexeme next,*macro;
 
-    int ok;
+    switch (le->i64) {
+        case KW_PP_IF: {
+            int ok = lexPreProcIf(macro_defs,l);
+            if (ok) {
+                l->collecting = 1;
+                l->skip_else = 1;
+            } else {
+                l->collecting = 0;
+                l->skip_else = 0;
+            }
+            return ok;
+        }
+
+        case KW_PP_IF_DEF: {
+            lex(l,&next);
+            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
+                l->collecting = 1;
+                l->skip_else = 1;
+                return 1;
+            } 
+
+            l->collecting = 0;
+            l->skip_else = 0;
+            return 0;
+        }
+
+        case KW_PP_IF_NDEF: {
+            lex(l,&next);
+            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) == NULL) {
+                l->collecting = 0;
+                l->skip_else = 1;
+                return 1;
+            }
+            l->collecting = 1;
+            l->skip_else = 0;
+            return 0;
+        }
+
+        case KW_PP_ELIF: {
+            if (l->skip_else) return 0;
+           // if (!can_collect) {
+            int ok = lexPreProcIf(macro_defs,l);
+            if (ok) {
+             //   l->collecting = 1;
+                l->skip_else = 1;
+            } else {
+               // l->collecting = 0;
+                l->skip_else = 0;
+            }
+            return ok;
+           // }
+           // return 0;
+        }
+
+        case KW_PP_ELIF_DEF: {
+            if (l->skip_else) return 0;
+           // if (!can_collect) {
+                lex(l,&next);
+                if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
+                    l->collecting = 1;
+                    l->skip_else = 1;
+                    return 1;
+                }
+                l->collecting = 0;
+                l->skip_else = 0;
+           // }
+            return 0;
+        }
+
+
+        case KW_PP_ELSE: {
+            if (l->skip_else) return 0;
+            l->collecting = 1;
+            //if (!can_collect) {
+            //    return 1;
+           // }
+            return 1;
+        }
+
+        case KW_PP_ENDIF:
+            l->skip_else = 0;
+            l->collecting = 1;
+            return 1;
+
+        default:
+            return 0;
+    }
+}
+
+lexeme *lexToken(StrMap *macro_defs, lexer *l) {
     lexeme le,next,*copy,*macro;
-    char prevous_to;
 
-    prevous_to = to;
-    tokens = listNew();
     macro_proccessor->macro_defs = macro_defs;
 
     while (1) {
-        ok = lex(l,&le);
-        if (!ok) {
-            break;
+        if (!lex(l,&le)) {
+            return NULL;
         }
 
-        if (l->flags & (CCF_ASM_BLOCK) && tokenPunctIs(&le, to)) {
+        if (l->flags & (CCF_ASM_BLOCK) && tokenPunctIs(&le, '}')) {
             copy = lexemeCopy(&le);
-            listAppend(tokens, copy);
             /* turn off assembly lexing */
             l->flags &= ~(CCF_MULTI_COLON|CCF_ACCEPT_NEWLINES|CCF_ASM_BLOCK);
-            to = prevous_to;
-            continue;
+            return copy;
         }
 
         if (le.tk_type == TK_KEYWORD) {
             switch (le.i64) {
                 case KW_ASM:
-                    lex(l,&next);
-                    if (!tokenPunctIs(&next,'{')) {
-                        loggerPanic("line %d: asm '{' expected Got: %s\n",
-                                next.line, lexemeToString(&next));
-                    }
-                    copy = lexemeCopy(&le);
-                    listAppend(tokens, copy);
-                    copy = lexemeCopy(&next);
-                    listAppend(tokens, copy);
-
                     l->flags |= (CCF_MULTI_COLON|CCF_ACCEPT_NEWLINES|CCF_ASM_BLOCK);
+                    copy = lexemeCopy(&le);
+                    return copy;
 
-                    to = '}';
+                case KW_PP_INCLUDE: {
+                    lexInclude(l);
                     continue;
+                }
+                case KW_PP_DEFINE: {
+                    copy = lexDefine(macro_defs,l);
+                    continue;
+                }
+                case KW_PP_UNDEF: {
+                    lexUndef(macro_defs, l);
+                    continue;
+                }
+
+                case KW_PP_ELIF_DEF:
+                case KW_PP_ELIF:
+                case KW_PP_ELSE: {
+                    if (l->skip_else) {
+                        while (lex(l,&le)) {
+                            if (le.tk_type == TK_KEYWORD && le.i64 == KW_PP_ENDIF) {
+                                break;
+                            }
+                        }
+                        l->skip_else = 0;
+                    } else {
+                        int should_collect = 0;
+                        int line = le.line;
+                        while ((should_collect = lexPreProcBoolean(l,macro_defs,&le, should_collect)) != 1) {
+                            int ok = lex(l,&le);
+                            if (!ok) {
+                                loggerPanic("line %d: Unterminated #if\n", line);
+                            }
+                        }
+                    }
+                    continue;
+                }
+
+                case KW_PP_IF_DEF:
+                case KW_PP_IF_NDEF:
+                case KW_PP_IF: {
+                    int should_collect = 0;
+                    int line = le.line;
+                    while ((should_collect = lexPreProcBoolean(l,macro_defs,&le,should_collect)) != 1) {
+                        int ok = lex(l,&le);
+                        if (!ok) {
+                            loggerPanic("line %d: Unterminated #if\n", line);
+                        }
+                    }
+                    continue;
+                }
+                case KW_PP_ENDIF:
+                    l->skip_else = 0;
+                    continue;
+
+                case KW_PP_ERROR:
+                    lex(l,&next);
+                    loggerPanic("line %d: %.*s",next.line,next.len,next.start);
+                    break;
+
                 default:
                     copy = lexemeCopy(&le);
-                    listAppend(tokens, copy);
-                    continue;
+                    return copy;
             }
         }
         
         if (le.tk_type == TK_IDENT) {
             if ((macro = strMapGetLen(macro_defs,le.start,le.len)) != NULL) {
                 copy = lexemeCopy(macro);
-                listAppend(tokens, copy);
-                continue;
+                return copy;
             }
             copy = lexemeCopy(&le);
-            listAppend(tokens, copy);
-            continue;
+            return copy;
         }
 
-        if (l->flags & CCF_PRE_PROC && tokenPunctIs(&le, '#')) {
-            if (lex(l,&next) && next.tk_type == TK_KEYWORD) {
-                switch (next.i64) {
-                    case KW_INCLUDE: lexInclude(l); break;
-                    case KW_DEFINE: copy = lexDefine(macro_defs,l); break;
-                    case KW_UNDEF: lexUndef(macro_defs, l); break;
-                    case KW_IF: {
-                        int should_collect = lexPreProcIf(macro_defs,l);
-                        lexExpandAndCollect(l,macro_defs,tokens,should_collect);
-                        break;
-                    }
-                    case KW_IF_NDEF:
-                    case KW_IF_DEF:
-                        lex(l, &next);
-                        if (next.tk_type != TK_IDENT) {
-                            loggerPanic("line %d: Syntax is: #ifdef <TK_IDENT>\n",next.line);
-                        }
-                        macro = strMapGetLen(macro_defs,next.start,next.len);
-                        if ((next.i64 == KW_IF_DEF && macro) || (next.i64 == KW_IF_NDEF && !macro))  {
-                            lexExpandAndCollect(l,macro_defs,tokens,1);
-                        } else {
-                            lexExpandAndCollect(l,macro_defs,tokens,0);
-                        }
-                        break;
-                    default:
-                        loggerPanic("line %d: #%.*s invalid \n",next.line,
-                                next.len,next.start);
-                }
-            } else if (tokenIdentIs(&next,"error",5)) {
-                lex(l,&next);
-                loggerPanic("line %d: %.*s",next.line,next.len,next.start);
-            }
-        } else {
-            copy = lexemeCopy(&le);
-            listAppend(tokens, copy);
-        }
+        copy = lexemeCopy(&le);
+        return copy;
     }
-    return tokens;
-}
-
-List *lexToLexemes(StrMap *defs, lexer *l) {
-    return lexUntil(defs,l,'\0');
+    return NULL;
 }
 
 void lexemeFree(void *_le) {
@@ -1595,10 +1760,6 @@ void lexemeFree(void *_le) {
         lexeme *le = (lexeme *)_le;
         free(le);
     }
-}
-
-void lexemelistRelease(List *tokens) {
-    listRelease(tokens,lexemeFree);
 }
 
 static void lexReleaseLexFile(lexFile *lex_file) {
@@ -1612,8 +1773,25 @@ void lexReleaseAllFiles(lexer *l) {
             ((void (*))&lexReleaseLexFile));
 }
 
-void lexemePrintList(List *tokens) {
-    listForEach(tokens) {
-        lexemePrint(it->value);
+const char *lexerReportLine(lexer *l, ssize_t lineno) {
+    static char buffer[4096];
+    char *tmp_ptr = buffer;
+
+    char *ptr = l->cur_file->src->data;
+    ssize_t line = 1;
+
+    while (line != lineno && *ptr) {
+        if (*ptr == '\n') {
+            line++;
+        }
+        ptr++;
     }
+    if (!*ptr) {
+        memcpy((void*)buffer,str_lit("invalid line number"));
+    }
+    while (*ptr && *ptr != '\n') {
+        *tmp_ptr++ = *ptr++;
+    }
+    *tmp_ptr = '\0';
+    return buffer;
 }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -194,5 +194,6 @@ int tokenPunctIs(lexeme *tok, long ch);
 int tokenIdentIs(lexeme *tok, char *ident, int len);
 void lexemeFree(void *_le);
 const char *lexerReportLine(lexer *l, ssize_t lineno);
+void lexerPoolRelease(void);
 
 #endif // !LEXER_H

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,6 +1,8 @@
 #ifndef LEXER_H
 #define LEXER_H
 
+#include <sys/types.h>
+
 #include "aostr.h"
 #include "map.h"
 #include "list.h"
@@ -77,7 +79,7 @@
 #define KW_PUBLIC       6
 #define KW_ATOMIC       8
 #define KW_DEFINE       10
-#define KW_INCLUDE      12
+#define KW_PP_INCLUDE   12
 #define KW_CAST  14
 #define KW_SIZEOF       16
 #define KW_RETURN       18
@@ -107,6 +109,17 @@
 #define KW_DO           66
 #define KW_STATIC       67
 #define KW_ELIF_DEF     68
+#define KW_PP_IF        69
+#define KW_PP_ELSE      70
+#define KW_PP_DEFINE    71
+#define KW_PP_IF_NDEF   72
+#define KW_PP_IF_DEF    73
+#define KW_PP_ELIF_DEF  74
+#define KW_PP_ENDIF     75
+#define KW_PP_ELIF      76
+#define KW_PP_DEFINED   77
+#define KW_PP_UNDEF     78
+#define KW_PP_ERROR     79
 
 /* Compiler Flags*/
 #define CCF_ESCAPE_STRING_NEWLINES (1ULL << 40)
@@ -137,6 +150,7 @@ typedef struct lexFile {
     aoStr *filename; /* name of the file */
     char *ptr; /* Where we are in the file */
     int lineno; /* line number in the file */
+    aoStr *src; /* source */
 } lexFile;
 
 typedef struct lexer {
@@ -151,6 +165,8 @@ typedef struct lexer {
     int lineno;
     int flags;
     int ishex;
+    int collecting;
+    int skip_else;
     char *builtin_root;
     List *files;
     List *all_source;/* This saves all of the files we see so we can free them later */
@@ -166,18 +182,17 @@ void lexSetBuiltinRoot(lexer *l, char *root);
 void lexInit(lexer *l, char *source, int flag);
 void lexPushFile(lexer *l, aoStr *filename);
 int lex(lexer *l, lexeme *le);
-List *lexToLexemes(StrMap *macro_defs, lexer *l);
-List *lexUntil(StrMap *macro_defs, lexer *l, char to);
+lexeme *lexToken(StrMap *macro_defs, lexer *l);
 void lexemePrint(lexeme *le);
 char *lexemeTypeToString(int tk_type);
 char *lexemePunctToString(long op);
 char *lexemePunctToStringWithFlags(long op, unsigned long flags);
 char *lexemePunctToEncodedString(long op);
 char *lexemeToString(lexeme *tok);
-void lexemePrintList(List *tokens);
-void lexemelistRelease(List *tokens);
 void lexReleaseAllFiles(lexer *l);
 int tokenPunctIs(lexeme *tok, long ch);
 int tokenIdentIs(lexeme *tok, char *ident, int len);
+void lexemeFree(void *_le);
+const char *lexerReportLine(lexer *l, ssize_t lineno);
 
 #endif // !LEXER_H

--- a/src/map.c
+++ b/src/map.c
@@ -710,7 +710,6 @@ void *strMapGetLen(StrMap *map, char *key, long key_len) {
             StrMapNode *n = map->entries[idx];
             assert(n);
             return n->value;
-            //->value;
         }
     }
     return NULL;

--- a/src/map.h
+++ b/src/map.h
@@ -118,6 +118,7 @@ StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
 void *strMapGetLen(StrMap *map, char *key, long key_len);
 void *strMapGet(StrMap *map, char *key);
 int strMapAdd(StrMap *map, char *key, void *value);
+int strMapAddOrErr(StrMap *map, char *key, void *value);
 int strMapHas(StrMap *map, char *key);
 int strMapRemove(StrMap *map, char *key);
 void strMapRelease(StrMap *map);

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -24,8 +24,7 @@ void prsAsmMem(Cctrl *cc, aoStr *buf) {
     lexeme *tok;
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        loggerPanic("line %d: [<register>] expected got: %s\n",
-                tok->line,lexemeToString(tok));
+        cctrlRaiseException(cc,"[<register>] expected got: %s",lexemeToString(tok));
     }
     cctrlTokenExpect(cc,']');
     aoStrCatPrintf(buf,"(%%%.*s)",tok->len,tok->start);
@@ -33,15 +32,14 @@ void prsAsmMem(Cctrl *cc, aoStr *buf) {
 
 void prsAsmOffset(Cctrl *cc, aoStr *buf, lexeme *tok) {
     if (tok->tk_type != TK_I64) {
-        loggerPanic("line %d: Expected TK_I64 type got: %s\n",
-                tok->line,lexemeToString(tok));
+        cctrlRaiseException(cc,"Expected TK_I64 type got: %s",lexemeToString(tok));
     }
 
     cctrlTokenExpect(cc,'[');
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        loggerPanic("line %d: Expected <number>[<register>] Got: %s\n",
-                tok->line, lexemeToString(tok));
+        cctrlRaiseException(cc,"Expected <number>[<register>] Got: %s",
+                lexemeToString(tok));
     }
     cctrlTokenExpect(cc,']');
     aoStrCatPrintf(buf, "(%%%.*s)",tok->len,tok->start);
@@ -52,13 +50,13 @@ void prsAsmImm(Cctrl *cc, aoStr *buf, lexeme *tok) {
     switch (tok->tk_type) {
         case TK_PUNCT:
             if (tok->i64 != '-') {
-                loggerPanic("line %d: Expected '-'<numerical>\n", tok->line);
+                cctrlRaiseException(cc,"Expected '-'<numerical>");
             }
 
             tok = cctrlTokenGet(cc);
             if (tok->tk_type != TK_I64 && tok->tk_type != TK_F64) {
-                loggerPanic("line %d: Expected -<numerical> got: %s\n",
-                        tok->line, lexemeToString(tok));
+                cctrlRaiseException(cc,"Expected -<numerical> got: %s\n",
+                        lexemeToString(tok));
             }
             next = cctrlTokenPeek(cc);
             if (!tokenPunctIs(next,'[')) {
@@ -103,12 +101,12 @@ void prsAsmLabel(Cctrl *cc, aoStr *buf) {
 
     tok = cctrlTokenGet(cc);
     if (!tokenPunctIs(tok,'@')) {
-        loggerPanic("line %d: Labels must be: '@@<int>'\n", tok->line);
+        cctrlRaiseException(cc,": Labels must be: '@@<int>'");
     }
 
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_I64) {
-        loggerPanic("line %d: Labels must be: '@@<int>'\n", tok->line);
+        cctrlRaiseException(cc,": Labels must be: '@@<int>'");
     }
     
     label_num = tok->i64;
@@ -135,7 +133,7 @@ void prsAsmPunct(Cctrl *cc, lexeme *tok, aoStr *buf) {
             break;
         default:
             lexemePrint(tok);
-            loggerPanic("line %d: Unexpected character\n", tok->line);
+            cctrlRaiseException(cc,": Unexpected character");
     }
 
     next = cctrlTokenPeek(cc);
@@ -300,9 +298,9 @@ Ast *prsAsmToATT(Cctrl *cc) {
                                 aoStrRelease(op3);
                                 break;
                             default:
-                                loggerPanic("line %ld: Unexpected number of arguments for"
-                                        " x86 transpilation: %d"" Expression\n",
-                                        cc->lineno, count);
+                                cctrlRaiseException(cc,"Unexpected number of arguments for"
+                                        " x86 transpilation: %d"" Expression",
+                                        count);
                         }
                         isbol = 1;
                         count = 0;

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -74,14 +74,16 @@ void assertIsPointer(Ast *ast, long lineno) {
 
 /* Check if one of the characters matches and the flag wants that character to
  * terminate */
-void assertTokenIsTerminator(lexeme *tok, long terminator_flags) {
+void assertTokenIsTerminator(Cctrl *cc, lexeme *tok, long terminator_flags) {
     if (tok == NULL) {
-        loggerPanic("NULL token passed to assertTokenIsTerminator\n");
+        cctrlRaiseException(cc,"NULL token passed to assertTokenIsTerminator");
     }
 
     if (tok->tk_type != TK_PUNCT) {
-        loggerPanic("line %d: Expected token of type TK_PUNCT, got type: %s\n",
-                tok->line,lexemeTypeToString(tok->tk_type));
+        cctrlTokenRewind(cc);
+        cctrlTokenRewind(cc);
+        cctrlRaiseException(cc,"Expected token of type TK_PUNCT, got type: %s",
+                lexemeTypeToString(tok->tk_type));
     }
 
     if ((tok->i64 == ';' && (terminator_flags & PUNCT_TERM_SEMI)) ||
@@ -92,20 +94,20 @@ void assertTokenIsTerminator(lexeme *tok, long terminator_flags) {
 
     if ((terminator_flags & PUNCT_TERM_SEMI) &&
         (terminator_flags & PUNCT_TERM_COMMA)) {
-        loggerPanic("line %d: Expected ';' or ',' got: %s\n",
-                tok->line, lexemePunctToString(tok->i64));
+        cctrlRaiseException(cc,"Expected ';' or ',' got: %s",
+                lexemePunctToString(tok->i64));
     } else if ((terminator_flags & PUNCT_TERM_SEMI)) {
-        loggerPanic("line %d: Expected ';' got: %s\n",
-                tok->line, lexemePunctToString(tok->i64));
+        cctrlRaiseException(cc,"Expected ';' got: %s",
+                lexemePunctToString(tok->i64));
     } else if ((terminator_flags & PUNCT_TERM_COMMA)) {
-        loggerPanic("line %d: Expected ',' got: %s\n",
-                tok->line, lexemePunctToString(tok->i64));
+        cctrlRaiseException(cc,"Expected ',' got: %s",
+                lexemePunctToString(tok->i64));
     } else if (terminator_flags & PUNCT_TERM_RPAREN) {
-        loggerPanic("line %d: Expected ')' got: %s\n",
-                tok->line, lexemePunctToString(tok->i64));
+        cctrlRaiseException(cc,"Expected ')' got: %s",
+                lexemePunctToString(tok->i64));
     } else {
-        loggerPanic("line %d: Expected terminating token with flags: 0x%lX, got: %s\n",
-                tok->line, terminator_flags, lexemeToString(tok));
+        cctrlRaiseException(cc,"Expected terminating token with flags: 0x%lX, got: %s",
+                terminator_flags, lexemeToString(tok));
     }
 }
 

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -30,7 +30,7 @@ int parseIsFloatOrInt(Ast *ast);
 int parseIsClassOrUnion(int kind);
 int parseIsFunction(Ast *ast);
 
-void assertTokenIsTerminator(lexeme *tok, long terminator_flags);
+void assertTokenIsTerminator(Cctrl *cc, lexeme *tok, long terminator_flags);
 void assertUniqueSwitchCaseLabels(PtrVec *case_vector, Ast *case_);
 void assertIsFloatOrInt(Ast *ast, long lineno);
 void assertIsInt(Ast *ast, long lineno);

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,8 @@
 #define ESC_CYAN   "\033[0;36m"
 #define ESC_WHITE  "\033[0;37m"
 #define ESC_RESET  "\033[0m"
+#define ESC_BOLD   "\x1b[1m"
+#define ESC_CLEAR_BOLD "\x1b[0m"
 
 #define min(x,y) (((x) < (y) ? (x) : (y)))
 


### PR DESCRIPTION
- Use a ring buffer for the lexer, this allows for significantly faster parsing as the tokens are now parsed on the fly when needed by the parse as opposed to a distinct step before parsing.
- Improve performance of `-run` command when on mac, pipe directly into gcc without writting to a file and use system to execute shell commands for running and removing.
- Better error reporting.