### PR TITLE
Feat: gcc to assmble an assembly file, fix for dereferencing a class

### DIFF
--- a/src/lexer.h
+++ b/src/lexer.h
@@ -197,5 +197,6 @@ void lexemeFree(void *_le);
 const char *lexerReportLine(lexer *l, ssize_t lineno);
 void lexerPoolRelease(void);
 int lexemeEq(lexeme *l1, lexeme *l2);
+char *lexReadfile(char *path, ssize_t *_len);
 
 #endif // !LEXER_H


### PR DESCRIPTION
- Call `gcc` on a `.s` file
- fix for `&` on a class; e.g: `Ptr *ptr = &ex->entries[0]`, before this was not working.