### PR TITLE
fix: if class is number do not do try to parse as an array

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -490,7 +490,7 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
         lexeme *tok = cctrlTokenGet(cc);
         assertTokenIsTerminator(cc,tok,terminator_flags);
         return astDecl(var,init);
-    } else if (var->type->kind == AST_TYPE_CLASS) {
+    } else if (var->type->kind == AST_TYPE_CLASS && !var->type->is_intrinsic) {
         init = parseDeclArrayInitInt(cc,var->type);
         lexeme *tok = cctrlTokenGet(cc);
         assertTokenIsTerminator(cc,tok,terminator_flags);


### PR DESCRIPTION
- Good reminder to always run the tests and do a fresh install before merging