### PR TITLE
fix: array indexing and global arrays

### DIFF
--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -356,8 +356,11 @@ lexeme *cctrlMaybeExpandToken(Cctrl *cc, lexeme *token) {
     return token; 
 }
 
-lexeme *cctrlTokenPeekBy(Cctrl *cc, int idx) {
-    return tokenRingBufferPeekBy(cc->token_buffer, idx);
+lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt) {
+    assert(cnt > 0);
+    /* The -1 is bizzare, however as an argument peeking by `1` you'd
+     * expect to see the next token, which is infact `0` */
+    return tokenRingBufferPeekBy(cc->token_buffer, cnt-1);
 }
 
 lexeme *cctrlTokenPeek(Cctrl *cc) {

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -142,6 +142,7 @@ Cctrl *cctrlNew(void);
 Cctrl *ccMacroProcessor(StrMap *macro_defs);
 lexeme *cctrlTokenGet(Cctrl *cc);
 lexeme *cctrlTokenPeek(Cctrl *cc);
+lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt);
 void cctrlInitMacroProcessor(Cctrl *cc);
 void cctrlTokenRewind(Cctrl *cc);
 void cctrlTokenExpect(Cctrl *cc, long expected);

--- a/src/transpiler.c
+++ b/src/transpiler.c
@@ -437,12 +437,21 @@ void transpileBinaryOp(TranspileCtx *ctx, aoStr *buf, char *op, Ast *ast, ssize_
 
     *indent = 0;
     if (ast->left && ast->left->kind == AST_DEREF) {
+        int is_bang = !strncmp(op,"!",1);
+        if (is_bang) {
+            aoStrCatFmt(buf, "%s", op);
+        }
+
         if (ast->left) {
             transpileAstInternal(ast->left,ctx, indent);
         } else {
             transpileAstInternal(ast,ctx, indent);
         }
-        aoStrCatFmt(buf, " %s ", op);
+
+        if (!is_bang) {
+            aoStrCatFmt(buf, " %s ", op);
+        }
+
         if (ast->right) {
             transpileAstInternal(ast->right,ctx, indent);
         }

--- a/src/x86.c
+++ b/src/x86.c
@@ -2023,6 +2023,22 @@ void asmDataInternal(aoStr *buf, Ast *data) {
         return;
     }
 
+    /* If we have something like:
+     * ```
+     * I64 arr[][2] = {
+     *   {1,2},
+     *   {3,4},
+     * };
+     * ```
+     * We need to call this function again.
+     * */
+    if (data->kind == AST_ARRAY_INIT) {
+        listForEach(data->arrayinit) {
+            asmDataInternal(buf,it->value);
+        }
+        return;
+    }
+
     if (data->type->kind == AST_TYPE_FLOAT) {
         aoStrCatPrintf(buf,".quad 0x%lX #%.9f\n\t",
                 ieee754(data->f64),


### PR DESCRIPTION
- Arrays in global and local scope like the below work, as do unary operators which before were doing something weird.
```hc
I64 arr[][2] = {
  {1,2},
  {3,4},
  {5,6}
};

if (!arr[0][1]) {
  "something!\n";
}
```