### PR TITLE
Fix - character counting

### DIFF
--- a/src/aostr.c
+++ b/src/aostr.c
@@ -72,9 +72,8 @@ void aoStrToLowerCase(aoStr *buf) {
 
 void aoStrPutChar(aoStr *buf, char ch) {
     aoStrExtendBufferIfNeeded(buf, 10);
-    buf->data[buf->len] = ch;
-    buf->data[buf->len + 1] = '\0';
-    buf->len++;
+    buf->data[buf->len++] = ch;
+    buf->data[buf->len] = '\0';
 }
 
 void aoStrRepeatChar(aoStr *buf, char ch, int times) {
@@ -267,41 +266,6 @@ aoStr *aoStrEscapeString(aoStr *buf) {
         ++ptr;
     }
     return outstr;
-}
-
-/* If we have an escaped string this will give the size of `\n` as `1` rather 
- * than `\` `n` which would be `2` */
-size_t aoStrEscapeLen(aoStr *str) {
-    size_t len = 0;
-    char *ptr = str->data;
-    while (*ptr) {
-        if (*ptr == '\\') {
-            ptr++;
-            printf("%c\n",*ptr);
-            switch (*ptr) {
-                case '\\': len++; break;
-                case '\'': len++; break;
-                case '0':  len++; break;
-                case '`':  len++; break;
-                case '"':  len++; break;
-                case 'n':  len++; break;
-                case 'r':  len++; break;
-                case 't':  len++; break;
-                case 'b':  len++; break;
-                case 'v':  len++; break;
-                case 'f':  len++; break;
-                case 'x':
-                case 'X':  ptr += 2; len++; break;
-                default:
-                    len++;
-                    break;
-            }
-        } else {
-            len++;
-        }
-        ptr++;
-    }
-    return len;
 }
 
 void aoStrArrayRelease(aoStr **arr, int count) {

--- a/src/aostr.c
+++ b/src/aostr.c
@@ -269,6 +269,41 @@ aoStr *aoStrEscapeString(aoStr *buf) {
     return outstr;
 }
 
+/* If we have an escaped string this will give the size of `\n` as `1` rather 
+ * than `\` `n` which would be `2` */
+size_t aoStrEscapeLen(aoStr *str) {
+    size_t len = 0;
+    char *ptr = str->data;
+    while (*ptr) {
+        if (*ptr == '\\') {
+            ptr++;
+            printf("%c\n",*ptr);
+            switch (*ptr) {
+                case '\\': len++; break;
+                case '\'': len++; break;
+                case '0':  len++; break;
+                case '`':  len++; break;
+                case '"':  len++; break;
+                case 'n':  len++; break;
+                case 'r':  len++; break;
+                case 't':  len++; break;
+                case 'b':  len++; break;
+                case 'v':  len++; break;
+                case 'f':  len++; break;
+                case 'x':
+                case 'X':  ptr += 2; len++; break;
+                default:
+                    len++;
+                    break;
+            }
+        } else {
+            len++;
+        }
+        ptr++;
+    }
+    return len;
+}
+
 void aoStrArrayRelease(aoStr **arr, int count) {
     if (arr) {
         for (int i = 0; i < count; ++i) {

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -41,6 +41,7 @@ void aoStrCatPrintf(aoStr *b, const char *fmt, ...);
 void aoStrCatFmt(aoStr *buf, const char *fmt, ...);
 aoStr *aoStrPrintf(const char *fmt, ...);
 aoStr *aoStrEscapeString(aoStr *buf);
+size_t aoStrEscapeLen(aoStr *str);
 aoStr *aoStrEncode(aoStr *buf);
 
 void aoStrArrayRelease(aoStr **arr, int count);

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -41,7 +41,6 @@ void aoStrCatPrintf(aoStr *b, const char *fmt, ...);
 void aoStrCatFmt(aoStr *buf, const char *fmt, ...);
 aoStr *aoStrPrintf(const char *fmt, ...);
 aoStr *aoStrEscapeString(aoStr *buf);
-size_t aoStrEscapeLen(aoStr *str);
 aoStr *aoStrEncode(aoStr *buf);
 
 void aoStrArrayRelease(aoStr **arr, int count);

--- a/src/ast.c
+++ b/src/ast.c
@@ -192,10 +192,16 @@ static void astFreeGVar(Ast *ast) {
     free(ast);
 }
 
-Ast *astString(char *str, int len) {
+Ast *astString(char *str, int len, long real_len) {
     Ast *ast = astNew();
     ast->kind = AST_STRING;
-    ast->sval = aoStrDupRaw(str,len);
+    if (len == 0) {
+        ast->sval = aoStrPrintf("\\0");
+        ast->real_len = 1;
+    } else {
+        ast->sval = aoStrDupRaw(str,len);
+        ast->real_len = real_len;
+    }
     ast->type = astMakeArrayType(ast_u8_type, ast->sval->len + 1);
     ast->slabel = astMakeLabel();
     return ast;
@@ -606,6 +612,7 @@ AstType *astMakeClassField(AstType *type, int offset) {
     memcpy(field_type,type,sizeof(AstType));
     field_type->clsname = NULL;
     field_type->offset = offset;
+    field_type->size = type->size;
     return field_type;
 }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -131,6 +131,7 @@ typedef struct Ast {
         struct {
             aoStr *sval;
             aoStr *slabel;
+            long real_len;
         };
 
         /* Local variable */
@@ -302,7 +303,7 @@ void astReleaseList(List *ast_list);
 Ast *astI64Type(long long val);
 Ast *astF64Type(double val);
 Ast *astCharType(long ch);
-Ast *astString(char *str, int len);
+Ast *astString(char *str, int len, long real_len);
 
 /* Declarations */
 Ast *astDecl(Ast *var, Ast *init);

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -928,7 +928,7 @@ Ast *cctrlGetVar(Cctrl *cc, char *varname, int len) {
             if (cc->flags & CCTRL_PASTE_DEFINES) {
                 return astLVar(astMakePointerType(ast_u8_type), varname, len);
             }
-            return cctrlGetOrSetString(cc, tok->start, tok->len);
+            return cctrlGetOrSetString(cc, tok->start, tok->len, tok->i64);
         }
         default:
             return NULL;
@@ -964,16 +964,16 @@ void cctrlSetCommandLineDefines(Cctrl *cc, List *defines_list) {
 }
 
 /* De-duplicates strings by checking their existance */
-Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len) {
+Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, long real_len) {
     Ast *ast_str = NULL;
     if (cc->strs) {
         ast_str = strMapGetLen(cc->strs, str, len);
         if (!ast_str) {
-            ast_str = astString(str,len);
-            strMapAdd(cc->strs, ast_str->sval->data, ast_str);
+            ast_str = astString(str,len,real_len);
+            strMapAddLen(cc->strs,ast_str->sval->data,len,ast_str);
         }
     } else {
-        ast_str = astString(str,len);
+        ast_str = astString(str,len,real_len);
     }
     return ast_str;
 }

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -155,7 +155,7 @@ void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from, char to, 
 void cctrlRaiseException(Cctrl *cc, char *fmt, ...) __attribute__ ((noreturn));
 void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt, ...) __attribute__ ((noreturn));
 void cctrlIce(Cctrl *cc, char *fmt, ...) __attribute__ ((noreturn));
-Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len);
+Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, long real_len);
 void cctrlRewindUntilPunctMatch(Cctrl *cc, long ch, int *_count);
 void cctrlRewindUntilStrMatch(Cctrl *cc, char *str, int len, int *_count);
 aoStr *cctrlMessagePrintF(Cctrl *cc, int severity, char *fmt,...);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -718,7 +718,6 @@ long lexInStr(Lexer *l, unsigned char *buf, long size, int *done,
 
                 case 'x':
                 case 'X':
-                    buf[i++] = '\\';
                     buf[i++] = 'x';
                     buf[i++] = toupper(lexNextChar(l));
                     buf[i++] = toupper(lexNextChar(l));

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -920,8 +920,8 @@ int lex(Lexer *l, Lexeme *le) {
         case '\"': {
             long real_len = 0;
             aoStr *str = lexString(l,'"',&real_len);
-            le->start = str->data; // l->cur_str;
-            le->len = str->len; //l->cur_strlen;
+            le->start = str->data;
+            le->len = str->len;
             le->tk_type = TK_STR;
             le->line = l->lineno;
             le->i64 = real_len;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -123,7 +123,6 @@
 #define KW_PP_ERROR     79
 
 /* Compiler Flags*/
-#define CCF_ESCAPE_STRING_NEWLINES (1ULL << 40)
 #define CCF_MULTI_CHAR_OP     (1<<0)
 #define CCF_PRE_PROC          (1<<1)
 #define CCF_ACCEPT_NEWLINES   (1<<2)

--- a/src/map.c
+++ b/src/map.c
@@ -653,7 +653,7 @@ int strMapResize(StrMap *map) {
     return 1;
 }
 
-int strMapAdd(StrMap *map, char *key, void *value) {
+int strMapAddLen(StrMap *map, char *key, long key_len, void *value) {
     int is_free;
 
     if (map->size >= map->threashold) {
@@ -663,7 +663,6 @@ int strMapAdd(StrMap *map, char *key, void *value) {
         }
     }
 
-    long key_len = strlen(key);
     unsigned long idx = strMapGetNextIdx(map, key, key_len, &is_free);
 
     if (is_free) {
@@ -673,13 +672,17 @@ int strMapAdd(StrMap *map, char *key, void *value) {
         map->size++;
         return 1;
     } else {
-        // return 0;
         StrMapNode *n = map->entries[idx];
         n->key = key;
         n->key_len = key_len;
         n->value = value;
         return 1;
     }
+}
+
+int strMapAdd(StrMap *map, char *key, void *value) {
+    long key_len = strlen(key);
+    return strMapAddLen(map,key,key_len,value);
 }
 
 int strMapAddOrErr(StrMap *map, char *key, void *value) {

--- a/src/map.h
+++ b/src/map.h
@@ -3,7 +3,7 @@
 
 #include <limits.h>
 
-#define HT_LOAD    0.60
+#define HT_LOAD    0.65
 #define HT_DELETED LONG_MAX
 #define HT_VACANT  LONG_MAX-1
 #define HT_PROBE_1 1
@@ -120,6 +120,7 @@ StrMap *strMapNew(unsigned long capacity);
 StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
 void *strMapGetLen(StrMap *map, char *key, long key_len);
 void *strMapGet(StrMap *map, char *key);
+int strMapAddLen(StrMap *map, char *key, long key_len, void *value);
 int strMapAdd(StrMap *map, char *key, void *value);
 int strMapAddOrErr(StrMap *map, char *key, void *value);
 int strMapHas(StrMap *map, char *key);

--- a/src/map.h
+++ b/src/map.h
@@ -120,6 +120,7 @@ StrMap *strMapNew(unsigned long capacity);
 StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
 void *strMapGetLen(StrMap *map, char *key, long key_len);
 void *strMapGet(StrMap *map, char *key);
+int strMapAddLen(StrMap *map, char *key, long key_len, void *value);
 int strMapAdd(StrMap *map, char *key, void *value);
 int strMapAddOrErr(StrMap *map, char *key, void *value);
 int strMapHas(StrMap *map, char *key);

--- a/src/map.h
+++ b/src/map.h
@@ -3,7 +3,7 @@
 
 #include <limits.h>
 
-#define HT_LOAD    0.65
+#define HT_LOAD    0.60
 #define HT_DELETED LONG_MAX
 #define HT_VACANT  LONG_MAX-1
 #define HT_PROBE_1 1
@@ -120,7 +120,6 @@ StrMap *strMapNew(unsigned long capacity);
 StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
 void *strMapGetLen(StrMap *map, char *key, long key_len);
 void *strMapGet(StrMap *map, char *key);
-int strMapAddLen(StrMap *map, char *key, long key_len, void *value);
 int strMapAdd(StrMap *map, char *key, void *value);
 int strMapAddOrErr(StrMap *map, char *key, void *value);
 int strMapHas(StrMap *map, char *key);

--- a/src/parser.c
+++ b/src/parser.c
@@ -42,7 +42,7 @@ Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
 
     while (ch) {
         str[len++] = ch & 0xFF;
-        ch = ch >> 8; 
+        ch = ch >> 8;
     }
 
     Ast *ast = cctrlGetOrSetString(cc,str,len,len);
@@ -441,7 +441,6 @@ AstType *parseClassOrUnion(Cctrl *cc, StrMap *env,
         int is_intrinsic)
 {
     aoStr *tag = NULL;
-    int real_size = 0;
     int aligned_size = 0;
     unsigned int class_size;
     Lexeme *tok = cctrlTokenGet(cc);

--- a/src/tests/38_sizeof.HC
+++ b/src/tests/38_sizeof.HC
@@ -5,6 +5,8 @@ Bool SizeofString()
   if (sizeof("hello") != 6) return FALSE;
   if (sizeof("h") != 2) return FALSE;
   if (sizeof("hello world") != 12) return FALSE;
+  if (sizeof("hello" " world") != 12) return FALSE;
+  if (sizeof("hey" "how " "are " " you?") != 17) return FALSE;
   return TRUE;
 }
 

--- a/src/tests/38_sizeof.HC
+++ b/src/tests/38_sizeof.HC
@@ -106,6 +106,7 @@ Bool SizeofArrays()
     {2,2,"b"},
     {3,3,"c"},
   };
+  U8 *strs[] = {"hello", " world\n"};
 
   if (sizeof(array1) != sizeof(I8)  * 3) return FALSE;
   if (sizeof(array2) != sizeof(I16) * 3) return FALSE;
@@ -119,6 +120,11 @@ Bool SizeofArrays()
   if (sizeof(array3) / sizeof(array3[0]) != 3) return FALSE;
   if (sizeof(array4) / sizeof(array4[0]) != 3) return FALSE;
   if (sizeof(array5) / sizeof(array5[0]) != 3) return FALSE;
+  if (sizeof(strs) / sizeof(strs[0]) != 2) return FALSE;
+
+  if (sizeof(strs)    != sizeof(U8 *) * 2) return FALSE;
+  if (sizeof(strs[0]) != 8) return FALSE;
+  if (sizeof(strs[1]) != 8) return FALSE;
 
   return TRUE;
 }
@@ -128,7 +134,6 @@ I32 Main()
   "Test - sizeof(...): \n";
   I64 tests = 8;
   I64 correct = 0;
-
   
   if (SizeofString()) {
     correct++;

--- a/src/tests/38_sizeof.HC
+++ b/src/tests/38_sizeof.HC
@@ -11,18 +11,19 @@ Bool SizeofString()
 Bool SizeofChars()
 {
   /* This is very quirky */
-  if (sizeof('f') != 8) return FALSE;
+  if (sizeof('f') != 1) return FALSE;
   return TRUE;
 }
 
 Bool SizeofEscapedChars()
 {
+  if (sizeof("\f\f\f") != 4) return FALSE;
+  if (sizeof("\\\\\\") != 4) return FALSE;
+  if (sizeof("\0\0\0") != 4) return FALSE;
   if (sizeof("\n\n\n") != 4) return FALSE;
   if (sizeof("\r\r\r") != 4) return FALSE;
   if (sizeof("\t\t\t") != 4) return FALSE;
-  if (sizeof("\t\t\t") != 4) return FALSE;
   if (sizeof("\v\v\v") != 4) return FALSE;
-  if (sizeof("\0\0\0") != 4) return FALSE;
   if (sizeof("\"\"\"") != 4) return FALSE;
   return TRUE;
 }
@@ -36,14 +37,12 @@ Bool SizeofBytes()
 Bool SizeofBuiltinTypes()
 {
     if (sizeof(U0)   != 0) return FALSE;
-    printf("here\n");
     if (sizeof(Bool) != 1) return FALSE;
     if (sizeof(I8)   != 1) return FALSE;
     if (sizeof(U8)   != 1) return FALSE;
     if (sizeof(I16)  != 2) return FALSE;
     if (sizeof(U16)  != 2) return FALSE;
     if (sizeof(I32)  != 4) return FALSE;
-    printf("here\n");
     if (sizeof(U32)  != 4) return FALSE;
     if (sizeof(I64)  != 8) return FALSE;
     if (sizeof(U64)  != 8) return FALSE;
@@ -66,13 +65,14 @@ class Type2
 class Type3
 {
   I64 a;   /* 8 */
-  I16 b;   /* 2 */
+  I16 b;   /* 2.. */
   U8 *buf; /* 8 */
 };
 
 Bool SizeofTypes()
 {
-  if (sizeof(Type1) != 18) return FALSE;
+  /* Structs are aligned */
+  if (sizeof(Type1) != 24) return FALSE;
   if (sizeof(Type2) != 8) return FALSE;
 
   return TRUE;
@@ -124,46 +124,53 @@ Bool SizeofArrays()
 I32 Main()
 {
   "Test - sizeof(...): \n";
-  I64 tests = 7;
+  I64 tests = 8;
   I64 correct = 0;
 
   
-  if (!SizeofString()) { correct++;
+  if (SizeofString()) {
+    correct++;
   } else {
     "Failed - SizeofString()\n";
   }
-  
-  if (!SizeofChars()) {
+
+  if (SizeofChars()) {
     correct++;
   } else {
     "Failed - SizeofChars()\n";
   }
   
-  if (!SizeofBytes()) {
+  if (SizeofEscapedChars()) {
+    correct++;
+  } else {
+    "Failed - SizeofEscapedChars()\n";
+  }
+
+  if (SizeofBytes()) {
     correct++;
   } else {
     "Failed - SizeofBytes()\n";
   }
-  
-  if (!SizeofBuiltinTypes()) {
+
+  if (SizeofBuiltinTypes()) {
     correct++;
   } else {
     "Failed - SizeofBuiltinTypes()\n";
   }
   
-  if (!SizeofTypes()) {
+  if (SizeofTypes()) {
     correct++;
   } else {
     "Failed - SizeofTypes()\n";
   }
   
-  if (!SizeofPointer()) {
+  if (SizeofPointer()) {
     correct++;
   } else {
     "Failed - SizeofPointer()\n";
   }
 
-  if (!SizeofArrays()) {
+  if (SizeofArrays()) {
     correct++;
   } else {
     "Failed - SizeofArrays()\n";

--- a/src/tests/38_sizeof.HC
+++ b/src/tests/38_sizeof.HC
@@ -1,0 +1,175 @@
+#include "./testhelper.HC"
+
+Bool SizeofString()
+{
+  if (sizeof("hello") != 6) return FALSE;
+  if (sizeof("h") != 2) return FALSE;
+  if (sizeof("hello world") != 12) return FALSE;
+  return TRUE;
+}
+
+Bool SizeofChars()
+{
+  /* This is very quirky */
+  if (sizeof('f') != 8) return FALSE;
+  return TRUE;
+}
+
+Bool SizeofEscapedChars()
+{
+  if (sizeof("\n\n\n") != 4) return FALSE;
+  if (sizeof("\r\r\r") != 4) return FALSE;
+  if (sizeof("\t\t\t") != 4) return FALSE;
+  if (sizeof("\t\t\t") != 4) return FALSE;
+  if (sizeof("\v\v\v") != 4) return FALSE;
+  if (sizeof("\0\0\0") != 4) return FALSE;
+  if (sizeof("\"\"\"") != 4) return FALSE;
+  return TRUE;
+}
+
+Bool SizeofBytes()
+{
+  if (sizeof("\xa3\xFF") != 2) return FALSE;
+  return TRUE;
+}
+
+Bool SizeofBuiltinTypes()
+{
+    if (sizeof(U0)   != 0) return FALSE;
+    printf("here\n");
+    if (sizeof(Bool) != 1) return FALSE;
+    if (sizeof(I8)   != 1) return FALSE;
+    if (sizeof(U8)   != 1) return FALSE;
+    if (sizeof(I16)  != 2) return FALSE;
+    if (sizeof(U16)  != 2) return FALSE;
+    if (sizeof(I32)  != 4) return FALSE;
+    printf("here\n");
+    if (sizeof(U32)  != 4) return FALSE;
+    if (sizeof(I64)  != 8) return FALSE;
+    if (sizeof(U64)  != 8) return FALSE;
+    if (sizeof(F64)  != 8) return FALSE;
+    return TRUE;
+}
+
+class Type1
+{
+  I64 a;     /* 8 */
+  I16 b;     /* 2 */
+  U8 buf[8]; /* 8 */
+};
+
+class Type2
+{
+  I64 a; /* 8 */
+};
+
+class Type3
+{
+  I64 a;   /* 8 */
+  I16 b;   /* 2 */
+  U8 *buf; /* 8 */
+};
+
+Bool SizeofTypes()
+{
+  if (sizeof(Type1) != 18) return FALSE;
+  if (sizeof(Type2) != 8) return FALSE;
+
+  return TRUE;
+}
+
+Bool SizeofPointer()
+{ /* Our pointers are all of size 8 */
+  U8 *u8_ptr;
+  I16 *i16_ptr;
+  I32 *i32_ptr;
+  I64 *i64_ptr;
+
+  if (sizeof(u8_ptr) != 8) return FALSE;
+  if (sizeof(i16_ptr) != 8) return FALSE;
+  if (sizeof(i32_ptr) != 8) return FALSE;
+  if (sizeof(i64_ptr) != 8) return FALSE;
+
+  return TRUE;
+}
+
+Bool SizeofArrays()
+{
+  I8  array1[] = {1,2,3};
+  I16 array2[] = {1,2,3};
+  I32 array3[] = {1,2,3};
+  I64 array4[] = {1,2,3};
+  Type3 array5[] = {
+    {1,1,"a"},
+    {2,2,"b"},
+    {3,3,"c"},
+  };
+
+  if (sizeof(array1) != sizeof(I8)  * 3) return FALSE;
+  if (sizeof(array2) != sizeof(I16) * 3) return FALSE;
+  if (sizeof(array3) != sizeof(I32) * 3) return FALSE;
+  if (sizeof(array4) != sizeof(I64) * 3) return FALSE;
+  if (sizeof(array5) != sizeof(Type3) * 3) return FALSE;
+
+
+  if (sizeof(array1) / sizeof(array1[0]) != 3) return FALSE;
+  if (sizeof(array2) / sizeof(array2[0]) != 3) return FALSE;
+  if (sizeof(array3) / sizeof(array3[0]) != 3) return FALSE;
+  if (sizeof(array4) / sizeof(array4[0]) != 3) return FALSE;
+  if (sizeof(array5) / sizeof(array5[0]) != 3) return FALSE;
+
+  return TRUE;
+}
+
+I32 Main()
+{
+  "Test - sizeof(...): \n";
+  I64 tests = 7;
+  I64 correct = 0;
+
+  
+  if (!SizeofString()) { correct++;
+  } else {
+    "Failed - SizeofString()\n";
+  }
+  
+  if (!SizeofChars()) {
+    correct++;
+  } else {
+    "Failed - SizeofChars()\n";
+  }
+  
+  if (!SizeofBytes()) {
+    correct++;
+  } else {
+    "Failed - SizeofBytes()\n";
+  }
+  
+  if (!SizeofBuiltinTypes()) {
+    correct++;
+  } else {
+    "Failed - SizeofBuiltinTypes()\n";
+  }
+  
+  if (!SizeofTypes()) {
+    correct++;
+  } else {
+    "Failed - SizeofTypes()\n";
+  }
+  
+  if (!SizeofPointer()) {
+    correct++;
+  } else {
+    "Failed - SizeofPointer()\n";
+  }
+
+  if (!SizeofArrays()) {
+    correct++;
+  } else {
+    "Failed - SizeofArrays()\n";
+  }
+
+  PrintResult(correct,tests);
+  "====\n";
+  return 0;
+}

--- a/src/x86.c
+++ b/src/x86.c
@@ -2112,33 +2112,13 @@ void asmDataSection(Cctrl *cc, aoStr *buf) {
         Ast *ast = (Ast *)n->value;
         assert(ast->kind == AST_STRING);
 
-        char *label = ast->slabel->data;
-        char *str = ast->sval->data;
-        aoStr *escaped = aoStrAlloc(1<<10);
-
-        char *ptr = str;
-        while (*ptr) {
-            switch (*ptr) {
-                case '\\': aoStrCatPrintf(escaped,"\\"); break;
-                case '\n': aoStrCatPrintf(escaped,"\\n"); break;
-                case '\t': aoStrCatPrintf(escaped,"\\t"); break;
-                case '\r': aoStrCatPrintf(escaped,"\\r"); break;
-                case '\b': aoStrCatPrintf(escaped,"\\n"); break;
-                case '\v': aoStrCatPrintf(escaped,"\\v"); break;
-                default: aoStrPutChar(escaped,*ptr); break;
-            }
-            ptr++;
-        }
-
-        if (escaped->len) {
-            aoStrCatPrintf(buf,"%s:\n\t",label);
+        if (ast->sval->len) {
+            aoStrCatFmt(buf,"%S:\n\t",ast->slabel);
             aoStrCatPrintf(buf,
-                    ".string \"%s\\0\"\n\t"
+                    ".string \"%S\\0\"\n\t"
                     ".data\n\t"
-                    ".align 4\n"
-                    , escaped->data);
+                    ".align 4\n", ast->sval);
         }
-        aoStrRelease(escaped);
     }
     aoStrPutChar(buf,'\t');
     strMapIteratorRelease(it);

--- a/src/x86.c
+++ b/src/x86.c
@@ -2114,7 +2114,7 @@ void asmDataSection(Cctrl *cc, aoStr *buf) {
 
         if (ast->sval->len) {
             aoStrCatFmt(buf,"%S:\n\t",ast->slabel);
-            aoStrCatPrintf(buf,
+            aoStrCatFmt(buf,
                     ".string \"%S\\0\"\n\t"
                     ".data\n\t"
                     ".align 4\n", ast->sval);

--- a/src/x86.c
+++ b/src/x86.c
@@ -2103,22 +2103,18 @@ void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast* ast) {
 }
 
 void asmDataSection(Cctrl *cc, aoStr *buf) {
-    aoStrCatPrintf(buf, "sign_bit:\n\t.quad 0x8000000000000000\n");
-    aoStrCatPrintf(buf, "one_dbl:\n\t.double 1.0\n");
+    aoStrCatFmt(buf, "sign_bit:\n\t.quad 0x8000000000000000\n");
+    aoStrCatFmt(buf, "one_dbl:\n\t.double 1.0\n");
 
     StrMapIterator *it = strMapIteratorNew(cc->strs);
     StrMapNode *n = NULL;
     while ((n = strMapNext(it)) != NULL) {
         Ast *ast = (Ast *)n->value;
         assert(ast->kind == AST_STRING);
-
-        if (ast->sval->len) {
-            aoStrCatFmt(buf,"%S:\n\t",ast->slabel);
-            aoStrCatFmt(buf,
-                    ".string \"%S\\0\"\n\t"
-                    ".data\n\t"
-                    ".align 4\n", ast->sval);
-        }
+        aoStrCatFmt(buf,
+                "%S:\n\t"
+                ".asciz \"%S\"\n",
+                ast->slabel, ast->sval);
     }
     aoStrPutChar(buf,'\t');
     strMapIteratorRelease(it);


### PR DESCRIPTION
Need to test this on Linux before merging.

- `sizeof(...)` a string now calculates the length of the string returning the correct number.
- Removed escaping logic from `x86.c`, escaping logic should only happen in one place.
- Refactored out `escape_string` as it was not used and was highly confusing (I don't really know what it did)

Closes: #146 #151