### PR TITLE
fix - error line reporting

### DIFF
--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -617,6 +617,7 @@ aoStr *cctrlCreateErrorLine(Cctrl *cc,
                             int severity,
                             char *suggestion)
 {
+    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED : CCTRL_WARN ? ESC_BOLD_YELLOW : ESC_CYAN;
     int is_terminal = isatty(STDOUT_FILENO) && isatty(STDERR_FILENO);
     if (!cc->lexer_) {
         aoStr *buf = aoStrNew();
@@ -654,7 +655,7 @@ aoStr *cctrlCreateErrorLine(Cctrl *cc,
 
         if (is_terminal) {
             for (int i = 0; i < tok_len; ++i) {
-                aoStrCat(buf,ESC_BOLD_RED"^"ESC_RESET);
+                aoStrCatFmt(buf,"%s^%s",color,ESC_RESET);
             }
         } else {
             for (int i = 0; i < tok_len; ++i) {
@@ -664,7 +665,7 @@ aoStr *cctrlCreateErrorLine(Cctrl *cc,
 
         if (suggestion) {
             if (is_terminal) {
-                aoStrCatFmt(buf, ESC_BOLD_RED" %s"ESC_RESET, suggestion);
+                aoStrCatFmt(buf, "%s %s%s",color,suggestion,ESC_RESET);
             } else {
                 aoStrCatFmt(buf, " %s", suggestion);
             }
@@ -825,6 +826,7 @@ void cctrlTokenExpect(Cctrl *cc, long expected) {
 aoStr *cctrlRaiseFromTo(Cctrl *cc, int severity, char *suggestion, char from, 
                         char to, char *fmt, va_list ap)
 {
+    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED : CCTRL_WARN ? ESC_BOLD_YELLOW : ESC_CYAN;
     char *msg = mprintVa(fmt, ap, NULL);
     aoStr *bold_msg = aoStrNew();
     aoStrCatFmt(bold_msg, ESC_BOLD"%s"ESC_CLEAR_BOLD, msg);
@@ -850,11 +852,11 @@ aoStr *cctrlRaiseFromTo(Cctrl *cc, int severity, char *suggestion, char from,
             aoStrPutChar(buf,' ');
         }
         for (int i = 0; i < (to_idx+1)-from_idx; ++i) {
-            aoStrCat(buf,ESC_BOLD_RED"^"ESC_RESET);
+            aoStrCatFmt(buf,"%s^%s",color,ESC_RESET);
         }
         if (suggestion) {
             if (isatty(STDOUT_FILENO)) {
-                aoStrCatFmt(buf, ESC_BOLD_RED" %s"ESC_RESET, suggestion);
+                aoStrCatFmt(buf,"%s %s%s",color,suggestion,ESC_RESET);
             } else {
                 aoStrCatFmt(buf, " %s", suggestion);
             }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -846,7 +846,6 @@ unsigned long lexCharConst(lexer *l) {
                 case 'd':  char_const |= (unsigned long)'$'  << ((unsigned long)idx); break;
                 case 'n':  {
                     char_const |= (unsigned long)'\n' << ((unsigned long)idx);
-                    l->lineno++;
                     break;
                 }
                 case 'r':  char_const |= (unsigned long)'\r' << ((unsigned long)idx); break;

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -474,6 +474,7 @@ void assertUniqueSwitchCaseLabels(PtrVec *case_vector, Ast *case_) {
 void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual) {
     aoStr *expected_type = astTypeToColorAoStr(expected->type);
     aoStr *actual_type = astTypeToColorAoStr(actual->type);
+    char *actual_str = astToString(actual);
 
 
     int count = 0;
@@ -481,11 +482,17 @@ void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual) {
     cctrlTokenGet(cc);
     count--;
 
-    cctrlWarningFromTo(cc,NULL, '=', ';', "Incompatible types '%s' is not assignable to type '%s'", 
+    char *suggestion = mprintf("%s is not of type %s, perhaps change the type to %s?",
+            actual_str,
+            expected_type->data,
+            actual_type->data);
+    cctrlWarningFromTo(cc, suggestion, '=', ';', "Incompatible types '%s' is not assignable to type '%s'",
             actual_type->data, expected_type->data);
     for (int i = 0; i < count; ++i) {
         cctrlTokenGet(cc);
     }
+    free(suggestion);
+    free(actual_str);
     aoStrRelease(expected_type);
     aoStrRelease(actual_type);
 }


### PR DESCRIPTION
- Fixes a bug where the lexer would increment the line counter when parsing the character `\n`.
- Improved error message for mismatching types
- Use the severity color for the `^` underlining.