### PR TITLE
fix: ReAlloc issues, qsort

### DIFF
--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -400,7 +400,7 @@ static U64 StrMapGetNextIdx(StrMap *map, U8 *key, I64 key_len, Bool *_is_free)
     if (cur->key == NULL) {
       *_is_free = FALSE;
       return idx;
-    } else if (!StrNCmp(cur->key,key,cur->key_len)) {
+    } else if (key_len == cur->key_len && !StrNCmp(cur->key,key,cur->key_len)) {
       *_is_free = FALSE;
       return idx;
     }

--- a/src/holyc-lib/io.HC
+++ b/src/holyc-lib/io.HC
@@ -106,7 +106,7 @@ public U8 *FileRead(U8 *path, I64 *_size=NULL)
   s = MAlloc(len+100);
   size = 0;
 
-  while ((rbytes = read(fd,s,len)) != 0) {
+  while ((rbytes = read(fd,s+size,len)) != 0) {
     size += rbytes;
   }
 

--- a/src/holyc-lib/memory.HC
+++ b/src/holyc-lib/memory.HC
@@ -121,7 +121,14 @@ public extern "c" U0 *realloc(U0 *ptr, U64 size);
 
 public _extern _MALLOC U0 *MAlloc(U64 size);
 public _extern _FREE U0 Free(U0 *ptr);
-public _extern _REALLOC U0 *ReAlloc(U0 *ptr, U64 new_size);
+public U0 *ReAlloc(U0 *ptr, U64 new_size)
+{
+  U64 old_size = MSize(ptr);
+  U0 *mem = MAlloc(new_size);
+  MemCpy(mem,ptr,old_size);
+  Free(ptr);
+  return mem;
+}
 public _extern _CALLOC U0 *CAlloc(U64 new_size);
 public _extern _MSIZE U64 MSize(U0 *ptr);
 public _extern _MEMCPY U0 *MemCpy(U0 *dst, U0 *src, U64 len);

--- a/src/holyc-lib/threads.HC
+++ b/src/holyc-lib/threads.HC
@@ -82,7 +82,7 @@ union pthread_attr_t
 
 
 /* this is the spiritual equivilent of typedef  */ 
-public U64 class pthread_t;
+public U64 class pthread_t {};
 
 class __pthread_list_t;
 class __pthread_list_t
@@ -186,6 +186,7 @@ public extern "c" I32 pthread_cond_signal(pthread_cond_t *cond);
 public extern "c" I32 pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *lk);
 public extern "c" I32 pthread_exit(U0 *data=NULL);
 public extern "c" I32 pthread_detach(pthread_t *th);
+public extern "c" I32 pthread_attr_setstacksize(pthread_attr_t *attr, U64 stacksize);
 
 static U0 ThreadSemaphoreSignal(ThreadSemaphore *sem)
 {

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -440,6 +440,9 @@ public extern "c" I32 pthread_cond_signal(pthread_cond_t *cond);
 public extern "c" I32 pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *lk);
 public extern "c" I32 pthread_exit(U0 *data = NULL);
 public extern "c" I32 pthread_detach(pthread_t *th);
+public extern "c" I32 pthread_attr_setstacksize(pthread_attr_t *attr, U64 stacksize);
+public extern "c" I32 pthread_attr_init(pthread_attr_t *attr);
+
 ThreadPool *ThreadPoolNew(I64 worker_count);
 public U0 ThreadPoolEnqueue(ThreadPool *pool, U0 *argv,
            U0 (*callback)(U0 *priv_data, U0 *argv));
@@ -519,7 +522,7 @@ public extern "c" U0 free(U0 *ptr);
 public extern "c" U0 *malloc(U64 size);
 public _extern _MALLOC U0 *MAlloc(U64 size);
 public _extern _FREE U0 Free(U0 *ptr);
-public _extern _REALLOC U0 *ReAlloc(U0 *ptr, U64 new_size);
+public U0 *ReAlloc(U0 *ptr, U64 new_size);
 public _extern _CALLOC U0 *CAlloc(U64 new_size);
 public _extern _MSIZE U64 MSize(U0 *ptr);
 public _extern _MEMCPY U0 *MemCpy(U0 *dst, U0 *src, U64 len);

--- a/src/holyc-lib/vector.HC
+++ b/src/holyc-lib/vector.HC
@@ -222,8 +222,8 @@ U0 QSortGeneric(U0 **arr, I64 high, I64 low,
 
     arr[high] = arr[idx];
     arr[idx] = pivot;
-    QSortGeneric(arr,high,low+1,_compare_fn);
-    QSortGeneric(arr,high-1,low,_compare_fn);
+    QSortGeneric(arr,high,idx+1,_compare_fn);
+    QSortGeneric(arr,idx-1,low,_compare_fn);
   }
 }
 


### PR DESCRIPTION
- `ReAlloc` Needs to call `MSize` in the assembly, implemented in HC for the time being
- Fixed `QSortGeneric`
- Added more prototypes for pthread