### PR TITLE
Fix/vector qsort

### DIFF
--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -161,7 +161,7 @@ public F64 FloatVecPop(FloatVec *vec, Bool *_ok);
 public F64 FloatVecGet(FloatVec *vec, I64 idx);
 public U0 FloatVecClear(FloatVec *vec);
 public U0 FloatVecRelease(FloatVec *vec);
-public U0 FloatVecSort(FloatVec *vec, I64 high, I64 low=0);
+public U0 FloatVecSort(FloatVec *vec);
 
 public IntVec *IntVecNew(I64 size = 32);
 public U64 IntVecCapacity(IntVec *vec);
@@ -170,7 +170,7 @@ public I64 IntVecPop(IntVec *vec, Bool *_ok);
 public I64 IntVecGet(IntVec *vec, I64 idx);
 public I64 IntVecClear(IntVec *vec);
 public I64 IntVecRelease(IntVec *vec);
-public U0 IntVecSort(IntVec *vec, I64 high, I64 low=0);
+public U0 IntVecSort(IntVec *vec);
 
 public PtrVec *PtrVecNew(I64 size = 32);
 public U64 PtrVecCapacity(IntVec *vec);
@@ -180,8 +180,7 @@ public U0 *PtrVecGet(PtrVec *vec, I64 idx);
 public I64 PtrVecClear(PtrVec *vec);
 public I64 PtrVecRelease(PtrVec *vec, U0 (*_free_value)(U0 *_val) = NULL);
 public U0 PtrVecSort(PtrVec *vec,
-                     I64(*_compare_fn)(U0 *_cmp_arg1, U0 *_cmp_arg2));
-
+                     I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2))
 
 public class IntMapNode
 {

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -151,6 +151,9 @@ public class FloatVec
   F64 *entries;
 };
 
+U0 QSortGeneric(U0 **arr, I64 high, I64 low, 
+    I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2));
+
 public FloatVec *FloatVecNew(I64 size = 32);
 public U64 FloatVecCapacity(IntVec *vec);
 public U0 FloatVecPush(FloatVec *vec, F64 value);
@@ -176,7 +179,7 @@ public U0 *PtrVecPop(PtrVec *vec, Bool *_ok);
 public U0 *PtrVecGet(PtrVec *vec, I64 idx);
 public I64 PtrVecClear(PtrVec *vec);
 public I64 PtrVecRelease(PtrVec *vec, U0 (*_free_value)(U0 *_val) = NULL);
-public U0 PtrVecSort(PtrVec *vec, I64 high, I64 low=0,
+public U0 PtrVecSort(PtrVec *vec,
                      I64(*_compare_fn)(U0 *_cmp_arg1, U0 *_cmp_arg2));
 
 

--- a/src/holyc-lib/vector.HC
+++ b/src/holyc-lib/vector.HC
@@ -72,7 +72,7 @@ U0 FloatVecSort(FloatVec *vec, I64 high, I64 low=0)
     I64 idx = low;
 
     for (I64 i = low; i < high; ++i) {
-      if (arr[i] <= pivot) {
+      if (arr[i] < pivot) {
         F64 tmp = arr[i];
         arr[i] = arr[idx];
         arr[idx] = tmp;
@@ -230,11 +230,10 @@ U0 *PtrVecGet(PtrVec *vec, I64 idx)
   return vec->entries[idx];
 }
 
-U0 PtrVecSort(PtrVec *vec, I64 high, I64 low,
-               I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2))
+U0 QSortGeneric(U0 **arr, I64 high, I64 low, 
+    I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2))
 {
   if (low < high) {
-    U0 **arr = vec->entries;
     U0 *pivot = arr[high];
     I64 idx = low;
 
@@ -249,9 +248,14 @@ U0 PtrVecSort(PtrVec *vec, I64 high, I64 low,
 
     arr[high] = arr[idx];
     arr[idx] = pivot;
-    PtrVecSort2(vec,high,low+1,_compare_fn);
-    PtrVecSort2(vec,high-1,low,_compare_fn);
+    QSortGeneric(arr,high,low+1,_compare_fn);
+    QSortGeneric(arr,high-1,low,_compare_fn);
   }
+}
+
+U0 PtrVecSort(PtrVec *vec, I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2))
+{
+  QSortGeneric(vec->entries,vec->size-1,0,_compare_fn);
 }
 
 I64 PtrVecClear(PtrVec *vec)

--- a/src/holyc-lib/vector.HC
+++ b/src/holyc-lib/vector.HC
@@ -64,7 +64,7 @@ F64 FloatVecGet(FloatVec *vec, I64 idx)
   return vec->entries[idx];
 }
 
-U0 FloatVecSort(FloatVec *vec, I64 high, I64 low=0)
+U0 FloatVecSortInternal(FloatVec *vec, I64 high, I64 low=0)
 {
   if (low < high) {
     F64 *arr = vec->entries;
@@ -82,9 +82,14 @@ U0 FloatVecSort(FloatVec *vec, I64 high, I64 low=0)
 
     arr[high] = arr[idx];
     arr[idx] = pivot;
-    FloatVecSort(vec,high,low+1);
-    FloatVecSort(vec,high-1,low);
+    FloatVecSortInternal(vec,high,low+1);
+    FloatVecSortInternal(vec,high-1,low);
   }
+}
+
+U0 FloatVecSort(FloatVec *vec)
+{
+  FloatVecSortInternal(vec,vec->size-1,0);
 }
 
 U0 FloatVecClear(FloatVec *vec)
@@ -147,7 +152,7 @@ I64 IntVecGet(IntVec *vec, I64 idx)
   return vec->entries[idx];
 }
 
-U0 IntVecSort(IntVec *vec, I64 high, I64 low=0)
+U0 IntVecSortInternal(IntVec *vec, I64 high, I64 low=0)
 {
   if (low < high) {
     I64 *arr = vec->entries;
@@ -165,9 +170,14 @@ U0 IntVecSort(IntVec *vec, I64 high, I64 low=0)
 
     arr[high] = arr[idx];
     arr[idx] = pivot;
-    IntVecSort(vec,high,low+1);
-    IntVecSort(vec,high-1,low);
+    IntVecSortInternal(vec,high,low+1);
+    IntVecSortInternal(vec,high-1,low);
   }
+}
+
+U0 IntVecSort(IntVec *vec)
+{
+  IntVecSortInternal(vec,vec->size-1,0);
 }
 
 I64 IntVecClear(IntVec *vec)


### PR DESCRIPTION
- Don't expose internals of sorting, just pass the vector
- Provided a `QSortGeneric` which can accept any collection while accepting a high and low
- Fix for calling a non-existant function