### PR TITLE
src/main.c: fix chopped off output file name

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -138,7 +138,8 @@ void getASMFileName(HccOpts *opts, char *file_name) {
         slashptr = file_name;
     }
 
-    int no_ext_len = strlen(slashptr) - (end-slashptr);
+    const char *dot_end = strrchr(slashptr, '.');
+    int no_ext_len = (dot_end == NULL) ? 0 : dot_end - slashptr;
 
     opts->infile_no_ext = mprintf("%.*s", no_ext_len, slashptr);
     opts->asm_outfile = mprintf("%s.s", opts->infile_no_ext);


### PR DESCRIPTION
Invoking hcc -<S/cfg> <file_name> creates an output file that discards everything, except the first 3 bytes of the file name. For instance, hcc -S hello.hc will create a file called hel.s, and the same with other holyc files.

Some other things to note

```hc
U0 Main() {}

Main;
```

In the above example, if the function `Main` doesn't end with a newline (that's an empty newline after `Main;`), but rather a nul-terminated character, hcc reports an error that  `;` wasn't given after the function name and crashes.

This shouldn't be an error though, it stops around here.
https://github.com/Jamesbarford/holyc-lang/blob/61a082428a6f53a744df6f0545105b42ab63e4b1/src/cctrl.c#L812-L816

This function `cctrlRewindUntilStrMatch()` calls `cctrlTokenPeek()` which returns `NULL`. Unfortunately I don't have enough time to debug it right now, but I'm adding it here, if someone else can fix it.