### PR TITLE
fix - use aoStrCatFmt

### DIFF
--- a/src/aostr.h
+++ b/src/aostr.h
@@ -38,6 +38,7 @@ void aoStrCatAoStr(aoStr *buf, aoStr *s2);
 void aoStrCat(aoStr *buf, const void *d);
 void aoStrCatRepeat(aoStr *buf, char *str, int times);
 void aoStrCatPrintf(aoStr *b, const char *fmt, ...);
+void aoStrCatFmt(aoStr *buf, const char *fmt, ...);
 aoStr *aoStrPrintf(const char *fmt, ...);
 aoStr *aoStrEscapeString(aoStr *buf);
 aoStr *aoStrEncode(aoStr *buf);


### PR DESCRIPTION
- prefer `aoStrCatFmt`, less bug prone than `aoStrCatPrintf`... Ideally we'd make `aoStrCatPrintf` internal and only use it for numbers.
- fix for character buffer null termination.