### PR TITLE
fixes for hashtables threshold and StrNCpy

### DIFF
--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -464,7 +464,6 @@ public Bool StrMapResize(StrMap *map, U64 size)
   new_capacity = map->capacity << 1;
   new_mask = new_capacity - 1;
 
-  "map->size = %d\n",map->size;
   /* OOM */
   if ((new_indexes = CAlloc(indexes_capacity * sizeof(I64))) == NULL) {
     return FALSE;

--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -4,7 +4,7 @@
 #include "./strings.HC"
 #include "./vector.HC"
 
-#define HT_LOAD 0.60
+#define HT_LOAD 60
 #define HT_DELETED 0x7fffffffffffffff
 #define HT_PROBE_1 1
 #define HT_PROBE_3 3
@@ -83,7 +83,7 @@ IntMap *IntMapNew(U64 capacity)
   map->mask = capacity-1;
   map->size = 0;
   map->indexes = IntVecNew();
-  map->threashold = (HT_LOAD * capacity)(U64);
+  map->threashold = (new_capacity * HT_LOAD)/100;
   map->_free_value = NULL;
   map->entries = CAlloc(capacity * sizeof(IntMapNode *));
   return map;
@@ -209,7 +209,7 @@ public Bool IntMapResize(IntMap *map, U64 size)
   map->indexes->size = new_size;
   map->indexes->entries = new_indexes;
 
-  map->threashold = (new_capacity * HT_LOAD)(U64);
+  map->threashold = (new_capacity * HT_LOAD)/100;
   map->entries = new_entries;
   map->size = new_size;
   return TRUE;
@@ -363,7 +363,7 @@ StrMap *StrMapNew(U64 capacity)
   map->mask = capacity-1;
   map->size = 0;
   map->indexes = IntVecNew();
-  map->threashold = (HT_LOAD * capacity)(U64);
+  map->threashold = (new_capacity * HT_LOAD)/100;
   map->_free_value = NULL;
   map->_free_key = NULL;
   map->entries = CAlloc(capacity * sizeof(StrMapNode *));
@@ -464,6 +464,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
   new_capacity = map->capacity << 1;
   new_mask = new_capacity - 1;
 
+  "map->size = %d\n",map->size;
   /* OOM */
   if ((new_indexes = CAlloc(indexes_capacity * sizeof(I64))) == NULL) {
     return FALSE;
@@ -501,7 +502,7 @@ public Bool StrMapResize(StrMap *map, U64 size)
 
   map->size = new_size;
   map->entries = new_entries;
-  map->threashold = (map->capacity * HT_LOAD)(U64);
+  map->threashold = (new_capacity * HT_LOAD)/100;
   return TRUE;
 }
 

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -289,7 +289,8 @@ public _extern _ATOI I64 Atoi(U8 *str);
 
 public U8 *StrNCpy(U8 *buf, I64 len)
 {
-  U8 *str = MAlloc(sizeof(U8)*len+1);
+  U8 *str = MAlloc(sizeof(U8)*(len+1));
+  if (len == 0) return str;
   MemCpy(str,buf,len);
   str[len] = '\0';
   return str;

--- a/src/holyc-lib/vector.HC
+++ b/src/holyc-lib/vector.HC
@@ -241,8 +241,10 @@ I64 PtrVecRelease(PtrVec *vec, U0 (*_free_value)(U0 *_val) = NULL)
 { // Optionally pass a callback to free each item in the vector 
   if (vec) {
     if (_free_value) {
-      for (U0 *it : vec) {
-        _free_value(it);
+      U0 **entries = vec->entries;
+      I64 size = vec->size;
+      for (I64 i = 0; i < size; ++i) {
+        _free_value(entries[i]);
       }
     }
     Free(vec->entries);


### PR DESCRIPTION
- Fix for threshold contantly being `0, something to do with mixing floats and ints in arithmetic operations
- Fix for `StrNCpy`