### PR TITLE
fix - compile files with no newline endings

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -522,7 +522,7 @@ char *lexReadfile(char *path, ssize_t *_len) {
     lseek(fd, 0, SEEK_SET);
 
     /* Add a `+1` for `\0` */
-    char *buf = (char *)malloc(sizeof(char) * (len+1));
+    char *buf = (char *)malloc((sizeof(char) * len)+1);
     int size = 0;
     int rbytes = 0;
     while ((rbytes = read(fd,buf,len)) != 0) {

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -521,7 +521,8 @@ char *lexReadfile(char *path, ssize_t *_len) {
     int len = lseek(fd, 0, SEEK_END);
     lseek(fd, 0, SEEK_SET);
 
-    char *buf = (char *)malloc(sizeof(char) * len);
+    /* Add a `+1` for `\0` */
+    char *buf = (char *)malloc(sizeof(char) * (len+1));
     int size = 0;
     int rbytes = 0;
     while ((rbytes = read(fd,buf,len)) != 0) {
@@ -533,7 +534,7 @@ char *lexReadfile(char *path, ssize_t *_len) {
     }
 
     *_len = len;
-    buf[len-1] = '\0';
+    buf[len] = '\0';
     close(fd);
     return buf;
 }


### PR DESCRIPTION
- `NULL` termination of a file was happening in the wrong place

Closes: #143