### PR TITLE
fix - remove offset on linux

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -289,7 +289,6 @@ void assemble(hccOpts *opts) {
         aoStr asm_buf = {
             .data = buffer,
             .len = len,
-            .offset = 0,
             .capacity = len,
         };
         writeAsmToTmp(&asm_buf);


### PR DESCRIPTION
- `aoStr` no longer has an offset