### PR TITLE
Make cppcheck happy

### DIFF
--- a/src/aostr.c
+++ b/src/aostr.c
@@ -7,8 +7,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "ast.h"
 #include "aostr.h"
+#include "ast.h"
 #include "lexer.h"
 #include "memory.h"
 
@@ -33,21 +33,20 @@ aoStr *aoStrNew(void) {
     return aoStrAlloc(1 << 5);
 }
 
-void aoStrRelease(aoStr *buf) {
-    return;
+void aoStrRelease(const aoStr *buf) {
 }
 
-/* Get the underlying string, we do not free the `aoStr`... it will get 
- * collected later. This means we don't need to manually keep track of this 
+/* Get the underlying string, we do not free the `aoStr`... it will get
+ * collected later. This means we don't need to manually keep track of this
  * buffer */
-char *aoStrMove(aoStr *buf) {
+char *aoStrMove(const aoStr *buf) {
     char *buffer = buf->data;
     return buffer;
 }
 
 /* Grow the capacity of the string buffer by `additional` space */
-int aoStrExtendBuffer(aoStr *buf, size_t additional) {
-    size_t new_capacity = (buf->capacity*2) + additional;
+int aoStrExtendBuffer(aoStr *buf, const size_t additional) {
+    const size_t new_capacity = (buf->capacity * 2) + additional;
     assert(new_capacity > buf->capacity);
     if (new_capacity <= buf->capacity) {
         return -1;
@@ -57,7 +56,7 @@ int aoStrExtendBuffer(aoStr *buf, size_t additional) {
     if (tmp == NULL) {
         return 0;
     }
-    memcpy(tmp,buf->data,buf->capacity);
+    memcpy(tmp, buf->data, buf->capacity);
     buf->data = tmp;
     buf->capacity = new_capacity;
     return 1;
@@ -65,9 +64,9 @@ int aoStrExtendBuffer(aoStr *buf, size_t additional) {
 
 /* Only extend the buffer if the additional space required would overspill the
  * current allocated capacity of the buffer */
-static int aoStrExtendBufferIfNeeded(aoStr *buf, size_t additional) {
+static int aoStrExtendBufferIfNeeded(aoStr *buf, const size_t additional) {
     if ((buf->len + additional + 1) >= buf->capacity) {
-        return aoStrExtendBuffer(buf, additional+1);
+        return aoStrExtendBuffer(buf, additional + 1);
     }
     return 0;
 }
@@ -78,26 +77,26 @@ void aoStrToLowerCase(aoStr *buf) {
     }
 }
 
-void aoStrPutChar(aoStr *buf, char ch) {
+void aoStrPutChar(aoStr *buf, const char ch) {
     aoStrExtendBufferIfNeeded(buf, 10);
     buf->data[buf->len++] = ch;
     buf->data[buf->len] = '\0';
 }
 
-void aoStrRepeatChar(aoStr *buf, char ch, int times) {
+void aoStrRepeatChar(aoStr *buf, const char ch, const int times) {
     for (int i = 0; i < times; ++i) {
-        aoStrPutChar(buf,ch);
+        aoStrPutChar(buf, ch);
     }
 }
 
-int aoStrCmp(aoStr *b1, aoStr *b2) {
-    size_t l1 = b1->len;
-    size_t l2 = b2->len;
-    return l1==l2&&!memcmp(b1->data, b2->data, l1);
+int aoStrCmp(const aoStr *b1, const aoStr *b2) {
+    const size_t l1 = b1->len;
+    const size_t l2 = b2->len;
+    return l1 == l2 && !memcmp(b1->data, b2->data, l1);
 }
 
-aoStr *aoStrDupRaw(char *s, size_t len) {
-    size_t capacity = len+10;
+aoStr *aoStrDupRaw(const char *s, const size_t len) {
+    const size_t capacity = len + 10;
     aoStr *dupe = aoStrAlloc(capacity);
     memcpy(dupe->data, s, len);
     dupe->len = len;
@@ -106,7 +105,7 @@ aoStr *aoStrDupRaw(char *s, size_t len) {
     return dupe;
 }
 
-aoStr *aoStrDup(aoStr *buf) {
+aoStr *aoStrDup(const aoStr *buf) {
     aoStr *dupe = aoStrAlloc(buf->len);
     memcpy(dupe->data, buf->data, buf->len);
     dupe->len = buf->len;
@@ -115,14 +114,14 @@ aoStr *aoStrDup(aoStr *buf) {
     return dupe;
 }
 
-void aoStrCatLen(aoStr *buf, const void *d, size_t len) {
+void aoStrCatLen(aoStr *buf, const void *d, const size_t len) {
     aoStrExtendBufferIfNeeded(buf, len);
     memcpy(buf->data + buf->len, d, len);
     buf->len += len;
     buf->data[buf->len] = '\0';
 }
 
-void aoStrCatAoStr(aoStr *buf, aoStr *s2) {
+void aoStrCatAoStr(aoStr *buf, const aoStr *s2) {
     aoStrCatLen(buf, s2->data, s2->len);
 }
 
@@ -131,152 +130,250 @@ void aoStrCat(aoStr *buf, const void *d) {
     aoStrCatLen(buf, d, len);
 }
 
-void aoStrCatRepeat(aoStr *buf, char *str, int times) {
-    int len = strlen(str);
+void aoStrCatRepeat(aoStr *buf, const char *str, const int times) {
+    const int len = strlen(str);
     for (int i = 0; i < times; ++i) {
-        aoStrCatLen(buf,str,len);
+        aoStrCatLen(buf, str, len);
     }
 }
 
-char *aoStrEncodeChar(long op) {
-    static char buf[4];
-    switch(op) {
-    case '\\':               return "\\";
-    case '\n':               return "\\n";
-    case '\t':               return "\\t";
-    case '\r':               return "\\r";
-    case '\"':               return "&#34;";
-    case '\'':               return "&#39;";
-    case ' ':                return "&#32;";
-    case '>':                return "&#62;";
-    case '<':                return "&#60;";
-    case '&':                return "&#38;";
-    case '|':                return "&#124;";
-    case ';':                return "&#59;";
-    case '@':                return "&#64;";
-    case '=':                return "&#61;";
-    case '(':                return "&#40;";
-    case ')':                return "&#41;";
-    case '~':                return "&#126;";
-    case '^':                return "&#94;";
-    case '_':                return "&#65;";
-    case '!':                return "&#33;";
-    case '{':                return "&#123;";
-    case '}':                return "&#125;";
-    case '[':                return "&#91;";
-    case ']':                return "&#93;";
-    case '`':                return "&#96;";
-    case '*':                return "&#42;";
-    case '+':                return "&#43;";
-    case '-':                return "&#45;";
-    case '/':                return "&#47;";
-    case '%':                return "&#37;";
-    case '$':                return "&#36;";
-    case '#':                return "&#35;";
-    case ',':                return "&#44;";
-    case '.':                return "&#46;";
-    case '?':                return "&#63;";
-    case ':':                return "&#48;";
+char *aoStrEncodeChar(const long op) {
+    switch (op) {
+    case '\\':
+        return "\\";
+    case '\n':
+        return "\\n";
+    case '\t':
+        return "\\t";
+    case '\r':
+        return "\\r";
+    case '\"':
+        return "&#34;";
+    case '\'':
+        return "&#39;";
+    case ' ':
+        return "&#32;";
+    case '>':
+        return "&#62;";
+    case '<':
+        return "&#60;";
+    case '&':
+        return "&#38;";
+    case '|':
+        return "&#124;";
+    case ';':
+        return "&#59;";
+    case '@':
+        return "&#64;";
+    case '=':
+        return "&#61;";
+    case '(':
+        return "&#40;";
+    case ')':
+        return "&#41;";
+    case '~':
+        return "&#126;";
+    case '^':
+        return "&#94;";
+    case '_':
+        return "&#65;";
+    case '!':
+        return "&#33;";
+    case '{':
+        return "&#123;";
+    case '}':
+        return "&#125;";
+    case '[':
+        return "&#91;";
+    case ']':
+        return "&#93;";
+    case '`':
+        return "&#96;";
+    case '*':
+        return "&#42;";
+    case '+':
+        return "&#43;";
+    case '-':
+        return "&#45;";
+    case '/':
+        return "&#47;";
+    case '%':
+        return "&#37;";
+    case '$':
+        return "&#36;";
+    case '#':
+        return "&#35;";
+    case ',':
+        return "&#44;";
+    case '.':
+        return "&#46;";
+    case '?':
+        return "&#63;";
+    case ':':
+        return "&#48;";
 
-    case TK_EQU_EQU:         return "&#61;&#61;";
-    case TK_NOT_EQU:         return "&#33;&#61;";
-    case TK_LESS_EQU:        return "&#60;&#61;";
-    case TK_GREATER_EQU:     return "&#62;&#61;";      
-    case TK_AND_AND:         return "&#38;&#38;";
-    case TK_OR_OR:           return "&#124;&#124;";
-    case TK_SHL:             return "&#60;&#60;";
-    case TK_SHL_EQU:         return "&#60;&#60;&#61;";
-    case TK_SHR:             return "&#62;&#62;";
-    case TK_SHR_EQU:         return "&#62;&#62;&#61;";
-    case TK_MUL_EQU:         return "&#42;&#61;";
-    case TK_DIV_EQU:         return "&#47;&#61;";
-    case TK_OR_EQU:          return "&#124;&#61;";
-    case TK_XOR_EQU:         return "&#94;&#61;";
-    case TK_AND_EQU:         return "&#38;&#61;";
-    case TK_SUB_EQU:         return "&#45;&#61;";
-    case TK_ADD_EQU:         return "&#43;&#61;";
-    case TK_MOD_EQU:         return "&#37;&#61;";
-    case TK_ELLIPSIS:        return "&#48;&#48;&#48;";
-    case TK_ARROW:           return "&#45;&#62;";
-    case TK_PRE_PLUS_PLUS:   return "&#43;&#43;";
-    case TK_PLUS_PLUS:       return "&#43;&#43;";
-    case TK_PRE_MINUS_MINUS: return "&#45;&#45;";
-    case TK_MINUS_MINUS:     return "&#45;&#45;";
+    case TK_EQU_EQU:
+        return "&#61;&#61;";
+    case TK_NOT_EQU:
+        return "&#33;&#61;";
+    case TK_LESS_EQU:
+        return "&#60;&#61;";
+    case TK_GREATER_EQU:
+        return "&#62;&#61;";
+    case TK_AND_AND:
+        return "&#38;&#38;";
+    case TK_OR_OR:
+        return "&#124;&#124;";
+    case TK_SHL:
+        return "&#60;&#60;";
+    case TK_SHL_EQU:
+        return "&#60;&#60;&#61;";
+    case TK_SHR:
+        return "&#62;&#62;";
+    case TK_SHR_EQU:
+        return "&#62;&#62;&#61;";
+    case TK_MUL_EQU:
+        return "&#42;&#61;";
+    case TK_DIV_EQU:
+        return "&#47;&#61;";
+    case TK_OR_EQU:
+        return "&#124;&#61;";
+    case TK_XOR_EQU:
+        return "&#94;&#61;";
+    case TK_AND_EQU:
+        return "&#38;&#61;";
+    case TK_SUB_EQU:
+        return "&#45;&#61;";
+    case TK_ADD_EQU:
+        return "&#43;&#61;";
+    case TK_MOD_EQU:
+        return "&#37;&#61;";
+    case TK_ELLIPSIS:
+        return "&#48;&#48;&#48;";
+    case TK_ARROW:
+        return "&#45;&#62;";
+    case TK_PRE_PLUS_PLUS:
+    case TK_PLUS_PLUS:
+        return "&#43;&#43;";
+    case TK_PRE_MINUS_MINUS:
+    case TK_MINUS_MINUS:
+        return "&#45;&#45;";
     default: {
-        int len = snprintf(buf,sizeof(buf),"%c",(char)op);
+        static char buf[4];
+        const int len = snprintf(buf, sizeof(buf), "%c", (char)op);
         buf[len] = '\0';
         return buf;
     }
     }
 }
 
-aoStr *aoStrEncode(aoStr *buf) {
-    aoStr *outstr = aoStrAlloc(buf->capacity);
-    char *ptr = buf->data;
-    char *encoded;
+aoStr *aoStrEncode(const aoStr *buf) {
+    aoStr *out = aoStrAlloc(buf->capacity);
+    const char *ptr = buf->data;
 
-    if (buf == NULL) return outstr;
     while (*ptr) {
         if (*ptr == '\\') {
-            aoStrPutChar(outstr, '\\');
+            aoStrPutChar(out, '\\');
             switch (*ptr) {
-                case '\'': aoStrPutChar(outstr,'\''); break;
-                case '\\': aoStrPutChar(outstr, '\\'); break;
-                case '\"': aoStrPutChar(outstr, '\"'); break;
-                case '\b': aoStrPutChar(outstr, 'b'); break;
-                case '\n': aoStrPutChar(outstr, 'n'); break;
-                case '\t': aoStrPutChar(outstr, 't'); break;
-                case '\v': aoStrPutChar(outstr, 'v'); break;
-                case '\f': aoStrPutChar(outstr, 'f'); break;
-                case '\r': aoStrPutChar(outstr, 'r'); break;
+            case '\'':
+                aoStrPutChar(out, '\'');
+                break;
+            case '\\':
+                aoStrPutChar(out, '\\');
+                break;
+            case '\"':
+                aoStrPutChar(out, '\"');
+                break;
+            case '\b':
+                aoStrPutChar(out, 'b');
+                break;
+            case '\n':
+                aoStrPutChar(out, 'n');
+                break;
+            case '\t':
+                aoStrPutChar(out, 't');
+                break;
+            case '\v':
+                aoStrPutChar(out, 'v');
+                break;
+            case '\f':
+                aoStrPutChar(out, 'f');
+                break;
+            case '\r':
+                aoStrPutChar(out, 'r');
+                break;
+            default:;
             }
         } else {
-            encoded = aoStrEncodeChar(*ptr);
-            aoStrCat(outstr,encoded);
+            const char *encoded = aoStrEncodeChar(*ptr);
+            aoStrCat(out, encoded);
         }
         ptr++;
     }
-    return outstr;
+    return out;
 }
 
-aoStr *aoStrEscapeString(aoStr *buf) {
-    aoStr *outstr = aoStrAlloc(buf->capacity);
-    char *ptr = buf->data;
+aoStr *aoStrEscapeString(const aoStr *buf) {
+    if (buf == NULL)
+        return NULL;
 
-    if (buf == NULL) {
-        return outstr;
-    }
+    aoStr *out = aoStrAlloc(buf->capacity);
+    const char *ptr = buf->data;
 
     while (*ptr) {
         if (*ptr > 31 && *ptr != '\"' && *ptr != '\\') {
             switch (*ptr) {
-            case '$': aoStrCat(outstr,"\\$"); break;
-            case '`': aoStrCat(outstr,"\\`"); break;
-            default:  aoStrPutChar(outstr, *ptr); break;
+            case '$':
+                aoStrCat(out, "\\$");
+                break;
+            case '`':
+                aoStrCat(out, "\\`");
+                break;
+            default:
+                aoStrPutChar(out, *ptr);
+                break;
             }
         } else {
-            aoStrPutChar(outstr, '\\');
+            aoStrPutChar(out, '\\');
             switch (*ptr) {
-            case '\'': aoStrPutChar(outstr,'\''); break;
-            case '\\': aoStrPutChar(outstr, '\\'); break;
-            case '\"': aoStrPutChar(outstr, '\"'); break;
-            case '\b': aoStrPutChar(outstr, 'b'); break;
-            case '\n': aoStrPutChar(outstr, 'n'); break;
-            case '\t': aoStrPutChar(outstr, 't'); break;
-            case '\v': aoStrPutChar(outstr, 'v'); break;
-            case '\f': aoStrPutChar(outstr, 'f'); break;
-            case '\r': aoStrPutChar(outstr, 'r'); break;
+            case '\'':
+                aoStrPutChar(out, '\'');
+                break;
+            case '\\':
+                aoStrPutChar(out, '\\');
+                break;
+            case '\"':
+                aoStrPutChar(out, '\"');
+                break;
+            case '\b':
+                aoStrPutChar(out, 'b');
+                break;
+            case '\n':
+                aoStrPutChar(out, 'n');
+                break;
+            case '\t':
+                aoStrPutChar(out, 't');
+                break;
+            case '\v':
+                aoStrPutChar(out, 'v');
+                break;
+            case '\f':
+                aoStrPutChar(out, 'f');
+                break;
+            case '\r':
+                aoStrPutChar(out, 'r');
+                break;
             default:
-                aoStrCatPrintf(outstr, "u%04x", (unsigned int)*ptr);
+                aoStrCatPrintf(out, "u%04x", (unsigned int)*ptr);
                 break;
             }
         }
         ++ptr;
     }
-    return outstr;
+    return out;
 }
 
-void aoStrArrayRelease(aoStr **arr, int count) {
+void aoStrArrayRelease(aoStr **arr, const int count) {
     if (arr) {
         for (int i = 0; i < count; ++i) {
             aoStrRelease(arr[i]);
@@ -288,17 +385,17 @@ void aoStrArrayRelease(aoStr **arr, int count) {
 /**
  * Split into strings on delimiter
  */
-aoStr **aoStrSplit(char *to_split, char delimiter, int *_count) {
+aoStr **aoStrSplit(const char *to_split, const char delimiter, int *_count) {
     aoStr **outArr;
-    long start, end;
-    char *ptr = to_split;
+    long end;
+    const char *ptr = to_split;
 
     if (*ptr == delimiter) {
         ptr++;
     }
 
     int memslot = 5;
-    start = end = 0;
+    long start = end = 0;
     int arrsize = 0;
 
     if ((outArr = (aoStr **)malloc(sizeof(aoStr *) * memslot)) == NULL)
@@ -339,17 +436,18 @@ error:
     return NULL;
 }
 
-static char *mprintVaImpl(const char *fmt, va_list ap, size_t *_len, size_t *_allocated) {
+static char *mprintVaImpl(const char *fmt, va_list ap, size_t *_len,
+                          size_t *_allocated) {
     va_list copy;
 
     /* Probably big enough */
-    size_t fmt_len = strlen(fmt);
+    const size_t fmt_len = strlen(fmt);
     size_t bufferlen = 1024;
     if (fmt_len > bufferlen) {
         bufferlen = fmt_len;
     }
     int len = 0;
-    char *buf = aoStrBufferAlloc(sizeof(char) * bufferlen+1);
+    char *buf = aoStrBufferAlloc(sizeof(char) * bufferlen + 1);
 
     while (1) {
         va_copy(copy, ap);
@@ -371,20 +469,22 @@ static char *mprintVaImpl(const char *fmt, va_list ap, size_t *_len, size_t *_al
         break;
     }
 
-    if (_len) *_len = len;
-    if (_allocated) *_allocated = bufferlen;
+    if (_len)
+        *_len = len;
+    if (_allocated)
+        *_allocated = bufferlen;
     buf[len] = '\0';
     return buf;
 }
 
 char *mprintVa(const char *fmt, va_list ap, ssize_t *_len) {
-    return mprintVaImpl(fmt,ap,(size_t *)_len,NULL);
+    return mprintVaImpl(fmt, ap, (size_t *)_len, NULL);
 }
 
 static aoStr *aoStrPrintfVa(const char *fmt, va_list ap) {
     size_t len = 0;
     size_t capacity = 0;
-    char *new_buf = mprintVaImpl(fmt,ap,&len,&capacity);
+    char *new_buf = mprintVaImpl(fmt, ap, &len, &capacity);
     aoStr *buffer = _aoStrAlloc();
     buffer->data = new_buf;
     buffer->len = len;
@@ -395,10 +495,10 @@ static aoStr *aoStrPrintfVa(const char *fmt, va_list ap) {
 /* Allocating printf */
 char *mprintf(const char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    /* This is so we can use the pool allocator, and not have to deal with 
+    va_start(ap, fmt);
+    /* This is so we can use the pool allocator, and not have to deal with
      * freeing aribitary strings */
-    aoStr *buffer = aoStrPrintfVa(fmt, ap);
+    const aoStr *buffer = aoStrPrintfVa(fmt, ap);
     va_end(ap);
     return aoStrMove(buffer);
 }
@@ -407,103 +507,105 @@ void aoStrCatPrintf(aoStr *b, const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
 
-    aoStr *new_str = aoStrPrintfVa(fmt, ap);
-    aoStrCatAoStr(b,new_str);
+    const aoStr *new_str = aoStrPrintfVa(fmt, ap);
+    aoStrCatAoStr(b, new_str);
     aoStrRelease(new_str);
     va_end(ap);
 }
-
 
 /* For the happy path of strings this is very fast */
 void aoStrCatFmt(aoStr *buf, const char *fmt, ...) {
     va_list ap;
     const char *ptr = fmt;
-    va_start(ap,fmt);
+    va_start(ap, fmt);
 
     while (*ptr) {
         switch (*ptr) {
-            case '%': {
-                ptr++;
-                if (*ptr == '\0') return;
-                switch (*ptr) {
-                    case 's': {
-                        char *str = va_arg(ap,char*);
-                        aoStrCat(buf, str);
-                        break;
-                    }
+        case '%': {
+            ptr++;
+            if (*ptr == '\0') {
+                va_end(ap);
+                return;
+            }
+            switch (*ptr) {
+            case 's': {
+                const char *str = va_arg(ap, char *);
+                aoStrCat(buf, str);
+                break;
+            }
 
-                    case 'S': {
-                        aoStr *str = va_arg(ap, aoStr*);
-                        aoStrCatLen(buf, str->data, str->len);
-                        break;
-                    }
+            case 'S': {
+                const aoStr *str = va_arg(ap, aoStr *);
+                aoStrCatLen(buf, str->data, str->len);
+                break;
+            }
 
-                    case '.': {
-                        if (*(ptr+1) == '*' && *(ptr+2) == 's') {
-                            ssize_t len = va_arg(ap,ssize_t);
-                            char *str = va_arg(ap,char*);
-                            aoStrCatLen(buf,str,len);
-                            ptr += 2;
-                        } else {
-                            aoStrPutChar(buf,'.');
-                        }
-                        break;
-                    }
-
-                    case 'U': {
-                        size_t uint_ = va_arg(ap, size_t);
-                        aoStrCatPrintf(buf,"%zu",uint_);
-                        break;
-                    }
-
-                    case 'u': {
-                        unsigned int uint_ = va_arg(ap, unsigned int);
-                        aoStrCatPrintf(buf,"%u",uint_);
-                        break;
-                    }
-
-                    case 'I': {
-                        ssize_t int_ = va_arg(ap, ssize_t);
-                        aoStrCatPrintf(buf,"%lld",int_);
-                        break;
-                    }
-
-                    case 'i': {
-                        int int_ = va_arg(ap, int);
-                        aoStrCatPrintf(buf,"%d",int_);
-                        break;
-                    }
-
-                    case 'f': {
-                        double float_ = va_arg(ap, double);
-                        aoStrCatPrintf(buf,"%g",float_);
-                        break;
-                    }
-
-                    case 'c': {
-                        char ch = (char)va_arg(ap, int);
-                        aoStrPutChar(buf,ch);
-                        break;
-                    }
-
-                    case 'A': {
-                        Ast *ast = va_arg(ap, Ast*);
-                        aoStr *ast_str = astLValueToAoStr(ast,0);
-                        aoStrCatAoStr(buf,ast_str);
-                        break;
-                    }
-                    default: {
-                        /* Put the character, probably a %% */
-                        aoStrPutChar(buf,*ptr);
-                        break;
-                    }
+            case '.': {
+                if (*(ptr + 1) == '*' && *(ptr + 2) == 's') {
+                    ssize_t len = va_arg(ap, ssize_t);
+                    const char *str = va_arg(ap, char *);
+                    aoStrCatLen(buf, str, len);
+                    ptr += 2;
+                } else {
+                    aoStrPutChar(buf, '.');
                 }
                 break;
             }
-            default: {
-                aoStrPutChar(buf,*ptr);
+
+            case 'U': {
+                size_t uint_ = va_arg(ap, size_t);
+                aoStrCatPrintf(buf, "%zu", uint_);
                 break;
             }
+
+            case 'u': {
+                unsigned int uint_ = va_arg(ap, unsigned int);
+                aoStrCatPrintf(buf, "%u", uint_);
+                break;
+            }
+
+            case 'I': {
+                ssize_t int_ = va_arg(ap, ssize_t);
+                aoStrCatPrintf(buf, "%lld", int_);
+                break;
+            }
+
+            case 'i': {
+                int int_ = va_arg(ap, int);
+                aoStrCatPrintf(buf, "%d", int_);
+                break;
+            }
+
+            case 'f': {
+                double float_ = va_arg(ap, double);
+                aoStrCatPrintf(buf, "%g", float_);
+                break;
+            }
+
+            case 'c': {
+                char ch = (char)va_arg(ap, int);
+                aoStrPutChar(buf, ch);
+                break;
+            }
+
+            case 'A': {
+                const Ast *ast = va_arg(ap, Ast *);
+                const aoStr *ast_str = astLValueToAoStr(ast, 0);
+                aoStrCatAoStr(buf, ast_str);
+                break;
+            }
+            default: {
+                /* Put the character, probably a %% */
+                aoStrPutChar(buf, *ptr);
+                break;
+            }
+            }
+            break;
+        }
+        default: {
+            aoStrPutChar(buf, *ptr);
+            break;
+        }
         }
         ptr++;
     }
@@ -512,14 +614,14 @@ void aoStrCatFmt(aoStr *buf, const char *fmt, ...) {
 aoStr *aoStrPrintf(const char *fmt, ...) {
     va_list ap;
     va_start(ap, fmt);
-    aoStr *buffer = aoStrPrintfVa(fmt,ap);
+    aoStr *buffer = aoStrPrintfVa(fmt, ap);
     va_end(ap);
     return buffer;
 }
 
 aoStr *aoStrError(void) {
-    char *err = strerror(errno);
-    aoStr *str = aoStrDupRaw(err,strlen(err));
+    const char *err = strerror(errno);
+    aoStr *str = aoStrDupRaw(err, strlen(err));
     return str;
 }
 
@@ -529,14 +631,14 @@ aoStr *aoStrIntToHumanReadableBytes(long bytes) {
 
     if (bytes < 1024) {
         aoStrCatFmt(str, "%uB", bytes);
-    } else if (bytes < (1024*1024)) {
-        d = (double)bytes/(1024);
+    } else if (bytes < (1024 * 1024)) {
+        d = (double)bytes / (1024);
         aoStrCatPrintf(str, "%.2fK", d);
-    } else if (bytes < (1024LL*1024*1024)) {
-        d = (double)bytes/(1024*1024);
+    } else if (bytes < (1024LL * 1024 * 1024)) {
+        d = (double)bytes / (1024 * 1024);
         aoStrCatPrintf(str, "%.2fM", d);
-    } else if ((long long)bytes < (1024LL*1024*1024*1024)) {
-        d = (double)bytes/(1024LL*1024*1024);
+    } else if ((long long)bytes < (1024LL * 1024 * 1024 * 1024)) {
+        d = (double)bytes / (1024LL * 1024 * 1024);
         aoStrCatPrintf(str, "%.2fG", d);
     }
     return str;

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -7,9 +7,10 @@
 #ifndef AOSTR_H
 #define AOSTR_H
 
+#include <sys/types.h>
+
 #include <stdarg.h>
 #include <stddef.h>
-#include <sys/types.h>
 
 typedef struct aoStr aoStr;
 
@@ -21,30 +22,30 @@ typedef struct aoStr {
 
 aoStr *aoStrAlloc(size_t capacity);
 aoStr *aoStrNew(void);
-void aoStrRelease(aoStr *buf);
+void aoStrRelease(const aoStr *buf);
 
 int aoStrExtendBuffer(aoStr *buf, size_t additional);
 void aoStrToLowerCase(aoStr *buf);
 void aoStrPutChar(aoStr *buf, char ch);
 void aoStrRepeatChar(aoStr *buf, char ch, int times);
-int aoStrCmp(aoStr *b1, aoStr *b2);
-aoStr *aoStrDupRaw(char *s, size_t len);
-aoStr *aoStrDup(aoStr *buf);
+int aoStrCmp(const aoStr *b1, const aoStr *b2);
+aoStr *aoStrDupRaw(const char *s, size_t len);
+aoStr *aoStrDup(const aoStr *buf);
 
-char *aoStrMove(aoStr *buf);
+char *aoStrMove(const aoStr *buf);
 
 void aoStrCatLen(aoStr *buf, const void *d, size_t len);
-void aoStrCatAoStr(aoStr *buf, aoStr *s2);
+void aoStrCatAoStr(aoStr *buf, const aoStr *s2);
 void aoStrCat(aoStr *buf, const void *d);
-void aoStrCatRepeat(aoStr *buf, char *str, int times);
+void aoStrCatRepeat(aoStr *buf, const char *str, int times);
 void aoStrCatPrintf(aoStr *b, const char *fmt, ...);
 void aoStrCatFmt(aoStr *buf, const char *fmt, ...);
 aoStr *aoStrPrintf(const char *fmt, ...);
-aoStr *aoStrEscapeString(aoStr *buf);
-aoStr *aoStrEncode(aoStr *buf);
+aoStr *aoStrEscapeString(const aoStr *buf);
+aoStr *aoStrEncode(const aoStr *buf);
 
 void aoStrArrayRelease(aoStr **arr, int count);
-aoStr **aoStrSplit(char *to_split, char delimiter, int *count);
+aoStr **aoStrSplit(const char *to_split, char delimiter, int *count);
 char *mprintf(const char *fmt, ...);
 char *mprintVa(const char *fmt, va_list ap, ssize_t *_len);
 aoStr *aoStrError(void);

--- a/src/arena.h
+++ b/src/arena.h
@@ -6,8 +6,8 @@ typedef struct ArenaBlock {
     unsigned int capacity;
     unsigned int used;
     void *mem;
-    ArenaBlock *next; 
-} ArenaBlock; 
+    ArenaBlock *next;
+} ArenaBlock;
 
 typedef struct Arena {
     unsigned int block_capacity;
@@ -17,10 +17,10 @@ typedef struct Arena {
 } Arena;
 
 void arenaInit(Arena *arena, unsigned int capacity);
-void arenaClear(Arena *arena);
+void arenaClear(const Arena *arena);
 Arena *arenaNew(unsigned int capacity);
 void *arenaAlloc(Arena *arena, unsigned int size);
 void arenaRelease(Arena *arena);
-void arenaPrintStats(Arena *arena);
+void arenaPrintStats(const Arena *arena);
 
 #endif // MEMORY_ARENA_H__

--- a/src/ast.c
+++ b/src/ast.c
@@ -7,8 +7,8 @@
 #include "arena.h"
 #include "ast.h"
 #include "config.h"
-#include "list.h"
 #include "lexer.h"
+#include "list.h"
 #include "map.h"
 #include "memory.h"
 #include "util.h"
@@ -43,62 +43,79 @@ static AstType *astTypeAlloc(void) {
     return (AstType *)arenaAlloc(&ast_arena, sizeof(AstType));
 }
 
-AstType *ast_u8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=0};
-AstType *ast_i8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=1};
-AstType *ast_i16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=1};
-AstType *ast_u16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=0};
-AstType *ast_i32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=1};
-AstType *ast_u32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=0};
-AstType *ast_int_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=1};
-AstType *ast_uint_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=0};
+AstType *ast_u8_type = &(
+        AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL, .issigned = 0};
+AstType *ast_i8_type = &(
+        AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL, .issigned = 1};
+AstType *ast_i16_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL, .issigned = 1};
+AstType *ast_u16_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL, .issigned = 0};
+AstType *ast_i32_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL, .issigned = 1};
+AstType *ast_u32_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL, .issigned = 0};
+AstType *ast_int_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL, .issigned = 1};
+AstType *ast_uint_type = &(
+        AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL, .issigned = 0};
 
-AstType *ast_float_type = &(AstType){.kind = AST_TYPE_FLOAT, .size = 8, .ptr = NULL,.issigned=0};
-AstType *ast_void_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL,.issigned=0};
-AstType *ast_auto_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL,.issigned=0};
+AstType *ast_float_type = &(
+        AstType){.kind = AST_TYPE_FLOAT, .size = 8, .ptr = NULL, .issigned = 0};
+AstType *ast_void_type = &(
+        AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL, .issigned = 0};
+AstType *ast_auto_type = &(
+        AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL, .issigned = 0};
 
-Ast *ast_loop_sentinal = &(Ast){.kind = AST_GOTO, .type=NULL,
-    .slabel = &(aoStr){.data="loop_sentinal", .len=13, .capacity = 0}};
-Ast *placeholder_arg = &(Ast){ .kind = AST_PLACEHOLDER};
+Ast *ast_loop_sentinal = &(Ast){.kind = AST_GOTO,
+                                .type = NULL,
+                                .slabel = &(aoStr){.data = "loop_sentinal",
+                                                   .len = 13,
+                                                   .capacity = 0}};
+Ast *placeholder_arg = &(Ast){.kind = AST_PLACEHOLDER};
 
-Ast *ast_forever_sentinal = &(Ast){ .kind = AST_LITERAL,
-  .type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=1},
-  .i64 = 1 };
+Ast *ast_forever_sentinal = &(Ast){.kind = AST_LITERAL,
+                                   .type = &(AstType){.kind = AST_TYPE_INT,
+                                                      .size = 8,
+                                                      .ptr = NULL,
+                                                      .issigned = 1},
+                                   .i64 = 1};
 
 void _astToString(aoStr *str, Ast *ast, int depth);
 char *_astToStringRec(Ast *ast, int depth);
 
 Ast *astNew(void) {
     Ast *ast = astAlloc();
-    memset(ast,0,sizeof(Ast));
+    memset(ast, 0, sizeof(Ast));
     return ast;
 }
 
 AstType *astTypeNew(void) {
     AstType *ast_type = astTypeAlloc();
-    memset(ast_type,0,sizeof(AstType));
+    memset(ast_type, 0, sizeof(AstType));
     return ast_type;
 }
 
 Ast *astMakeForeverSentinal(void) {
     Ast *ast = astAlloc();
     AstType *type = astTypeAlloc();
-    memcpy(ast,ast_forever_sentinal,sizeof(Ast));
+    memcpy(ast, ast_forever_sentinal, sizeof(Ast));
     ast->type = type;
-    memcpy(ast->type,ast_forever_sentinal->type,sizeof(AstType));
+    memcpy(ast->type, ast_forever_sentinal->type, sizeof(AstType));
     return ast;
 }
 
-/* If we don't clone these then they end up getting mutated by every function 
+/* If we don't clone these then they end up getting mutated by every function
  * that uses them */
 Ast *astMakeLoopSentinal(void) {
     Ast *ast = astNew();
-    memcpy(ast,ast_loop_sentinal,sizeof(Ast));
+    memcpy(ast, ast_loop_sentinal, sizeof(Ast));
     return ast;
 }
 
-AstType *astTypeCopy(AstType *type) {
+AstType *astTypeCopy(const AstType *type) {
     AstType *copy = astTypeNew();
-    memcpy(copy,type,sizeof(AstType));
+    memcpy(copy, type, sizeof(AstType));
     return copy;
 }
 
@@ -112,7 +129,7 @@ Ast *astUnaryOperator(AstType *type, long kind, Ast *operand) {
 
 Ast *astBinaryOp(long operation, Ast *left, Ast *right, int *_is_err) {
     Ast *ast = astNew();
-    ast->type = astGetResultType(operation,left->type,right->type);  
+    ast->type = astGetResultType(operation, left->type, right->type);
 
     if (ast->type == NULL) {
         *_is_err = 1;
@@ -120,8 +137,8 @@ Ast *astBinaryOp(long operation, Ast *left, Ast *right, int *_is_err) {
 
     ast->kind = operation;
     if (operation != '=' &&
-            astConvertArray(left->type)->kind != AST_TYPE_POINTER &&
-            astConvertArray(right->type)->kind == AST_TYPE_POINTER) {
+        astConvertArray(left->type)->kind != AST_TYPE_POINTER &&
+        astConvertArray(right->type)->kind == AST_TYPE_POINTER) {
         ast->left = right;
         ast->right = left;
     } else {
@@ -172,12 +189,12 @@ aoStr *astMakeTmpName(void) {
 
 static int tmp_anonymous_label = 0;
 char *astAnnonymousLabel(void) {
-    /* Adding a space makes this an invalid name for other classes as no 
+    /* Adding a space makes this an invalid name for other classes as no
      * identifier can have spaces. */
-    return mprintf("cls_label %d",tmp_anonymous_label++);
+    return mprintf("cls_label %d", tmp_anonymous_label++);
 }
 
-Ast *astLVar(AstType *type, char *name, int len) {
+Ast *astLVar(AstType *type, const char *name, int len) {
     Ast *ast = astNew();
     ast->kind = AST_LVAR;
     ast->type = type;
@@ -185,7 +202,7 @@ Ast *astLVar(AstType *type, char *name, int len) {
     return ast;
 }
 
-Ast *astGVar(AstType *type, char *name, int len, int is_static) {
+Ast *astGVar(AstType *type, const char *name, int len, int is_static) {
     Ast *ast = astNew();
     ast->kind = AST_GVAR;
     ast->type = type;
@@ -195,14 +212,14 @@ Ast *astGVar(AstType *type, char *name, int len, int is_static) {
     return ast;
 }
 
-Ast *astString(char *str, int len, long real_len) {
+Ast *astString(const char *str, int len, long real_len) {
     Ast *ast = astNew();
     ast->kind = AST_STRING;
     if (len == 0) {
         ast->sval = aoStrPrintf("\\0");
         ast->real_len = 1;
     } else {
-        ast->sval = aoStrDupRaw(str,len);
+        ast->sval = aoStrDupRaw(str, len);
         ast->real_len = real_len;
     }
     ast->type = astMakeArrayType(ast_u8_type, ast->sval->len + 1);
@@ -210,7 +227,7 @@ Ast *astString(char *str, int len, long real_len) {
     return ast;
 }
 
-Ast *astFunctionCall(AstType *type, char *fname, int len, PtrVec *argv) {
+Ast *astFunctionCall(AstType *type, const char *fname, int len, PtrVec *argv) {
     Ast *ast = astNew();
     ast->type = type;
     ast->kind = AST_FUNCALL;
@@ -228,9 +245,8 @@ Ast *astFunctionDefaultParam(Ast *var, Ast *init) {
     return ast;
 }
 
-Ast *astFunctionPtrCall(AstType *type, char *fname, int len,
-                        PtrVec *argv, Ast *ref)
-{
+Ast *astFunctionPtrCall(AstType *type, const char *fname, int len, PtrVec *argv,
+                        Ast *ref) {
     Ast *ast = astNew();
     ast->type = type;
     ast->kind = AST_FUNPTR_CALL;
@@ -240,7 +256,7 @@ Ast *astFunctionPtrCall(AstType *type, char *fname, int len,
     return ast;
 }
 
-Ast *astFunctionPtr(AstType *type, char *fname, int len, PtrVec *params) {
+Ast *astFunctionPtr(AstType *type, const char *fname, int len, PtrVec *params) {
     Ast *ast = astNew();
     ast->type = type;
     ast->kind = AST_FUNPTR;
@@ -250,9 +266,8 @@ Ast *astFunctionPtr(AstType *type, char *fname, int len, PtrVec *params) {
     return ast;
 }
 
-Ast *astFunction(AstType *type, char *fname, int len, PtrVec *params, Ast *body,
-                 List *locals, int has_var_args)
-{
+Ast *astFunction(AstType *type, const char *fname, int len, PtrVec *params,
+                 Ast *body, List *locals, int has_var_args) {
     Ast *ast = astNew();
     ast->type = type;
     type->has_var_args = has_var_args;
@@ -307,12 +322,12 @@ static void astJumpTableSort(Ast **cases, int high, int low) {
         }
         cases[high] = cases[idx];
         cases[idx] = pivot;
-        astJumpTableSort(cases,high,idx+1);
-        astJumpTableSort(cases,idx-1,low);
+        astJumpTableSort(cases, high, idx + 1);
+        astJumpTableSort(cases, idx - 1, low);
     }
 }
 
-/* For cases that are stacked remove their individual labels, merging them 
+/* For cases that are stacked remove their individual labels, merging them
  * with their neighbours */
 static void astCasesCompress(Ast **cases, int size) {
     aoStr *label = NULL;
@@ -321,7 +336,8 @@ static void astCasesCompress(Ast **cases, int size) {
         label = _case->case_label;
         while (listEmpty(_case->case_asts)) {
             i++;
-            if (i == size) break;
+            if (i == size)
+                break;
             _case = cases[i];
             _case->case_label = label;
         }
@@ -330,17 +346,17 @@ static void astCasesCompress(Ast **cases, int size) {
 }
 
 Ast *astSwitch(Ast *cond, PtrVec *cases, Ast *case_default,
-        aoStr *case_end_label, int switch_bounds_checked)
-{
+               aoStr *case_end_label, int switch_bounds_checked) {
     Ast *ast = astNew();
     Ast **jump_table_order = (Ast **)malloc(sizeof(Ast *) * cases->size);
 
     /* Sorting the cases in a separate array allows us to generate assembly
-     * code that matches the ordering of how the code was written and 
+     * code that matches the ordering of how the code was written and
      * preserve the Ast */
-    memcpy(jump_table_order,(Ast **)cases->entries,cases->size * sizeof(Ast*));
-    astCasesCompress(jump_table_order,cases->size);
-    astJumpTableSort(jump_table_order,cases->size-1,0);
+    memcpy(jump_table_order, (Ast **)cases->entries,
+           cases->size * sizeof(Ast *));
+    astCasesCompress(jump_table_order, cases->size);
+    astJumpTableSort(jump_table_order, cases->size - 1, 0);
 
     ast->kind = AST_SWITCH;
     ast->switch_cond = cond;
@@ -352,7 +368,8 @@ Ast *astSwitch(Ast *cond, PtrVec *cases, Ast *case_default,
     return ast;
 }
 
-Ast *astCase(aoStr *case_label, long case_begin, long case_end, List *case_asts) {
+Ast *astCase(aoStr *case_label, long case_begin, long case_end,
+             List *case_asts) {
     Ast *ast = astNew();
     ast->type = ast_int_type;
     ast->kind = AST_CASE;
@@ -367,20 +384,19 @@ Ast *astDefault(aoStr *case_label, List *case_asts) {
     Ast *ast = astNew();
     ast->kind = AST_DEFAULT;
     ast->case_label = case_label;
-    ast->case_asts  = case_asts;
+    ast->case_asts = case_asts;
     return ast;
 }
 
-Ast *astJump(char *name, int len) {
+Ast *astJump(const char *name, int len) {
     Ast *ast = astNew();
     ast->kind = AST_JUMP;
-    ast->jump_label = aoStrDupRaw(name,len);
+    ast->jump_label = aoStrDupRaw(name, len);
     return ast;
 }
 
 Ast *astFor(Ast *init, Ast *cond, Ast *step, Ast *body, aoStr *for_begin,
-        aoStr *for_middle, aoStr *for_end)
-{
+            aoStr *for_middle, aoStr *for_end) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_FOR;
@@ -394,9 +410,8 @@ Ast *astFor(Ast *init, Ast *cond, Ast *step, Ast *body, aoStr *for_begin,
     return ast;
 }
 
-Ast *astDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin, 
-        aoStr *while_end)
-{
+Ast *astDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
+                aoStr *while_end) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_DO_WHILE;
@@ -407,9 +422,8 @@ Ast *astDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
     return ast;
 }
 
-Ast *astWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin, 
-        aoStr *while_end)
-{
+Ast *astWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
+              aoStr *while_end) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_WHILE;
@@ -421,7 +435,7 @@ Ast *astWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
 }
 
 /* Duplicates the label */
-Ast *astContinue(aoStr *continue_label) {
+Ast *astContinue(const aoStr *continue_label) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_CONTINUE;
@@ -429,9 +443,9 @@ Ast *astContinue(aoStr *continue_label) {
     return ast;
 }
 
-/* XXX: reference count string? 
+/* XXX: reference count string?
  * Duplicates the label */
-Ast *astBreak(aoStr *break_label) {
+Ast *astBreak(const aoStr *break_label) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_BREAK;
@@ -505,9 +519,9 @@ AstType *astMakeFunctionType(AstType *rettype, PtrVec *param_types) {
     return type;
 }
 
-AstType *astMakeClassField(AstType *type, int offset) {
+AstType *astMakeClassField(const AstType *type, int offset) {
     AstType *field_type = astTypeNew();
-    memcpy(field_type,type,sizeof(AstType));
+    memcpy(field_type, type, sizeof(AstType));
     field_type->clsname = NULL;
     field_type->offset = offset;
     field_type->size = type->size;
@@ -523,7 +537,8 @@ Ast *astClassRef(AstType *type, Ast *cls, char *field_name) {
     return ref;
 }
 
-AstType *astClassType(StrMap *fields, aoStr *clsname, int size, int is_intrinsic) {
+AstType *astClassType(StrMap *fields, aoStr *clsname, int size,
+                      int is_intrinsic) {
     AstType *ref = astTypeNew();
     ref->kind = AST_TYPE_CLASS;
     ref->fields = fields;
@@ -559,9 +574,8 @@ Ast *astAsmFunctionDef(aoStr *asm_fname, aoStr *asm_stmt) {
     return ast;
 }
 
-Ast *astAsmFunctionBind(AstType *rettype, aoStr *asm_fname,
-                        aoStr *fname, PtrVec *params)
-{
+Ast *astAsmFunctionBind(AstType *rettype, aoStr *asm_fname, aoStr *fname,
+                        PtrVec *params) {
     Ast *ast = astNew();
     ast->kind = AST_ASM_FUNC_BIND;
     ast->fname = fname;
@@ -582,9 +596,8 @@ Ast *astAsmFunctionCall(AstType *rettype, aoStr *asm_fname, PtrVec *argv) {
 
 int astIsVarArg(Ast *ast) {
     if (ast->kind == AST_LVAR) {
-        return ast->type->has_var_args == 1 && 
-               ast->lname->len == 4 &&
-               !memcmp(ast->lname->data, str_lit("argv"));
+        return ast->type->has_var_args == 1 && ast->lname->len == 4 &&
+                !memcmp(ast->lname->data, str_lit("argv"));
     }
     return 0;
 }
@@ -594,8 +607,8 @@ Ast *astVarArgs(void) {
     ast->kind = AST_VAR_ARGS;
     ast->type = NULL;
     AstType *int_clone = astTypeCopy(ast_int_type);
-    ast->argc = astLVar(int_clone,"argc",4);
-    ast->argv = astLVar(astMakeArrayType(int_clone,0),"argv",4);
+    ast->argc = astLVar(int_clone, "argc", 4);
+    ast->argv = astLVar(astMakeArrayType(int_clone, 0), "argv", 4);
     ast->argv->type->has_var_args = 1;
     ast->argc->type->has_var_args = 1;
     return ast;
@@ -605,8 +618,11 @@ Ast *astGlobalCmdArgs(void) {
     Ast *ast = astNew();
     ast->kind = AST_VAR_ARGS;
     ast->type = NULL;
-    ast->argc = astDecl(astGVar(ast_int_type,"argc",4,0),NULL);
-    ast->argv = astDecl(astGVar(astMakePointerType(astMakePointerType(ast_u8_type)),"argv",4,0),NULL);
+    ast->argc = astDecl(astGVar(ast_int_type, "argc", 4, 0), NULL);
+    ast->argv = astDecl(astGVar(astMakePointerType(
+                                        astMakePointerType(ast_u8_type)),
+                                "argv", 4, 0),
+                        NULL);
     return ast;
 }
 
@@ -618,60 +634,65 @@ Ast *astCast(Ast *var, AstType *to) {
     return ast;
 }
 
-Ast *astComment(char *comment, int len) {
+Ast *astComment(const char *comment, int len) {
     Ast *ast = astNew();
     ast->type = NULL;
     ast->kind = AST_COMMENT;
-    printf("astComment(): %.*s\n",len,comment);
+    printf("astComment(): %.*s\n", len, comment);
     ast->sval = aoStrDupRaw(comment, len);
     return ast;
 }
 
-aoStr *astNormaliseFunctionName(char *fname) {
+aoStr *astNormaliseFunctionName(const char *fname) {
     aoStr *newfn = aoStrNew();
 #if IS_BSD
     if (fname[0] != '_') {
         aoStrPutChar(newfn, '_');
     }
 #endif
-    aoStrCatPrintf(newfn,fname);
+    aoStrCatPrintf(newfn, fname);
     /* XXX: Dynamically create main function */
     return newfn;
 }
 
 int astIsAssignment(long op) {
     switch (op) {
-        case '=':
-        case TK_SHL_EQU:
-        case TK_SHR_EQU:
-        case TK_OR_EQU:
-        case TK_AND_EQU:
-        case TK_ADD_EQU:
-        case TK_SUB_EQU:
-        case TK_MUL_EQU:
-        case TK_DIV_EQU:
-        case TK_MOD_EQU:
-        /* These can be treated as short hand expressions for */
-        case TK_PLUS_PLUS:
-        case TK_PRE_PLUS_PLUS:
-        case TK_MINUS_MINUS:
-        case TK_PRE_MINUS_MINUS:
-            return 1;
-        default:
-            return 0;
+    case '=':
+    case TK_SHL_EQU:
+    case TK_SHR_EQU:
+    case TK_OR_EQU:
+    case TK_AND_EQU:
+    case TK_ADD_EQU:
+    case TK_SUB_EQU:
+    case TK_MUL_EQU:
+    case TK_DIV_EQU:
+    case TK_MOD_EQU:
+    /* These can be treated as short hand expressions for */
+    case TK_PLUS_PLUS:
+    case TK_PRE_PLUS_PLUS:
+    case TK_MINUS_MINUS:
+    case TK_PRE_MINUS_MINUS:
+        return 1;
+    default:
+        return 0;
     }
 }
 
 int astIsValidPointerOp(long op) {
     switch (op) {
-        case '-': case '+':
-        case '<': case TK_LESS_EQU:
-        case '>': case TK_GREATER_EQU:
-        case TK_EQU_EQU: case TK_NOT_EQU:
-        case TK_OR_OR: case TK_AND_AND:    
-            return 1;
-        default:
-            return 0;
+    case '-':
+    case '+':
+    case '<':
+    case TK_LESS_EQU:
+    case '>':
+    case TK_GREATER_EQU:
+    case TK_EQU_EQU:
+    case TK_NOT_EQU:
+    case TK_OR_OR:
+    case TK_AND_AND:
+        return 1;
+    default:
+        return 0;
     }
 }
 
@@ -725,9 +746,8 @@ start_routine:
         if (!astIsValidPointerOp(op)) {
             goto error;
         }
-        if (op != '+' && op != '-'
-                && op != TK_EQU_EQU &&
-                op != TK_NOT_EQU && op != TK_OR_OR && op != TK_AND_AND) {
+        if (op != '+' && op != '-' && op != TK_EQU_EQU && op != TK_NOT_EQU &&
+            op != TK_OR_OR && op != TK_AND_AND) {
             goto error;
         }
 
@@ -795,7 +815,8 @@ error:
 }
 
 AstType *astTypeCheck(AstType *expected, Ast *ast, long op) {
-    if (expected != NULL && ast == NULL) return NULL;
+    if (expected != NULL && ast == NULL)
+        return NULL;
 
     AstType *original_actual = ast->type;
     AstType *actual;
@@ -820,7 +841,8 @@ check_type:
         goto out;
     }
 
-    if ((e->kind == AST_TYPE_POINTER || e->kind == AST_TYPE_FUNC) && a->kind == AST_TYPE_INT) {
+    if ((e->kind == AST_TYPE_POINTER || e->kind == AST_TYPE_FUNC) &&
+        a->kind == AST_TYPE_INT) {
         if (ast->kind == AST_LITERAL && ast->i64 == 0) {
             ret = e;
             goto out;
@@ -834,13 +856,17 @@ check_type:
             }
             goto out;
         }
-    } else if (e->kind == AST_TYPE_POINTER && a->kind != AST_TYPE_POINTER) {
+    }
+
+    if (e->kind == AST_TYPE_POINTER && a->kind != AST_TYPE_POINTER) {
         if (a->kind == AST_TYPE_VOID && actual->kind == AST_TYPE_POINTER) {
             ret = e;
             goto out;
         }
         goto out;
-    } else if (a->kind == AST_TYPE_POINTER && e->kind != AST_TYPE_POINTER) {
+    }
+
+    if (a->kind == AST_TYPE_POINTER && e->kind != AST_TYPE_POINTER) {
         /* this is a generic pointer */
         if (e->kind == AST_TYPE_VOID && expected->kind == AST_TYPE_POINTER) {
             ret = expected;
@@ -848,132 +874,158 @@ check_type:
         } else {
             goto out;
         }
-    } else if (e->kind == AST_TYPE_POINTER && a->kind == AST_TYPE_POINTER) {
+    }
+
+    if (e->kind == AST_TYPE_POINTER && a->kind == AST_TYPE_POINTER) {
         e = e->ptr;
         a = a->ptr;
         goto check_type;
-    } else if (astIsIntType(e) && astIsIntType(a)) {
+    }
+
+    if (astIsIntType(e) && astIsIntType(a)) {
         ret = e;
         goto out;
-    } else if (astIsFloatType(e) && astIsFloatType(a)) {
+    }
+
+    if (astIsFloatType(e) && astIsFloatType(a)) {
         ret = e;
         goto out;
-    } else if (astIsFloatType(e) && astIsIntType(a)) {
+    }
+
+    if (astIsFloatType(e) && astIsIntType(a)) {
         ret = e;
         goto out;
-    } else if (e->kind == a->kind) {
+    }
+
+    if (e->kind == a->kind) {
         ret = e;
         goto out;
-    } else if (e->kind != a->kind) {
-        if (expected->kind == AST_TYPE_POINTER && actual->kind == AST_TYPE_POINTER) {
-            if (e->kind == AST_TYPE_VOID || a->kind == AST_TYPE_VOID) {
-                ret = e;
-                goto out;
-            } else {
-                goto out;
-            }
-        } else if (e->kind == AST_TYPE_CLASS && e->is_intrinsic && astIsIntType(a)) {
+    }
+
+    if (expected->kind == AST_TYPE_POINTER &&
+        actual->kind == AST_TYPE_POINTER) {
+        if (e->kind == AST_TYPE_VOID || a->kind == AST_TYPE_VOID) {
             ret = e;
-            goto out;
-        } 
+        }
+        goto out;
+    }
+
+    if (e->kind == AST_TYPE_CLASS && e->is_intrinsic && astIsIntType(a)) {
+        ret = e;
     }
 
 out:
     return ret;
 }
 
-int astIsFloatType(AstType *type) {
+int astIsFloatType(const AstType *type) {
     return type->kind == AST_TYPE_FLOAT;
 }
 
-int astIsIntType(AstType *type) {
+int astIsIntType(const AstType *type) {
+    if (type == NULL)
+        return 0;
+
     switch (type->kind) {
     case AST_TYPE_INT:
     case AST_TYPE_CHAR:
         return 1;
-    default: return 0;
+    default:
+        return 0;
     }
 }
 
 void astStringEndStmt(aoStr *str) {
-    if (str->data[str->len-1] != '\n') {
+    if (str->data[str->len - 1] != '\n') {
         aoStrPutChar(str, '\n');
     }
 }
 
-void astUnaryOpToString(aoStr *str, char *op, Ast *ast,int depth) {
+void astUnaryOpToString(aoStr *str, char *op, const Ast *ast, int depth) {
     aoStrCatPrintf(str, "<unary_expr> %s\n", op);
-    _astToString(str, ast->operand, depth+1);
+    _astToString(str, ast->operand, depth + 1);
     astStringEndStmt(str);
 }
 
-void astBinaryOpToString(aoStr *str, char *op, Ast *ast, int depth) {
+void astBinaryOpToString(aoStr *str, char *op, const Ast *ast, int depth) {
     aoStrCatPrintf(str, "<binary_expr> %s\n", op);
-    _astToString(str, ast->left, depth+1);
+    _astToString(str, ast->left, depth + 1);
     astStringEndStmt(str);
     if (ast->right) {
-        _astToString(str, ast->right, depth+1);
+        _astToString(str, ast->right, depth + 1);
         astStringEndStmt(str);
     }
 }
 
-int astIsClassPointer(AstType *type) {
+int astIsClassPointer(const AstType *type) {
     return type && type->kind == AST_TYPE_POINTER &&
-           type->ptr->kind == AST_TYPE_CLASS;
+            type->ptr->kind == AST_TYPE_CLASS;
 }
 
-int astIsUnionPointer(AstType *type) {
+int astIsUnionPointer(const AstType *type) {
     return type && type->kind == AST_TYPE_POINTER &&
-           type->ptr->kind == AST_TYPE_UNION;
+            type->ptr->kind == AST_TYPE_UNION;
 }
 
-int astIsLabelMatch(Ast *ast, aoStr *goto_label) {
+int astIsLabelMatch(const Ast *ast, const aoStr *goto_label) {
     return ast->kind == AST_LABEL &&
-           aoStrCmp(goto_label, astHackedGetLabel(ast));
+            aoStrCmp(goto_label, astHackedGetLabel(ast));
 }
 
-static aoStr *astTypeToAoStrInternal(AstType *type) {
+static aoStr *astTypeToAoStrInternal(const AstType *type) {
     aoStr *str = aoStrNew();
 
     switch (type->kind) {
     case AST_TYPE_VOID:
         aoStrCatPrintf(str, "U0");
         return str;
-    
+
     case AST_TYPE_INT:
         switch (type->size) {
-            case 0:
-                if (type->issigned) aoStrCatPrintf(str, "I0");
-                else                aoStrCatPrintf(str, "U0");
-                break;
-            case 1:
-                if (type->issigned) aoStrCatPrintf(str, "I8");
-                else                aoStrCatPrintf(str, "U8");
-                break;
-            case 2:
-                if (type->issigned) aoStrCatPrintf(str, "I16");
-                else                aoStrCatPrintf(str, "U16");
-                break;
-            case 4:
-                if (type->issigned) aoStrCatPrintf(str, "I32");
-                else                aoStrCatPrintf(str, "U32");
-                break;
-            case 8:
-                if (type->issigned) aoStrCatPrintf(str, "I64");
-                else                aoStrCatPrintf(str, "U64");
-                break;
-            default: loggerPanic("Unknown integer size: %d\n", type->size);
-
+        case 0:
+            if (type->issigned)
+                aoStrCatPrintf(str, "I0");
+            else
+                aoStrCatPrintf(str, "U0");
+            break;
+        case 1:
+            if (type->issigned)
+                aoStrCatPrintf(str, "I8");
+            else
+                aoStrCatPrintf(str, "U8");
+            break;
+        case 2:
+            if (type->issigned)
+                aoStrCatPrintf(str, "I16");
+            else
+                aoStrCatPrintf(str, "U16");
+            break;
+        case 4:
+            if (type->issigned)
+                aoStrCatPrintf(str, "I32");
+            else
+                aoStrCatPrintf(str, "U32");
+            break;
+        case 8:
+            if (type->issigned)
+                aoStrCatPrintf(str, "I64");
+            else
+                aoStrCatPrintf(str, "U64");
+            break;
+        default:
+            loggerPanic("Unknown integer size: %d\n", type->size);
         }
         return str;
-    
+
     case AST_TYPE_CHAR:
-        if (type->issigned) aoStrCatPrintf(str, "I8");
-        else                aoStrCatPrintf(str, "U8");
+        if (type->issigned)
+            aoStrCatPrintf(str, "I8");
+        else
+            aoStrCatPrintf(str, "U8");
         return str;
 
     case AST_TYPE_FLOAT:
-        aoStrCatLen(str,str_lit("F64"));
+        aoStrCatLen(str, str_lit("F64"));
         return str;
 
     case AST_TYPE_POINTER: {
@@ -984,9 +1036,11 @@ static aoStr *astTypeToAoStrInternal(AstType *type) {
 
     case AST_TYPE_ARRAY: {
         if (type->size == -1 && type->ptr->clsname != NULL) {
-            aoStrCatPrintf(str, "%s[%s]", astTypeToString(type->ptr), type->ptr->clsname->data);
+            aoStrCatPrintf(str, "%s[%s]", astTypeToString(type->ptr),
+                           type->ptr->clsname->data);
         } else {
-            aoStrCatPrintf(str, "%s[%d]", astTypeToString(type->ptr), type->size);
+            aoStrCatPrintf(str, "%s[%d]", astTypeToString(type->ptr),
+                           type->size);
         }
         return str;
     }
@@ -1010,7 +1064,7 @@ static aoStr *astTypeToAoStrInternal(AstType *type) {
     }
 
     case AST_TYPE_AUTO:
-        aoStrCatPrintf(str,str_lit("auto"));
+        aoStrCatPrintf(str, str_lit("auto"));
         return str;
 
     default:
@@ -1018,11 +1072,11 @@ static aoStr *astTypeToAoStrInternal(AstType *type) {
     }
 }
 
-aoStr *astTypeToAoStr(AstType *type) {
+aoStr *astTypeToAoStr(const AstType *type) {
     aoStr *str_type = astTypeToAoStrInternal(type);
     if (str_type->data[str_type->len - 1] == '*') {
         /* move the stars to the end of the string
-         * 
+         *
          * 'SomeType**' -> 'SomeType **'
          *  1) 'SomeType** '
          *  2) 'SomeType** '
@@ -1041,12 +1095,12 @@ aoStr *astTypeToAoStr(AstType *type) {
     return str_type;
 }
 
-char *astTypeToString(AstType *type) {
-    aoStr *str_type = astTypeToAoStr(type);
+char *astTypeToString(const AstType *type) {
+    const aoStr *str_type = astTypeToAoStr(type);
     return aoStrMove(str_type);
 }
 
-aoStr *astTypeToColorAoStr(AstType *type) {
+aoStr *astTypeToColorAoStr(const AstType *type) {
     aoStr *str = astTypeToAoStr(type);
     if (!isatty(STDOUT_FILENO)) {
         return str;
@@ -1054,7 +1108,7 @@ aoStr *astTypeToColorAoStr(AstType *type) {
 
     aoStr *buf = aoStrNew();
     int star_count = 0;
-    if (str->data[str->len-1] == '*') {
+    if (str->data[str->len - 1] == '*') {
         ssize_t idx = str->len - 1;
         while (str->data[idx] == '*') {
             idx--;
@@ -1064,7 +1118,7 @@ aoStr *astTypeToColorAoStr(AstType *type) {
         str->data[str->len] = '\0';
     }
 
-    aoStrCatPrintf(buf,"\033[0;34m%s\033[0m",str->data);
+    aoStrCatPrintf(buf, "\033[0;34m%s\033[0m", str->data);
     if (star_count) {
         aoStrPutChar(buf, ' ');
         while (star_count > 0) {
@@ -1075,84 +1129,90 @@ aoStr *astTypeToColorAoStr(AstType *type) {
     return buf;
 }
 
-char *astTypeToColorString(AstType *type) {
-    aoStr *color_type = astTypeToColorAoStr(type);
+char *astTypeToColorString(const AstType *type) {
+    const aoStr *color_type = astTypeToColorAoStr(type);
     return aoStrMove(color_type);
 }
 
-char *astFunctionNameToString(AstType *rettype, char *fname, int len) {
+char *astFunctionNameToString(const AstType *rettype, const char *fname,
+                              int len) {
     aoStr *str = aoStrNew();
-    aoStr *tmp = astTypeToColorAoStr(rettype);
+    const aoStr *tmp = astTypeToColorAoStr(rettype);
 
     /* Add type definition */
-    aoStrCatLen(str,tmp->data,tmp->len);
+    aoStrCatLen(str, tmp->data, tmp->len);
     if (tmp->data[tmp->len - 1] != '*') {
-        aoStrPutChar(str,' ');
+        aoStrPutChar(str, ' ');
     }
 
     /* Add the actual function name */
-    aoStrCatLen(str,fname,len);
+    aoStrCatLen(str, fname, len);
 
     return aoStrMove(str);
 }
 
-static char *astParamsToString(PtrVec *params) {
+static char *astParamsToString(const PtrVec *params) {
     aoStr *str = aoStrNew();
     char *tmp;
     if (params->size == 0) {
         tmp = astTypeToColorString(ast_void_type);
-        aoStrCatPrintf(str,"%s",tmp);
+        aoStrCatPrintf(str, "%s", tmp);
     } else {
         for (ssize_t i = 0; i < params->size; ++i) {
-            Ast *param = params->entries[i];
-            int is_last = i+1 == params->size;
+            const Ast *param = params->entries[i];
+            int is_last = i + 1 == params->size;
             if (param->kind == AST_VAR_ARGS) {
-                if (!is_last) aoStrCatPrintf(str,"..., ");
-                else          aoStrCatPrintf(str,"..."); 
+                if (!is_last)
+                    aoStrCatPrintf(str, "..., ");
+                else
+                    aoStrCatPrintf(str, "...");
             } else {
                 tmp = astTypeToString(param->type);
-                if (!is_last) aoStrCatPrintf(str,"%s, ",tmp);
-                else          aoStrCatPrintf(str,"%s",tmp); 
+                if (!is_last)
+                    aoStrCatPrintf(str, "%s, ", tmp);
+                else
+                    aoStrCatPrintf(str, "%s", tmp);
             }
         }
     }
     return aoStrMove(str);
 }
 
-static char *astFunctionToStringInternal(Ast *func, AstType *type) {
+static char *astFunctionToStringInternal(const Ast *func, const AstType *type) {
     aoStr *str = aoStrNew();
     char *strparams = NULL;
 
-    aoStr *tmp = astTypeToColorAoStr(type);
+    const aoStr *tmp = astTypeToColorAoStr(type);
     if (tmp->data[tmp->len - 1] == '*') {
-        aoStrCatPrintf(str,"%s%s",tmp->data,func->fname->data);
+        aoStrCatPrintf(str, "%s%s", tmp->data, func->fname->data);
     } else {
-        aoStrCatPrintf(str,"%s %s",tmp->data,func->fname->data);
+        aoStrCatPrintf(str, "%s %s", tmp->data, func->fname->data);
     }
 
     switch (func->kind) {
-        case AST_FUNCALL:
-        case AST_FUNPTR_CALL:
-        case AST_ASM_FUNCALL:
-            strparams = astParamsToString(func->args);
-            break;
+    case AST_FUNCALL:
+    case AST_FUNPTR_CALL:
+    case AST_ASM_FUNCALL:
+        strparams = astParamsToString(func->args);
+        break;
 
-        case AST_FUNC:
-        case AST_FUN_PROTO:
-            strparams = astParamsToString(func->params);
-            break;
+    case AST_FUNC:
+    case AST_FUN_PROTO:
+        strparams = astParamsToString(func->params);
+        break;
+    default:;
     }
 
     if (strparams) {
-        aoStrCatPrintf(str,"(%s)",strparams);
+        aoStrCatPrintf(str, "(%s)", strparams);
     } else {
-        aoStrCatPrintf(str,"(U0)");
+        aoStrCatPrintf(str, "(U0)");
     }
     return aoStrMove(str);
 }
 
-char *astFunctionToString(Ast *func) {
-    return astFunctionToStringInternal(func,func->type->rettype);
+char *astFunctionToString(const Ast *func) {
+    return astFunctionToStringInternal(func, func->type->rettype);
 }
 
 void _astToString(aoStr *str, Ast *ast, int depth) {
@@ -1164,80 +1224,81 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
 
     Ast *param;
     List *node;
-    aoStr *escaped;
     char *tmp;
 
-    switch(ast->kind) {
-        case AST_LITERAL: {
-            aoStrCatPrintf(str,"<ast_literal> ");
-            switch (ast->type->kind) {
-            case AST_TYPE_VOID:  aoStrCatPrintf(str, "<U0>"); break;
-            case AST_TYPE_INT: {
-                if (!isatty(STDOUT_FILENO)) {
-                    aoStrCatPrintf(str, "<integer> %ld", ast->i64);
-                } else {
-                    aoStrCatPrintf(str, "<integer> \033[0;35m%ld\033[0m", ast->i64);
-                }
-                break;
-            }    
-            case AST_TYPE_CHAR:  {
-                char buf[9];
-                unsigned long ch = ast->i64;
-                buf[0] = ch & 0xFF;
-                buf[1] = ((unsigned long)ch) >> 8  & 0xFF;
-                buf[2] = ((unsigned long)ch) >> 16 & 0xFF;
-                buf[3] = ((unsigned long)ch) >> 24 & 0xFF;
-                buf[4] = ((unsigned long)ch) >> 32 & 0xFF;
-                buf[5] = ((unsigned long)ch) >> 40 & 0xFF;
-                buf[6] = ((unsigned long)ch) >> 48 & 0xFF;
-                buf[7] = ((unsigned long)ch) >> 56 & 0xFF;
-                buf[8] = '\0';
-                if (!isatty(STDOUT_FILENO)) {
-                    aoStrCatPrintf(str, "<const_char> '%s'", buf);
-                } else {
-                    aoStrCatPrintf(str, "\033[0;35m%s\033[0m", buf);
-                }
-                break;
-            }
-            case AST_TYPE_FLOAT: {
-                if (!isatty(STDOUT_FILENO)) {
-                    aoStrCatPrintf(str, "<float> %g", ast->f64);
-                } else {
-                    aoStrCatPrintf(str, "\033[0;35m%g\033[0m", ast->f64);
-                }
-                break;
-            }
-            default:
-                loggerPanic("Unhandled type: %d\n", ast->type->kind);
-            }
+    switch (ast->kind) {
+    case AST_LITERAL: {
+        aoStrCatPrintf(str, "<ast_literal> ");
+        switch (ast->type->kind) {
+        case AST_TYPE_VOID:
+            aoStrCatPrintf(str, "<U0>");
             break;
-
-        case AST_STRING: {
+        case AST_TYPE_INT: {
             if (!isatty(STDOUT_FILENO)) {
-                aoStrCatPrintf(str, "<string> \"%s\"", ast->sval->data);
+                aoStrCatPrintf(str, "<integer> %ld", ast->i64);
             } else {
-                aoStrCatPrintf(str, "<string> \033[0;35m\"%s\"\033[0m",
-                        ast->sval->data);
+                aoStrCatPrintf(str, "<integer> \033[0;35m%ld\033[0m", ast->i64);
             }
             break;
         }
+        case AST_TYPE_CHAR: {
+            char buf[9];
+            unsigned long ch = ast->i64;
+            buf[0] = ch & 0xFF;
+            buf[1] = ((unsigned long)ch) >> 8 & 0xFF;
+            buf[2] = ((unsigned long)ch) >> 16 & 0xFF;
+            buf[3] = ((unsigned long)ch) >> 24 & 0xFF;
+            buf[4] = ((unsigned long)ch) >> 32 & 0xFF;
+            buf[5] = ((unsigned long)ch) >> 40 & 0xFF;
+            buf[6] = ((unsigned long)ch) >> 48 & 0xFF;
+            buf[7] = ((unsigned long)ch) >> 56 & 0xFF;
+            buf[8] = '\0';
+            if (!isatty(STDOUT_FILENO)) {
+                aoStrCatPrintf(str, "<const_char> '%s'", buf);
+            } else {
+                aoStrCatPrintf(str, "\033[0;35m%s\033[0m", buf);
+            }
+            break;
+        }
+        case AST_TYPE_FLOAT: {
+            if (!isatty(STDOUT_FILENO)) {
+                aoStrCatPrintf(str, "<float> %g", ast->f64);
+            } else {
+                aoStrCatPrintf(str, "\033[0;35m%g\033[0m", ast->f64);
+            }
+            break;
+        }
+        default:
+            loggerPanic("Unhandled type: %d\n", ast->type->kind);
+        }
+        break;
+
+    case AST_STRING: {
+        if (!isatty(STDOUT_FILENO)) {
+            aoStrCatPrintf(str, "<string> \"%s\"", ast->sval->data);
+        } else {
+            aoStrCatPrintf(str, "<string> \033[0;35m\"%s\"\033[0m",
+                           ast->sval->data);
+        }
+        break;
+    }
     }
     case AST_LVAR: {
-        aoStr *type_str = astTypeToColorAoStr(ast->type);
+        const aoStr *type_str = astTypeToColorAoStr(ast->type);
 
         aoStrCatLen(str, str_lit("<lvar> "));
-        
+
         aoStrCatAoStr(str, type_str);
         if (type_str->data[type_str->len - 1] != '*') {
             aoStrPutChar(str, ' ');
         }
 
-        aoStrCatAoStr(str,ast->lname);
+        aoStrCatAoStr(str, ast->lname);
         break;
-    }    
-    
+    }
+
     case AST_DECL: {
-        aoStr *type_color = astTypeToColorAoStr(ast->declvar->type);
+        const aoStr *type_color = astTypeToColorAoStr(ast->declvar->type);
 
         /* type declaration sorted */
         aoStrCatLen(str, str_lit("<decl> "));
@@ -1247,7 +1308,7 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
         }
 
         aoStrCatAoStr(str, type_color);
-        if (type_color->data[type_color->len-1] != '*') {
+        if (type_color->data[type_color->len - 1] != '*') {
             aoStrPutChar(str, ' ');
         }
 
@@ -1263,7 +1324,7 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
 
         aoStrPutChar(str, '\n');
         if (ast->declinit) {
-            _astToString(str,ast->declinit,depth+1);
+            _astToString(str, ast->declinit, depth + 1);
             astStringEndStmt(str);
         }
         break;
@@ -1272,415 +1333,410 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
     case AST_GVAR:
         aoStrCatPrintf(str, "<gvar> %s", ast->gname->data);
         break;
-    
+
     case AST_ASM_FUNCALL: {
-        tmp = astFunctionToStringInternal(ast,ast->type);
+        tmp = astFunctionToStringInternal(ast, ast->type);
         aoStrCatPrintf(str, "<asm_function_call> %s\n", tmp);
-            depth++;
-            for (ssize_t i = 0; i < ast->args->size; ++i) {
-                Ast *tmp = (Ast *)ast->args->entries[i];
-                aoStrCatRepeat(str, "  ", depth);
-                aoStrCatPrintf(str, "<asm_function_arg>\n");
-                _astToString(str,tmp,depth+1);
+        depth++;
+        for (ssize_t i = 0; i < ast->args->size; ++i) {
+            Ast *tmp1 = (Ast *)ast->args->entries[i];
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<asm_function_arg>\n");
+            _astToString(str, tmp1, depth + 1);
+            astStringEndStmt(str);
+        }
+        break;
+    }
+
+    case AST_FUNPTR_CALL: {
+        tmp = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "<function_ptr_call*> %s %s\n", tmp,
+                       ast->fname->data);
+        depth++;
+        for (ssize_t i = 0; i < ast->args->size; ++i) {
+            Ast *tmp1 = (Ast *)ast->args->entries[i];
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<function_ptr_arg>\n");
+            if (tmp1->kind == AST_TYPE_FUNC) {
+                loggerWarning("%s\n",
+                              astTypeToString(((AstType *)tmp1)->rettype));
+            }
+            _astToString(str, tmp1, depth + 1);
+            astStringEndStmt(str);
+        }
+        break;
+    }
+
+    case AST_FUNCALL: {
+        tmp = astFunctionToStringInternal(ast, ast->type);
+        aoStrCatPrintf(str, "<function_call> %s \n", tmp);
+        depth++;
+
+        for (ssize_t i = 0; i < ast->args->size; ++i) {
+            Ast *tmp1 = (Ast *)ast->args->entries[i];
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<function_arg>\n");
+            if (tmp1->kind == AST_TYPE_FUNC) {
+                loggerDebug("%s\n", astTypeToString(((AstType *)tmp)->rettype));
+            }
+            _astToString(str, (Ast *)tmp1, depth + 1);
+            astStringEndStmt(str);
+        }
+        break;
+    }
+
+    case AST_FUNPTR: {
+        tmp = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "<function_ptr*> %s %s\n", tmp, ast->fname->data);
+        depth++;
+        for (ssize_t i = 0; i < ast->params->size; ++i) {
+            param = (Ast *)ast->params->entries[i];
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<function_ptr_arg>\n");
+            _astToString(str, param, depth + 1);
+            astStringEndStmt(str);
+        }
+        break;
+    }
+
+    case AST_EXTERN_FUNC: {
+        tmp = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "<extern_function> %s %s\n", tmp, ast->fname->data);
+        for (ssize_t i = 0; i < ast->params->size; ++i) {
+            param = ast->params->entries[i];
+            aoStrCatRepeat(str, "  ", depth + 1);
+            aoStrCatPrintf(str, "<extern_function_param>\n");
+            _astToString(str, param, depth + 2);
+            astStringEndStmt(str);
+        }
+        astStringEndStmt(str);
+        break;
+    }
+
+    case AST_FUN_PROTO: {
+        tmp = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "<function_proto> %s %s\n", tmp, ast->fname->data);
+        for (ssize_t i = 0; i < ast->params->size; ++i) {
+            param = ast->params->entries[i];
+            aoStrCatRepeat(str, "  ", depth + 1);
+            aoStrCatPrintf(str, "<function_proto_param>\n");
+            _astToString(str, param, depth + 2);
+            astStringEndStmt(str);
+        }
+        astStringEndStmt(str);
+        break;
+    }
+
+    case AST_FUNC: {
+        tmp = astFunctionToString(ast);
+        if (ast->flags & AST_FLAG_INLINE) {
+            aoStrCatPrintf(str, "<function_def_inline> %s\n", tmp);
+        } else {
+            aoStrCatPrintf(str, "<function_def> %s\n", tmp);
+        }
+        for (ssize_t i = 0; i < ast->params->size; ++i) {
+            param = ast->params->entries[i];
+            aoStrCatRepeat(str, "  ", depth + 1);
+            aoStrCatPrintf(str, "<function_param>\n");
+            _astToString(str, param, depth + 2);
+            astStringEndStmt(str);
+        }
+        _astToString(str, ast->body, depth + 1);
+        astStringEndStmt(str);
+        break;
+    }
+
+    case AST_ASM_FUNC_BIND: {
+        tmp = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "<asm_function_bind> %s %s %s\n", tmp,
+                       ast->asmfname->data, ast->fname->data);
+        for (ssize_t i = 0; i < ast->params->size; ++i) {
+            param = ast->params->entries[i];
+            aoStrCatRepeat(str, "  ", depth + 1);
+            aoStrCatPrintf(str, "<asm_function_param>\n");
+            _astToString(str, param, depth + 2);
+            astStringEndStmt(str);
+        }
+        astStringEndStmt(str);
+        break;
+    }
+
+    case AST_ASM_STMT: {
+        aoStrCatPrintf(str, "<asm_block>\n");
+        break;
+    }
+
+    case AST_ARRAY_INIT:
+        node = ast->arrayinit->next;
+        aoStrCatPrintf(str, "<array_initaliser>\n");
+        while (node != ast->arrayinit) {
+            _astToString(str, node->value, depth + 1);
+            if (node->next != ast->arrayinit) {
                 astStringEndStmt(str);
             }
-            break;
+            node = node->next;
         }
+        break;
 
-        case AST_FUNPTR_CALL: {
-            tmp = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "<function_ptr_call*> %s %s\n", 
-                    tmp, ast->fname->data);
-            depth++;
-            for (ssize_t i = 0; i < ast->args->size; ++i) {
-                Ast *tmp = (Ast *)ast->args->entries[i];
-                aoStrCatRepeat(str, "  ", depth);
-                aoStrCatPrintf(str, "<function_ptr_arg>\n");
-                if (tmp->kind == AST_TYPE_FUNC) {
-                    loggerWarning("%s\n",
-                            astTypeToString(((AstType *)tmp)->rettype));
-                }
-                _astToString(str,tmp,depth+1);
-                astStringEndStmt(str);
-            }
-            break;
+    case AST_IF:
+        aoStrCatPrintf(str, "<if_cond>\n");
+        _astToString(str, ast->cond, depth + 1);
+        astStringEndStmt(str);
+        _astToString(str, ast->then, depth + 1);
+        if (ast->els) {
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<else_cond>\n");
+            _astToString(str, ast->els, depth + 1);
+            astStringEndStmt(str);
         }
+        break;
 
-        case AST_FUNCALL: {
-            tmp = astFunctionToStringInternal(ast,ast->type);
-            aoStrCatPrintf(str, "<function_call> %s \n",tmp);
-            depth++;
+    case AST_DO_WHILE:
+        aoStrCatRepeat(str, " ", depth);
+        aoStrCatPrintf(str, "<do_while>\n");
+        _astToString(str, ast->whilebody, depth + 2);
+        _astToString(str, ast->whilebody, depth + 2);
 
-            for (ssize_t i = 0; i < ast->args->size; ++i) {
-                Ast *tmp = (Ast *)ast->args->entries[i];
-                aoStrCatRepeat(str, "  ", depth);
-                aoStrCatPrintf(str, "<function_arg>\n");
-                if (tmp->kind == AST_TYPE_FUNC) {
-                    loggerDebug("%s\n",
-                            astTypeToString(((AstType *)tmp)->rettype));
-                }
-                _astToString(str,(Ast *)tmp,depth+1);
-                astStringEndStmt(str);
-            }
-            break;
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<while_cond>\n");
+        _astToString(str, ast->whilecond, depth + 2);
+        astStringEndStmt(str);
+        astStringEndStmt(str);
+        break;
+
+    case AST_WHILE:
+        aoStrCatPrintf(str, "<while_cond>\n");
+        _astToString(str, ast->whilecond, depth + 2);
+        astStringEndStmt(str);
+
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<while_body>\n");
+        _astToString(str, ast->whilebody, depth + 2);
+        astStringEndStmt(str);
+        break;
+
+    case AST_FOR:
+        aoStrCatPrintf(str, "<for_expr>\n");
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<for_init>\n");
+        _astToString(str, ast->forinit, depth + 2);
+        astStringEndStmt(str);
+
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<for_cond>\n");
+        _astToString(str, ast->forcond, depth + 2);
+        astStringEndStmt(str);
+
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<for_step>\n");
+        _astToString(str, ast->forstep, depth + 2);
+        astStringEndStmt(str);
+
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<for_body>\n");
+        _astToString(str, ast->forbody, depth + 2);
+        astStringEndStmt(str);
+        break;
+
+    case AST_RETURN:
+        aoStrCatPrintf(str, "<return>\n");
+        _astToString(str, ast->retval, depth + 1);
+        astStringEndStmt(str);
+        break;
+
+    case AST_VAR_ARGS:
+        aoStrCatPrintf(str, "<var_args>...\n");
+        break;
+
+    case AST_COMPOUND_STMT: {
+        aoStrCatPrintf(str, "<compound_expr>\n");
+        listForEach(ast->stms) {
+            Ast *next = (Ast *)it->value;
+            _astToString(str, next, depth + 1);
+            astStringEndStmt(str);
         }
+        astStringEndStmt(str);
+        break;
+    }
 
-        case AST_FUNPTR: {
-            tmp = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "<function_ptr*> %s %s\n", tmp,
-                    ast->fname->data);
-            depth++;
-            for (ssize_t i = 0; i < ast->params->size; ++i) {
-                param = (Ast*)ast->params->entries[i];
-                aoStrCatRepeat(str, "  ", depth);
-                aoStrCatPrintf(str, "<function_ptr_arg>\n");
-                _astToString(str,param,depth+1);
-                astStringEndStmt(str);
-            }
-            break;
-        }
+    case AST_CLASS_REF: {
+        aoStrCatPrintf(str, "<class_ref>\n");
+        const AstType *field_type = strMapGet(ast->cls->type->fields,
+                                              ast->field);
 
-        case AST_EXTERN_FUNC: {
-            tmp = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "<extern_function> %s %s\n", tmp, ast->fname->data);
-            for (ssize_t i = 0; i < ast->params->size; ++i) {
-                param = ast->params->entries[i];
-                aoStrCatRepeat(str, "  ", depth+1);
-                aoStrCatPrintf(str, "<extern_function_param>\n");
-                _astToString(str, param, depth+2);
-                astStringEndStmt(str);
-            }
-            astStringEndStmt(str);
-            break;
-        }
-
-        case AST_FUN_PROTO: {
-            tmp = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "<function_proto> %s %s\n", tmp, ast->fname->data);
-            for (ssize_t i = 0; i < ast->params->size; ++i) {
-                param = ast->params->entries[i];
-                aoStrCatRepeat(str, "  ", depth+1);
-                aoStrCatPrintf(str, "<function_proto_param>\n");
-                _astToString(str, param, depth+2);
-                astStringEndStmt(str);
-            }
-            astStringEndStmt(str);
-            break;
-        }
-
-        case AST_FUNC: {
-            tmp = astFunctionToString(ast);
-            if (ast->flags & AST_FLAG_INLINE) {
-                aoStrCatPrintf(str, "<function_def_inline> %s\n", tmp);
-            } else {
-                aoStrCatPrintf(str, "<function_def> %s\n", tmp);
-            }
-            for (ssize_t i = 0; i < ast->params->size; ++i) {
-                param = ast->params->entries[i];
-                aoStrCatRepeat(str, "  ", depth+1);
-                aoStrCatPrintf(str, "<function_param>\n");
-                _astToString(str, param, depth+2);
-                astStringEndStmt(str);
-            }
-            _astToString(str, ast->body, depth + 1);
-            astStringEndStmt(str);
-            break;
-        }
-
-        case AST_ASM_FUNC_BIND: {
-            tmp = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "<asm_function_bind> %s %s %s\n", tmp,
-                    ast->asmfname->data,
-                    ast->fname->data);
-            for (ssize_t i = 0; i < ast->params->size; ++i) {
-                param = ast->params->entries[i];
-                aoStrCatRepeat(str, "  ", depth+1);
-                aoStrCatPrintf(str, "<asm_function_param>\n");
-                _astToString(str, param, depth+2);
-                astStringEndStmt(str);
-            }
-            astStringEndStmt(str);
-            break;
-        }
-
-        case AST_ASM_STMT: {
-            aoStrCatPrintf(str, "<asm_block>\n");
-            break;
-        }
-
-        case AST_ARRAY_INIT:
-            node = ast->arrayinit->next;
-            aoStrCatPrintf(str, "<array_initaliser>\n");
-            while (node != ast->arrayinit) {
-                _astToString(str, node->value, depth + 1);
-                if (node->next != ast->arrayinit) {
-                    astStringEndStmt(str);
-                }
-                node = node->next;
-            }
-            break;
-
-        case AST_IF:
-            aoStrCatPrintf(str, "<if_cond>\n");
-            _astToString(str,ast->cond,depth+1);
-            astStringEndStmt(str);
-            _astToString(str,ast->then,depth+1);
-            if (ast->els) {
-                aoStrCatRepeat(str, "  ", depth);
-                aoStrCatPrintf(str, "<else_cond>\n");
-                _astToString(str,ast->els,depth+1);
-                astStringEndStmt(str);
-            }
-            break;
-
-        case AST_DO_WHILE:
-            aoStrCatRepeat(str, " ", depth);
-            aoStrCatPrintf(str, "<do_while>\n");
-            _astToString(str, ast->whilebody, depth+2);
-            _astToString(str, ast->whilebody, depth+2);
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<while_cond>\n"); 
-            _astToString(str, ast->whilecond, depth+2);
-            astStringEndStmt(str);
-            astStringEndStmt(str);
-            break;
-
-        case AST_WHILE:
-            aoStrCatPrintf(str, "<while_cond>\n"); 
-            _astToString(str, ast->whilecond, depth+2);
-            astStringEndStmt(str);
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<while_body>\n"); 
-            _astToString(str, ast->whilebody, depth+2);
-            astStringEndStmt(str);
-            break;
-
-        case AST_FOR:
-            aoStrCatPrintf(str, "<for_expr>\n");
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<for_init>\n"); 
-            _astToString(str, ast->forinit, depth+2);
-            astStringEndStmt(str);
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<for_cond>\n"); 
-            _astToString(str, ast->forcond, depth+2);
-            astStringEndStmt(str);
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<for_step>\n"); 
-            _astToString(str, ast->forstep, depth+2);
-            astStringEndStmt(str);
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<for_body>\n"); 
-            _astToString(str, ast->forbody, depth+2);
-            astStringEndStmt(str);
-            break;
-
-        case AST_RETURN:
-            aoStrCatPrintf(str, "<return>\n");
-            _astToString(str, ast->retval, depth+1);
-            astStringEndStmt(str);
-            break;
-
-        case AST_VAR_ARGS:
-            aoStrCatPrintf(str, "<var_args>...\n");
-            break;
-
-        case AST_COMPOUND_STMT: {
-            aoStrCatPrintf(str, "<compound_expr>\n");
-            listForEach(ast->stms) {
-                Ast *next = (Ast *)it->value;
-                _astToString(str, next, depth+1);
-                astStringEndStmt(str);
-            }
-            astStringEndStmt(str);
-            break;
-        }
-        
-        case AST_CLASS_REF: {
-            Ast *ast_tmp;
-            char *field_names[30];
+        /* We only really want to print at the data type we are looking
+         * at, not the whole class */
+        if (field_type && ast->cls->kind == AST_DEREF) {
             int field_name_count = 0;
-            aoStrCatPrintf(str, "<class_ref>\n");
-            AstType *field_type = strMapGet(ast->cls->type->fields, ast->field);
+            char *field_names[30];
+            aoStrCatRepeat(str, "  ", depth + 1);
 
-            /* We only really want to print at the data type we are looking 
-             * at, not the whole class */
-            if (field_type && ast->cls->kind == AST_DEREF) {
-                aoStrCatRepeat(str, "  ", depth+1);
+            if (!astIsClassPointer(field_type)) {
+                const aoStr *color_type = astTypeToColorAoStr(field_type);
+                aoStrCatLen(str, color_type->data, color_type->len);
+                if (color_type->data[color_type->len - 1] != '*') {
+                    aoStrPutChar(str, ' ');
+                }
+            } else {
+                tmp = astTypeToColorString(field_type);
+                aoStrCatPrintf(str, "<class> %s ", tmp);
+            }
 
-                if (!astIsClassPointer(field_type)) {
-                    aoStr *color_type = astTypeToColorAoStr(field_type);
-                    aoStrCatLen(str, color_type->data, color_type->len);
-                    if (color_type->data[color_type->len - 1] != '*') {
-                        aoStrPutChar(str, ' ');
-                    } 
+            /* Find the name of the variable that contains this reference */
+            const Ast *ast_tmp = ast;
+            while (ast_tmp->kind == AST_DEREF ||
+                   ast_tmp->kind == AST_CLASS_REF) {
+                field_names[field_name_count++] = ast_tmp->field;
+                if (ast_tmp->kind != AST_DEREF &&
+                    ast_tmp->kind != AST_CLASS_REF) {
+                    break;
+                }
+                ast_tmp = ast_tmp->cls->operand;
+            }
+
+            if (ast_tmp->kind == AST_LVAR) {
+                aoStrCatPrintf(str, "%s->", ast_tmp->lname->data);
+            }
+            for (int i = 0; i < field_name_count; ++i) {
+                if (i + 1 == field_name_count) {
+                    aoStrCatPrintf(str, "%s", field_names[i]);
                 } else {
-                    tmp = astTypeToColorString(field_type);
-                    aoStrCatPrintf(str, "<class> %s ",tmp);
-                }
-
-                /* Find the name of the variable that contains this reference */
-                ast_tmp = ast;
-                while (ast_tmp->kind == AST_DEREF ||
-                        ast_tmp->kind == AST_CLASS_REF) {
-                    field_names[field_name_count++] = ast_tmp->field;
-                    if (ast_tmp->kind != AST_DEREF &&
-                            ast_tmp->kind != AST_CLASS_REF) {
-                        break;
-                    }
-                    ast_tmp = ast_tmp->cls->operand;
-                }
-
-                if (ast_tmp->kind == AST_LVAR) {
-                    aoStrCatPrintf(str, "%s->",ast_tmp->lname->data);
-                }
-                for (int i = 0; i < field_name_count; ++i) {
-                    if (i + 1 == field_name_count) {
-                        aoStrCatPrintf(str, "%s",field_names[i]);
-                    } else {
-                        aoStrCatPrintf(str, "%s->",field_names[i]);
-                    }
-                }
-            } else {
-                loggerWarning("printing whole class: %s!\n",
-                    astKindToString(ast->cls->kind));
-                aoStrCatRepeat(str, "  ", depth+1);
-                if (ast->cls->kind == AST_LVAR) {
-                    aoStrCatPrintf(str, "%s",ast->cls->lname->data);
-                }
-                aoStrCatPrintf(str, ".%s", ast->field, ast->type->offset);
-            }
-            astStringEndStmt(str);
-            break;
-        }
-
-        case AST_GOTO:
-            aoStrCatPrintf(str, "<goto> %s\n", ast->slabel->data);
-            break;
-
-        /* XXX: fix labels */
-        case AST_LABEL:
-            if (ast->slabel) {
-                aoStrCatPrintf(str, "<label> %s:\n", ast->slabel->data);
-            } else {
-                aoStrCatPrintf(str, "<label> %s:\n", ast->sval->data);
-            }
-            break;
-
-        case AST_ADDR:
-            aoStrCatPrintf(str, "<addr>\n");
-            _astToString(str,ast->operand,depth+1);
-            astStringEndStmt(str);
-            break;
-
-        case AST_DEREF:
-            aoStrCatPrintf(str, "<deref>\n");
-            _astToString(str,ast->operand,depth+1);
-            //astStringEndStmt(str);
-            break;
-
-        case AST_CAST:
-            aoStrCatPrintf(str, "<cast> %s %s -> %s\n",
-                    astTypeToString(ast->operand->type),
-                    astLValueToString(ast->operand,0),
-                    astTypeToString(ast->type));
-            break;
-
-        case AST_JUMP:
-            aoStrCatPrintf(str, "<jump> %s\n", ast->jump_label->data);
-            break;
-
-        case AST_CASE: {
-            if (ast->case_begin == ast->case_end) {
-                aoStrCatPrintf(str, "<case> %d %s:\n", ast->case_begin,
-                        ast->case_label->data);
-            } else {
-                aoStrCatPrintf(str, "<case> %d...%d %s:\n",
-                        ast->case_begin,
-                        ast->case_end,
-                        ast->case_label->data);
-            }
-            if (!listEmpty(ast->case_asts)) {
-                listForEach(ast->case_asts) {
-                    Ast *case_ast = (Ast *)it->value;
-                    _astToString(str,case_ast,depth+1);
+                    aoStrCatPrintf(str, "%s->", field_names[i]);
                 }
             }
-            break;
-        }
-
-        case AST_SWITCH: {
-            if (ast->switch_bounds_checked) {
-                aoStrCatPrintf(str, "<switch>\n");
-            } else {
-                aoStrCatPrintf(str, "<no_bounds_switch>\n");
+        } else {
+            loggerWarning("printing whole class: %s!\n",
+                          astKindToString(ast->cls->kind));
+            aoStrCatRepeat(str, "  ", depth + 1);
+            if (ast->cls->kind == AST_LVAR) {
+                aoStrCatPrintf(str, "%s", ast->cls->lname->data);
             }
+            aoStrCatPrintf(str, ".%s", ast->field, ast->type->offset);
+        }
+        astStringEndStmt(str);
+        break;
+    }
 
-            _astToString(str,ast->switch_cond,depth+1);
-            for (int i = 0; i < ast->cases->size; ++i) {
-                _astToString(str,(Ast *)ast->cases->entries[i],depth+1);
+    case AST_GOTO:
+        aoStrCatPrintf(str, "<goto> %s\n", ast->slabel->data);
+        break;
+
+    /* XXX: fix labels */
+    case AST_LABEL:
+        if (ast->slabel) {
+            aoStrCatPrintf(str, "<label> %s:\n", ast->slabel->data);
+        } else {
+            aoStrCatPrintf(str, "<label> %s:\n", ast->sval->data);
+        }
+        break;
+
+    case AST_ADDR:
+        aoStrCatPrintf(str, "<addr>\n");
+        _astToString(str, ast->operand, depth + 1);
+        astStringEndStmt(str);
+        break;
+
+    case AST_DEREF:
+        aoStrCatPrintf(str, "<deref>\n");
+        _astToString(str, ast->operand, depth + 1);
+        // astStringEndStmt(str);
+        break;
+
+    case AST_CAST:
+        aoStrCatPrintf(str, "<cast> %s %s -> %s\n",
+                       astTypeToString(ast->operand->type),
+                       astLValueToString(ast->operand, 0),
+                       astTypeToString(ast->type));
+        break;
+
+    case AST_JUMP:
+        aoStrCatPrintf(str, "<jump> %s\n", ast->jump_label->data);
+        break;
+
+    case AST_CASE: {
+        if (ast->case_begin == ast->case_end) {
+            aoStrCatPrintf(str, "<case> %d %s:\n", ast->case_begin,
+                           ast->case_label->data);
+        } else {
+            aoStrCatPrintf(str, "<case> %d...%d %s:\n", ast->case_begin,
+                           ast->case_end, ast->case_label->data);
+        }
+        if (!listEmpty(ast->case_asts)) {
+            listForEach(ast->case_asts) {
+                Ast *case_ast = (Ast *)it->value;
+                _astToString(str, case_ast, depth + 1);
             }
+        }
+        break;
+    }
 
-            if (ast->case_default) {
-                _astToString(str,ast->case_default,depth+1);
+    case AST_SWITCH: {
+        if (ast->switch_bounds_checked) {
+            aoStrCatPrintf(str, "<switch>\n");
+        } else {
+            aoStrCatPrintf(str, "<no_bounds_switch>\n");
+        }
+
+        _astToString(str, ast->switch_cond, depth + 1);
+        for (int i = 0; i < ast->cases->size; ++i) {
+            _astToString(str, (Ast *)ast->cases->entries[i], depth + 1);
+        }
+
+        if (ast->case_default) {
+            _astToString(str, ast->case_default, depth + 1);
+        }
+
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "<end_label>: %s\n", ast->case_end_label->data);
+        break;
+    }
+
+    case AST_DEFAULT: {
+        aoStrCatPrintf(str, "<default> %s\n", ast->case_label->data);
+        if (!listEmpty(ast->case_asts)) {
+            listForEach(ast->case_asts) {
+                _astToString(str, (Ast *)it->value, depth + 1);
             }
-
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "<end_label>: %s\n", ast->case_end_label->data);
-            break;
         }
+        break;
+    }
 
-        case AST_DEFAULT: {
-            aoStrCatPrintf(str, "<default> %s\n", ast->case_label->data);
-            if (!listEmpty(ast->case_asts)) {
-                listForEach(ast->case_asts) {
-                    _astToString(str,(Ast *)it->value,depth+1);
-                }
-            }
-            break;
+    case AST_BREAK:
+        aoStrCatPrintf(str, "<break>\n");
+        break;
+
+    case AST_CONTINUE:
+        aoStrCatPrintf(str, "<continue>\n");
+        break;
+
+    case AST_DEFAULT_PARAM: {
+        aoStrCatPrintf(str, "<default_param>\n");
+        _astToString(str, ast->declvar, depth + 1);
+        if (ast->declvar) {
+            _astToString(str, ast->declinit, depth + 1);
         }
+        break;
+    }
 
-        case AST_BREAK:
-            aoStrCatPrintf(str, "<break>\n");
-            break;
+    case AST_COMMENT: {
+        aoStrCatPrintf(str, "<comment>\n");
+        aoStrCatRepeat(str, "  ", depth + 1);
+        aoStrCatPrintf(str, "%s\n", ast->sval->data);
+        break;
+    }
 
-        case AST_CONTINUE:
-            aoStrCatPrintf(str, "<continue>\n");
-            break;
+    case TK_PRE_PLUS_PLUS:
+    case TK_PLUS_PLUS:
+    case TK_PRE_MINUS_MINUS:
+    case TK_MINUS_MINUS:
+        astUnaryOpToString(str, astKindToString(ast->kind), ast, depth);
+        break;
 
-        case AST_DEFAULT_PARAM: {
-            aoStrCatPrintf(str, "<default_param>\n");
-            _astToString(str,ast->declvar,depth+1);
-            if (ast->declvar) {
-                _astToString(str,ast->declinit,depth+1);
-            }
-            break;
-        }
-
-        case AST_COMMENT: {
-            aoStrCatPrintf(str, "<comment>\n");
-            aoStrCatRepeat(str, "  ", depth+1);
-            aoStrCatPrintf(str, "%s\n", ast->sval->data);
-            break;
-        }
-
-        case TK_PRE_PLUS_PLUS:
-        case TK_PLUS_PLUS:   
-        case TK_PRE_MINUS_MINUS:
-        case TK_MINUS_MINUS:
-            astUnaryOpToString(str, astKindToString(ast->kind),ast,depth);
-            break;
-
-        default: {
-            astBinaryOpToString(str,astKindToString(ast->kind),ast,depth);
-            astStringEndStmt(str);
-            break;
-        }
+    default: {
+        astBinaryOpToString(str, astKindToString(ast->kind), ast, depth);
+        astStringEndStmt(str);
+        break;
+    }
     }
 }
 
@@ -1688,85 +1744,158 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
 char *astKindToString(int kind) {
     switch (kind) {
     /* KIND FOR AST TYPE */
-    case AST_TYPE_VOID:  return "AST_TYPE_VOID";
-    case AST_TYPE_INT:   return "AST_TYPE_INT";
-    case AST_TYPE_FLOAT: return "AST_TYPE_FLOAT";
-    case AST_TYPE_CHAR:  return "AST_TYPE_CHAR";
-    case AST_TYPE_ARRAY: return "AST_TYPE_ARRAY";
-    case AST_TYPE_POINTER: return "->AST_TYPE_POINTER";
-    case AST_TYPE_FUNC:  return "AST_TYPE_FUNC";
-    case AST_TYPE_CLASS: return "AST_TYPE_CLASS";
-    case AST_TYPE_UNION: return "AST_TYPE_UNION";
-    case AST_TYPE_AUTO:  return "AST_TYPE_AUTO";
+    case AST_TYPE_VOID:
+        return "AST_TYPE_VOID";
+    case AST_TYPE_INT:
+        return "AST_TYPE_INT";
+    case AST_TYPE_FLOAT:
+        return "AST_TYPE_FLOAT";
+    case AST_TYPE_CHAR:
+        return "AST_TYPE_CHAR";
+    case AST_TYPE_ARRAY:
+        return "AST_TYPE_ARRAY";
+    case AST_TYPE_POINTER:
+        return "->AST_TYPE_POINTER";
+    case AST_TYPE_FUNC:
+        return "AST_TYPE_FUNC";
+    case AST_TYPE_CLASS:
+        return "AST_TYPE_CLASS";
+    case AST_TYPE_UNION:
+        return "AST_TYPE_UNION";
+    case AST_TYPE_AUTO:
+        return "AST_TYPE_AUTO";
 
-    case AST_GVAR:       return "AST_GVAR";
-    case AST_DEREF:      return "AST_DEREF";
-    case AST_ADDR:       return "AST_ADDR";
-    case AST_LVAR:       return "AST_LVAR";
-    case AST_FUNC:       return "AST_FUNC";
-    case AST_FUNPTR:     return "AST_FUNPTR";
-    case AST_EXTERN_FUNC: return "AST_EXTERN_FUNC";
-    case AST_DECL:       return "AST_DECL";
-    case AST_STRING:     return "AST_STRING";
-    case AST_FUNCALL:    return "AST_FUNCALL";
-    case AST_LITERAL:    return "AST_LITERAL";
-    case AST_ARRAY_INIT: return "AST_ARRAY_INIT";
-    case AST_IF:         return "AST_IF";
-    case AST_FOR:        return "AST_FOR";
-    case AST_GOTO:       return "AST_GOTO";
-    case AST_LABEL:      return "AST_LABEL";
-    case AST_RETURN:     return "AST_RETURN";
-    case AST_COMPOUND_STMT: return "AST_COMPOUND_STMT";
-    case AST_CLASS_REF:  return "AST_CLASS_REF";
-    case AST_DEFAULT_PARAM: return "AST_DEFAULT_PARAM";
-    case AST_VAR_ARGS:   return "AST_VAR_ARGS";
-    case AST_CAST:       return "AST_CAST";
-    case AST_JUMP:       return "AST_JUMP";
-    case AST_ASM_FUNC_BIND: return "AST_ASM_FUNC_BIND";
+    case AST_GVAR:
+        return "AST_GVAR";
+    case AST_DEREF:
+        return "AST_DEREF";
+    case AST_ADDR:
+        return "AST_ADDR";
+    case AST_LVAR:
+        return "AST_LVAR";
+    case AST_FUNC:
+        return "AST_FUNC";
+    case AST_FUNPTR:
+        return "AST_FUNPTR";
+    case AST_EXTERN_FUNC:
+        return "AST_EXTERN_FUNC";
+    case AST_DECL:
+        return "AST_DECL";
+    case AST_STRING:
+        return "AST_STRING";
+    case AST_FUNCALL:
+        return "AST_FUNCALL";
+    case AST_LITERAL:
+        return "AST_LITERAL";
+    case AST_ARRAY_INIT:
+        return "AST_ARRAY_INIT";
+    case AST_IF:
+        return "AST_IF";
+    case AST_FOR:
+        return "AST_FOR";
+    case AST_GOTO:
+        return "AST_GOTO";
+    case AST_LABEL:
+        return "AST_LABEL";
+    case AST_RETURN:
+        return "AST_RETURN";
+    case AST_COMPOUND_STMT:
+        return "AST_COMPOUND_STMT";
+    case AST_CLASS_REF:
+        return "AST_CLASS_REF";
+    case AST_DEFAULT_PARAM:
+        return "AST_DEFAULT_PARAM";
+    case AST_VAR_ARGS:
+        return "AST_VAR_ARGS";
+    case AST_CAST:
+        return "AST_CAST";
+    case AST_JUMP:
+        return "AST_JUMP";
+    case AST_ASM_FUNC_BIND:
+        return "AST_ASM_FUNC_BIND";
 
-    case AST_SWITCH:        return "AST_SWITCH";
-    case AST_CASE:          return "AST_CASE";
-    case AST_DEFAULT:       return "AST_DEFAULT";
-    case AST_COMMENT:       return "AST_COMMENT";
-    case AST_SIZEOF:        return "AST_SIZEOF";
+    case AST_SWITCH:
+        return "AST_SWITCH";
+    case AST_CASE:
+        return "AST_CASE";
+    case AST_DEFAULT:
+        return "AST_DEFAULT";
+    case AST_COMMENT:
+        return "AST_COMMENT";
+    case AST_SIZEOF:
+        return "AST_SIZEOF";
 
-
-    case TK_AND_AND:         return "&&";
-    case TK_OR_OR:           return "||";
-    case TK_SHL:             return "<<";
-    case TK_SHR:             return ">>";
-    case TK_PLUS_PLUS:       return "++";
-    case TK_PRE_PLUS_PLUS:   return "<p>++";
-    case TK_PRE_MINUS_MINUS: return "<p>--";
-    case TK_MINUS_MINUS:     return "--";
-    case TK_EQU_EQU:         return "==";
-    case TK_NOT_EQU:         return "!=";
-    case TK_LESS_EQU:        return "<=";
-    case TK_GREATER_EQU:     return ">=";
-    case TK_DIV_EQU:         return "/=";
-    case TK_MUL_EQU:         return "*=";
-    case TK_MOD_EQU:         return "%=";
-    case TK_ADD_EQU:         return "+=";
-    case TK_SUB_EQU:         return "-=";
-    case TK_SHL_EQU:         return "<<=";
-    case TK_SHR_EQU:         return ">>=";
-    case TK_AND_EQU:         return "&=";
-    case TK_OR_EQU:          return "|=";
-    case TK_XOR_EQU:         return "^=";
+    case TK_AND_AND:
+        return "&&";
+    case TK_OR_OR:
+        return "||";
+    case TK_SHL:
+        return "<<";
+    case TK_SHR:
+        return ">>";
+    case TK_PLUS_PLUS:
+        return "++";
+    case TK_PRE_PLUS_PLUS:
+        return "<p>++";
+    case TK_PRE_MINUS_MINUS:
+        return "<p>--";
+    case TK_MINUS_MINUS:
+        return "--";
+    case TK_EQU_EQU:
+        return "==";
+    case TK_NOT_EQU:
+        return "!=";
+    case TK_LESS_EQU:
+        return "<=";
+    case TK_GREATER_EQU:
+        return ">=";
+    case TK_DIV_EQU:
+        return "/=";
+    case TK_MUL_EQU:
+        return "*=";
+    case TK_MOD_EQU:
+        return "%=";
+    case TK_ADD_EQU:
+        return "+=";
+    case TK_SUB_EQU:
+        return "-=";
+    case TK_SHL_EQU:
+        return "<<=";
+    case TK_SHR_EQU:
+        return ">>=";
+    case TK_AND_EQU:
+        return "&=";
+    case TK_OR_EQU:
+        return "|=";
+    case TK_XOR_EQU:
+        return "^=";
     case '+':
-    case AST_OP_ADD:     return "+";
-    case '-':            return "-";
-    case '*':            return "*";
-    case '~':            return "~";
-    case '<':            return "<";
-    case '>':            return ">";
-    case '/':            return "/";
-    case '&':            return "&";
-    case '|':            return "|";
-    case '=':            return "=";
-    case '!':            return "!";
-    case '%':            return "%";
-    case '^':            return "^";
+    case AST_OP_ADD:
+        return "+";
+    case '-':
+        return "-";
+    case '*':
+        return "*";
+    case '~':
+        return "~";
+    case '<':
+        return "<";
+    case '>':
+        return ">";
+    case '/':
+        return "/";
+    case '&':
+        return "&";
+    case '|':
+        return "|";
+    case '=':
+        return "=";
+    case '!':
+        return "!";
+    case '%':
+        return "%";
+    case '^':
+        return "^";
     default:
         loggerPanic("Cannot find kind: %d\n", kind);
     }
@@ -1786,363 +1915,440 @@ int astIsRangeOperator(long op) {
 
 char *_astToStringRec(Ast *ast, int depth) {
     aoStr *str = aoStrNew();
-    _astToString(str,ast, depth);
+    _astToString(str, ast, depth);
     return aoStrMove(str);
 }
 
 /* Convert an Ast to a string */
 char *astToString(Ast *ast) {
-    return _astToStringRec(ast,0);
+    return _astToStringRec(ast, 0);
 }
 
 /* This can only be used for lvalues */
-static void _astLValueToString(aoStr *str, Ast *ast, unsigned long lexeme_flags);
+static void _astLValueToString(aoStr *str, const Ast *ast,
+                               unsigned long lexeme_flags);
 
-void astUnaryArgToString(aoStr *str, char *op, Ast *ast, unsigned long lexeme_flags) {
+void astUnaryArgToString(aoStr *str, char *op, const Ast *ast,
+                         unsigned long lexeme_flags) {
     aoStrCatPrintf(str, "%s", op);
-    _astLValueToString(str, ast->operand,lexeme_flags);
+    _astLValueToString(str, ast->operand, lexeme_flags);
 }
 
-void astBinaryArgToString(aoStr *str, char *op, Ast *ast, unsigned long lexeme_flags) {
-    _astLValueToString(str, ast->left,lexeme_flags);
+void astBinaryArgToString(aoStr *str, char *op, const Ast *ast,
+                          unsigned long lexeme_flags) {
+    _astLValueToString(str, ast->left, lexeme_flags);
     aoStrCatPrintf(str, " %s ", op);
-    _astLValueToString(str, ast->right,lexeme_flags);
+    _astLValueToString(str, ast->right, lexeme_flags);
 }
 
 /* This can only be used for lvalues */
-static void _astLValueToString(aoStr *str, Ast *ast, unsigned long lexeme_flags) {
+static void _astLValueToString(aoStr *str, const Ast *ast,
+                               unsigned long lexeme_flags) {
     char *str_op = NULL;
     if (ast == NULL) {
         aoStrCatLen(str, "(null)", 6);
         return;
     }
-    switch(ast->kind) {
-        case AST_LITERAL:
-            switch (ast->type->kind) {
-            case AST_TYPE_VOID:  aoStrCatPrintf(str, "void"); break;
-            case AST_TYPE_INT:   {
-                aoStrCatPrintf(str, "%ld", ast->i64);
-                break;
+    switch (ast->kind) {
+    case AST_LITERAL:
+        switch (ast->type->kind) {
+        case AST_TYPE_VOID:
+            aoStrCatPrintf(str, "void");
+            break;
+        case AST_TYPE_INT: {
+            aoStrCatPrintf(str, "%ld", ast->i64);
+            break;
+        }
+        case AST_TYPE_CHAR: {
+            char *single_quote = lexemePunctToStringWithFlags('\'',
+                                                              lexeme_flags);
+            aoStrCatPrintf(str, "%s", single_quote);
+            char *escaped = lexemePunctToStringWithFlags(ast->i64,
+                                                         lexeme_flags);
+            aoStrCatPrintf(str, "%s", escaped);
+            single_quote = lexemePunctToStringWithFlags('\'', lexeme_flags);
+            aoStrCatPrintf(str, "%s", single_quote);
+            break;
+        }
+        case AST_TYPE_FLOAT:
+            aoStrCatPrintf(str, "%g", ast->f64);
+            break;
+        default:
+            loggerPanic("Unhandled type: %d\n", ast->type->kind);
+        }
+        break;
+
+    case AST_STRING: {
+        aoStr *encoded = NULL;
+        char *quote = "\"";
+        if (lexeme_flags & LEXEME_GRAPH_VIZ_ENCODE_PUNCT) {
+            quote = "&#34;";
+            encoded = aoStrEncode(ast->sval);
+        } else {
+            encoded = ast->sval;
+        }
+        aoStrCatPrintf(str, "%s%s%s", quote, encoded->data, quote);
+        break;
+    }
+
+    case AST_LVAR:
+        aoStrCatPrintf(str, "%s", ast->lname->data);
+        break;
+
+    case AST_DECL:
+        if (ast->declvar->kind == AST_FUNPTR) {
+            aoStrCatPrintf(str, "%s = ", ast->declvar->fname->data);
+        } else {
+            aoStrCatPrintf(str, "%s", ast->declvar->lname->data);
+        }
+        if (ast->declinit) {
+            aoStrCatPrintf(str, " %s ",
+                           lexemePunctToStringWithFlags('=', lexeme_flags));
+            _astLValueToString(str, ast->declinit, lexeme_flags);
+            aoStrPutChar(str, ';');
+        }
+        break;
+
+    case AST_GVAR:
+        aoStrCatPrintf(str, "%s", ast->gname->data);
+        break;
+
+    case AST_FUNCALL:
+    case AST_FUNPTR_CALL:
+    case AST_ASM_FUNCALL: {
+        aoStr *internal = aoStrAlloc(256);
+        for (ssize_t i = 0; i < ast->args->size; ++i) {
+            const Ast *val = cast(Ast *, ast->args->entries[i]);
+            _astLValueToString(internal, val, lexeme_flags);
+            if (i + 1 != ast->args->size) {
+                aoStrCatPrintf(internal, ",");
             }
-            case AST_TYPE_CHAR:  {
-                char *single_quote = lexemePunctToStringWithFlags('\'',lexeme_flags);
-                aoStrCatPrintf(str,"%s",single_quote);
-                char *escaped = lexemePunctToStringWithFlags(ast->i64,lexeme_flags);
-                aoStrCatPrintf(str,"%s",escaped);
-                single_quote = lexemePunctToStringWithFlags('\'',lexeme_flags);
-                aoStrCatPrintf(str,"%s",single_quote);
-                break;
+        }
+
+        if (internal->len > 0) {
+            aoStrCatPrintf(str, "%s(%s);", ast->fname->data, internal->data);
+        } else {
+            aoStrCatPrintf(str, "%s();", ast->fname->data);
+        }
+        break;
+    }
+
+    case AST_FUNC:
+    case AST_FUN_PROTO:
+    case AST_EXTERN_FUNC:
+    case AST_FUNPTR: {
+        aoStrCatPrintf(str, "%s", ast->fname->data);
+        break;
+    }
+
+    case AST_ASM_FUNC_BIND: {
+        aoStrCatPrintf(str, "%s =\\> %s", ast->asmfname->data,
+                       ast->fname->data);
+        break;
+    }
+
+    case AST_VAR_ARGS:
+        aoStrCatPrintf(str, "...\n");
+        break;
+
+    case AST_CLASS_REF: {
+        _astLValueToString(str, ast->cls, lexeme_flags);
+        if (ast->cls->deref_symbol == TK_ARROW) {
+            aoStrCatFmt(str, "->%s", ast->field);
+        } else {
+            aoStrCatFmt(str, ".%s", ast->field);
+        }
+        break;
+    }
+
+    case AST_GOTO: {
+        const aoStr *label = astHackedGetLabel(ast);
+        aoStrCatPrintf(str, "goto %s", label->data);
+        break;
+    }
+
+    case AST_LABEL: {
+        const aoStr *label = astHackedGetLabel(ast);
+        aoStrCatPrintf(str, "%s:", label->data);
+        break;
+    }
+
+    case AST_ADDR:
+        aoStrCatPrintf(str, "&");
+        _astLValueToString(str, ast->operand, lexeme_flags);
+        break;
+
+    case AST_DEREF: {
+        if (ast->operand->kind == '+') {
+            const Ast *left = ast->operand->left;
+            const Ast *right = ast->operand->right;
+            _astLValueToString(str, left, lexeme_flags);
+            aoStrPutChar(str, '[');
+            _astLValueToString(str, right, lexeme_flags);
+            aoStrPutChar(str, ']');
+        } else {
+            /* As `->` is a dereference we need to be able to distinguish
+             * between a class dereference and a general pointer dereference */
+            if (ast->deref_symbol != TK_ARROW) {
+                aoStrCatFmt(str, "*");
             }
-            case AST_TYPE_FLOAT: aoStrCatPrintf(str, "%g", ast->f64); break;
-            default:
-                loggerPanic("Unhandled type: %d\n", ast->type->kind);
-            }
-            break;
-
-        case AST_STRING: {
-            aoStr *str_formatted = aoStrNew();
-            aoStr *encoded = NULL;
-            char *quote = "\"";
-            if (lexeme_flags & LEXEME_GRAPH_VIZ_ENCODE_PUNCT) {
-                quote = "&#34;";
-                encoded = aoStrEncode(ast->sval);
-            } else {
-                encoded = ast->sval;
-            }
-            aoStrCatPrintf(str,"%s%s%s",quote,encoded->data,quote);
-            break;
+            _astLValueToString(str, ast->operand, lexeme_flags);
         }
-        
-        case AST_LVAR:
-            aoStrCatPrintf(str, "%s",ast->lname->data);
-            break;
-        
-        case AST_DECL:
-            if (ast->declvar->kind == AST_FUNPTR) {
-                aoStrCatPrintf(str,"%s = ",ast->declvar->fname->data);
-            } else {
-                aoStrCatPrintf(str,"%s",ast->declvar->lname->data);
-            }
-            if (ast->declinit) {
-                aoStrCatPrintf(str, " %s ",
-                        lexemePunctToStringWithFlags('=',lexeme_flags));
-                _astLValueToString(str,ast->declinit,lexeme_flags);
-                aoStrPutChar(str, ';');
-            }
-            break;
+        break;
+    }
 
-        case AST_GVAR:
-            aoStrCatPrintf(str, "%s", ast->gname->data);
-            break;
+    case AST_CAST: {
+        _astLValueToString(str, ast->operand, lexeme_flags);
+        char *type = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "(%s)", type);
+        break;
+    }
 
-        case AST_FUNCALL:
-        case AST_FUNPTR_CALL:
-        case AST_ASM_FUNCALL: {
-            aoStr *internal = aoStrAlloc(256);
-            for (ssize_t i = 0; i < ast->args->size; ++i) {
-                Ast *val = cast(Ast *, ast->args->entries[i]);
-                _astLValueToString(internal,val,lexeme_flags);
-                if (i+1 != ast->args->size) {
-                    aoStrCatPrintf(internal,",");
-                }
-            }
+    case AST_RETURN:
+        aoStrCatPrintf(str, "return ");
+        _astLValueToString(str, ast->retval, lexeme_flags);
+        aoStrCatPrintf(str, "%s",
+                       lexemePunctToStringWithFlags(';', lexeme_flags));
+        break;
 
-            if (internal->len > 0) {
-                aoStrCatPrintf(str, "%s(%s);",ast->fname->data,internal->data);
-            } else {
-                aoStrCatPrintf(str, "%s();",ast->fname->data);
-            }
-            break;
+    case AST_DEFAULT:
+        aoStrCatPrintf(str, "default:");
+        break;
+
+    case AST_CASE: {
+        if (ast->case_begin == ast->case_end) {
+            aoStrCatPrintf(str, "case (%ld):", ast->case_begin);
+        } else {
+            aoStrCatPrintf(str, "case (%ld ... %ld\\):", ast->case_begin,
+                           ast->case_end);
         }
+        break;
+    }
 
-        case AST_FUNC:
-        case AST_FUN_PROTO:
-        case AST_EXTERN_FUNC:
-        case AST_FUNPTR: {
-            aoStrCatPrintf(str, "%s", ast->fname->data);
-            break;
+    case AST_SIZEOF: {
+        char *type_str = astTypeToString(ast->type);
+        aoStrCatPrintf(str, "sizeof(%s)", type_str);
+        break;
+    }
+
+    case AST_BREAK:
+        aoStrCatPrintf(str, "break;");
+        break;
+
+    case TK_PRE_PLUS_PLUS:
+    case TK_PLUS_PLUS:
+    case TK_PRE_MINUS_MINUS:
+    case TK_MINUS_MINUS:
+    case '~':
+    case '!': {
+        str_op = lexemePunctToStringWithFlags(ast->kind, lexeme_flags);
+        astUnaryArgToString(str, str_op, ast, lexeme_flags);
+        break;
+    }
+    case '-': {
+        str_op = lexemePunctToStringWithFlags(ast->kind, lexeme_flags);
+        if (ast->right == NULL) {
+            astUnaryArgToString(str, str_op, ast, lexeme_flags);
+        } else {
+            astBinaryArgToString(str, str_op, ast, lexeme_flags);
         }
+        break;
+    }
 
-        case AST_ASM_FUNC_BIND: {
-            aoStrCatPrintf(str, "%s =\\> %s",
-                    ast->asmfname->data,
-                    ast->fname->data);
-            break;
+    case AST_COMMENT: {
+        aoStrCatPrintf(str, "%s\n", ast->sval->data);
+        break;
+    }
+
+    default: {
+        str_op = lexemePunctToStringWithFlags(ast->kind, lexeme_flags);
+        astBinaryArgToString(str, str_op, ast, lexeme_flags);
+        if (ast->left == NULL) {
+            aoStrCatPrintf(str, "%s",
+                           lexemePunctToStringWithFlags(';', lexeme_flags));
         }
-
-        case AST_VAR_ARGS:
-            aoStrCatPrintf(str, "...\n");
-            break;
-
-        case AST_CLASS_REF: {
-            _astLValueToString(str, ast->cls, lexeme_flags);
-            if (ast->cls->deref_symbol == TK_ARROW) {
-                aoStrCatFmt(str, "->%s",ast->field);
-            } else {
-                aoStrCatFmt(str, ".%s",ast->field);
-            }
-            break;
-        }
-
-        case AST_GOTO: {
-            aoStr *label = astHackedGetLabel(ast);
-            aoStrCatPrintf(str,"goto %s",label->data);
-            break;
-        }
-
-        case AST_LABEL: {
-            aoStr *label = astHackedGetLabel(ast);
-            aoStrCatPrintf(str,"%s:",label->data);
-            break;
-        }
-
-        case AST_ADDR:
-            aoStrCatPrintf(str, "&");
-            _astLValueToString(str,ast->operand,lexeme_flags);
-            break;
-
-        case AST_DEREF: {
-            if (ast->operand->kind == '+') {
-                Ast *left = ast->operand->left;
-                Ast *right = ast->operand->right;
-                _astLValueToString(str, left, lexeme_flags);
-                aoStrPutChar(str, '[');
-                _astLValueToString(str, right, lexeme_flags);
-                aoStrPutChar(str, ']');
-            } else {
-                /* As `->` is a dereference we need to be able to distinguish 
-                 * between a class dereference and a general pointer dereference */
-                if (ast->deref_symbol != TK_ARROW) {
-                    aoStrCatFmt(str, "*");
-                }
-                _astLValueToString(str, ast->operand, lexeme_flags);
-            }
-            break;
-        }
-
-        case AST_CAST: {
-            _astLValueToString(str,ast->operand,lexeme_flags);
-            char *type = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "(%s)", type);
-            break;
-        }
-
-        case AST_RETURN:
-            aoStrCatPrintf(str, "return ");
-            _astLValueToString(str,ast->retval, lexeme_flags);
-            aoStrCatPrintf(str,"%s",
-                    lexemePunctToStringWithFlags(';',lexeme_flags));
-            break;
-
-        case AST_DEFAULT:
-            aoStrCatPrintf(str,"default:");
-            break;
-
-        case AST_CASE: {
-            if (ast->case_begin == ast->case_end) {
-                aoStrCatPrintf(str,"case (%ld):",ast->case_begin);
-            } else {
-                aoStrCatPrintf(str,"case (%ld ... %ld\\):",
-                        ast->case_begin,ast->case_end);
-            }
-            break;
-        }
-
-
-        case AST_SIZEOF: {
-            char *type_str = astTypeToString(ast->type);
-            aoStrCatPrintf(str, "sizeof(%s)",type_str);
-            break;
-        }
-
-        case AST_BREAK:
-            aoStrCatPrintf(str, "break;");
-            break;
-
-        case TK_PRE_PLUS_PLUS:
-        case TK_PLUS_PLUS:   
-        case TK_PRE_MINUS_MINUS:
-        case TK_MINUS_MINUS:
-        case '~':
-        case '!': {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            astUnaryArgToString(str,str_op,ast,lexeme_flags);
-            break;
-        }
-        case '-': {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            if (ast->right == NULL) {
-                astUnaryArgToString(str,str_op,ast,lexeme_flags);
-            } else {
-                astBinaryArgToString(str,str_op,ast,lexeme_flags);
-            }
-            break;
-        }
-
-        case AST_COMMENT: {
-            aoStrCatPrintf(str, "%s\n", ast->sval->data);
-            break;
-        }
-
-
-        default: {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            astBinaryArgToString(str,str_op,ast,lexeme_flags);
-            if (ast->left == NULL) {
-                aoStrCatPrintf(str,"%s",
-                        lexemePunctToStringWithFlags(';',lexeme_flags));
-            }
-            break;
-        }
+        break;
+    }
     }
 }
 
-aoStr *astLValueToAoStr(Ast *ast, unsigned long lexeme_flags) {
+aoStr *astLValueToAoStr(const Ast *ast, unsigned long lexeme_flags) {
     aoStr *str = aoStrNew();
-    _astLValueToString(str,ast,lexeme_flags);
+    _astLValueToString(str, ast, lexeme_flags);
     return str;
 }
 
-char *astLValueToString(Ast *ast, unsigned long lexeme_flags) {
-    aoStr *str = astLValueToAoStr(ast,lexeme_flags);
+char *astLValueToString(const Ast *ast, unsigned long lexeme_flags) {
+    const aoStr *str = astLValueToAoStr(ast, lexeme_flags);
     return aoStrMove(str);
 }
 
 /* Just print out one */
 void astPrint(Ast *ast) {
-    char *str = astToString(ast);
+    const char *str = astToString(ast);
     printf("%s\n", str);
 }
 
-void astTypePrint(AstType *type) {
-    char *str = astTypeToString(type);
+void astTypePrint(const AstType *type) {
+    const char *str = astTypeToString(type);
     printf("%s\n", str);
 }
 
 void astKindPrint(int kind) {
-    char *str = astKindToString(kind);
-    printf("%s\n",str);
+    const char *str = astKindToString(kind);
+    printf("%s\n", str);
 }
 
-const char *astTypeKindToHumanReadable(AstType *type) {
+const char *astTypeKindToHumanReadable(const AstType *type) {
     switch (type->kind) {
-        case AST_TYPE_VOID:    return "void type";
-        case AST_TYPE_INT:     return "integer type";
-        case AST_TYPE_FLOAT:   return "float type";
-        case AST_TYPE_CHAR:    return "character type";
-        case AST_TYPE_ARRAY:   return "array type";
-        case AST_TYPE_POINTER: return "pointer type";
-        case AST_TYPE_FUNC:    return "function";
-        case AST_TYPE_CLASS:   return "class";
-        case AST_TYPE_UNION:   return "union";
-        case AST_TYPE_AUTO:    return "auto type";
-        default:
-            loggerPanic("Cannot find kind: %d\n", type->kind);
+    case AST_TYPE_VOID:
+        return "void type";
+    case AST_TYPE_INT:
+        return "integer type";
+    case AST_TYPE_FLOAT:
+        return "float type";
+    case AST_TYPE_CHAR:
+        return "character type";
+    case AST_TYPE_ARRAY:
+        return "array type";
+    case AST_TYPE_POINTER:
+        return "pointer type";
+    case AST_TYPE_FUNC:
+        return "function";
+    case AST_TYPE_CLASS:
+        return "class";
+    case AST_TYPE_UNION:
+        return "union";
+    case AST_TYPE_AUTO:
+        return "auto type";
+    default:
+        loggerPanic("Cannot find kind: %d\n", type->kind);
     }
 }
 
-const char *astKindToHumanReadable(Ast *ast) {
+const char *astKindToHumanReadable(const Ast *ast) {
     switch (ast->kind) {
-        case '|': return "bitwise OR";
-        case '&': return "bitwise AND";
-        case '!': return "logical NOT";
-        case '~': return "bitwise NOT";
-        case AST_ADDR: return "address";
-        case AST_DEREF: return "dereference";
-        case TK_PLUS_PLUS: return "increment";
-        case TK_MINUS_MINUS: return "decrement";
-        case AST_LITERAL: return "literal";
-        case AST_GVAR: return "global variable";
-        case AST_GOTO: return "goto statement";
-        case AST_LABEL: return "label";
-        case AST_JUMP: return "jump";
-        case AST_LVAR: return "local variable";
-        case AST_EXTERN_FUNC: return "external function";
-        case AST_FUN_PROTO: return "function prototype";
-        case AST_FUNC: return "function";
-        case AST_DECL: return "declaration";
-        case AST_STRING: return "string literal";
-        case AST_FUNCALL: return "function call";
-        case AST_ARRAY_INIT: return "array initialization";
-        case AST_IF: return "if statement";
-        case AST_FOR: return "for loop";
-        case AST_RETURN: return "return statement";
-        case AST_DO_WHILE: return "do-while loop";
-        case AST_WHILE: return "while loop";
-        case AST_CLASS_REF: return "class reference";
-        case AST_COMPOUND_STMT: return "compound statement";
-        case AST_ASM_STMT: return "assembly block";
-        case AST_ASM_FUNC_BIND: return "assembly function binding";
-        case AST_ASM_FUNCALL: return "assembly function call";
-        case AST_FUNPTR: return "function pointer";
-        case AST_FUNPTR_CALL: return "function pointer call";
-        case AST_BREAK: return "break statement";
-        case AST_CONTINUE: return "continue statement";
-        case AST_DEFAULT_PARAM: return "default parameter";
-        case AST_VAR_ARGS: return "variadic arguments";
-        case AST_ASM_FUNCDEF: return "assembly function definition";
-        case AST_CAST: return "type cast";
-        case AST_SWITCH: return "switch statement";
-        case AST_CASE: return "case statement";
-        case AST_DEFAULT: return "default statement";
-        case AST_SIZEOF: return "size of";
-        case AST_COMMENT: return "comment";
-        case TK_AND_AND: return "logical AND";
-        case TK_OR_OR: return "logical OR";
-        case TK_EQU_EQU: return "equality comparison";
-        case TK_NOT_EQU: return "inequality comparison";
-        case TK_LESS_EQU: return "less than or equal comparison";
-        case TK_GREATER_EQU: return "greater than or equal comparison";
-        case TK_SHL: return "left shift";
-        case TK_SHR: return "right shift";
-        case TK_ARROW: return "pointer dereference";
-        case '=': return "assignment";
-        case '>': return "greater than comparison";
-        case '<': return "less than comparison";
-        case '/': return "division";
-        case '+': return "addition";
-        case '*': return "multiplication";
-        case '-': return "subtraction";
-        default: return "unknown AST kind";
+    case '|':
+        return "bitwise OR";
+    case '&':
+        return "bitwise AND";
+    case '!':
+        return "logical NOT";
+    case '~':
+        return "bitwise NOT";
+    case AST_ADDR:
+        return "address";
+    case AST_DEREF:
+        return "dereference";
+    case TK_PLUS_PLUS:
+        return "increment";
+    case TK_MINUS_MINUS:
+        return "decrement";
+    case AST_LITERAL:
+        return "literal";
+    case AST_GVAR:
+        return "global variable";
+    case AST_GOTO:
+        return "goto statement";
+    case AST_LABEL:
+        return "label";
+    case AST_JUMP:
+        return "jump";
+    case AST_LVAR:
+        return "local variable";
+    case AST_EXTERN_FUNC:
+        return "external function";
+    case AST_FUN_PROTO:
+        return "function prototype";
+    case AST_FUNC:
+        return "function";
+    case AST_DECL:
+        return "declaration";
+    case AST_STRING:
+        return "string literal";
+    case AST_FUNCALL:
+        return "function call";
+    case AST_ARRAY_INIT:
+        return "array initialization";
+    case AST_IF:
+        return "if statement";
+    case AST_FOR:
+        return "for loop";
+    case AST_RETURN:
+        return "return statement";
+    case AST_DO_WHILE:
+        return "do-while loop";
+    case AST_WHILE:
+        return "while loop";
+    case AST_CLASS_REF:
+        return "class reference";
+    case AST_COMPOUND_STMT:
+        return "compound statement";
+    case AST_ASM_STMT:
+        return "assembly block";
+    case AST_ASM_FUNC_BIND:
+        return "assembly function binding";
+    case AST_ASM_FUNCALL:
+        return "assembly function call";
+    case AST_FUNPTR:
+        return "function pointer";
+    case AST_FUNPTR_CALL:
+        return "function pointer call";
+    case AST_BREAK:
+        return "break statement";
+    case AST_CONTINUE:
+        return "continue statement";
+    case AST_DEFAULT_PARAM:
+        return "default parameter";
+    case AST_VAR_ARGS:
+        return "variadic arguments";
+    case AST_ASM_FUNCDEF:
+        return "assembly function definition";
+    case AST_CAST:
+        return "type cast";
+    case AST_SWITCH:
+        return "switch statement";
+    case AST_CASE:
+        return "case statement";
+    case AST_DEFAULT:
+        return "default statement";
+    case AST_SIZEOF:
+        return "size of";
+    case AST_COMMENT:
+        return "comment";
+    case TK_AND_AND:
+        return "logical AND";
+    case TK_OR_OR:
+        return "logical OR";
+    case TK_EQU_EQU:
+        return "equality comparison";
+    case TK_NOT_EQU:
+        return "inequality comparison";
+    case TK_LESS_EQU:
+        return "less than or equal comparison";
+    case TK_GREATER_EQU:
+        return "greater than or equal comparison";
+    case TK_SHL:
+        return "left shift";
+    case TK_SHR:
+        return "right shift";
+    case TK_ARROW:
+        return "pointer dereference";
+    case '=':
+        return "assignment";
+    case '>':
+        return "greater than comparison";
+    case '<':
+        return "less than comparison";
+    case '/':
+        return "division";
+    case '+':
+        return "addition";
+    case '*':
+        return "multiplication";
+    case '-':
+        return "subtraction";
+    default:
+        return "unknown AST kind";
     }
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -2,8 +2,8 @@
 #define AST_H
 
 #include "aostr.h"
-#include "map.h"
 #include "list.h"
+#include "map.h"
 
 /* Relates to the 'kind' property on the AstType struct */
 #define AST_TYPE_VOID         0
@@ -20,54 +20,56 @@
 #define AST_TYPE_AUTO         11
 
 /* Relates to the 'kind' property on the Ast struct */
-#define AST_GVAR           256
-#define AST_DEREF          257
-#define AST_GOTO           258
-#define AST_LABEL          259
-#define AST_ADDR           260
-#define AST_LVAR           261
-#define AST_FUNC           262
-#define AST_DECL           263
-#define AST_STRING         264
-#define AST_FUNCALL        265
-#define AST_LITERAL        266
-#define AST_ARRAY_INIT     267
-#define AST_IF             268
-#define AST_FOR            269
-#define AST_RETURN         270
-#define AST_WHILE          271
-#define AST_OP_ADD         272
-#define AST_CLASS_REF      273
-#define AST_COMPOUND_STMT  274
-#define AST_ASM_STMT       275
-#define AST_ASM_FUNC_BIND  276
-#define AST_ASM_FUNCALL    277
-#define AST_FUNPTR         278
-#define AST_FUNPTR_CALL    279
-#define AST_BREAK          280
-#define AST_CONTINUE       281
-#define AST_DEFAULT_PARAM  282
-#define AST_VAR_ARGS       283
-#define AST_ASM_FUNCDEF    284
-#define AST_CAST           285
-#define AST_FUN_PROTO      286
-#define AST_CASE           287
-#define AST_JUMP           288
-#define AST_EXTERN_FUNC    289
-#define AST_DO_WHILE       290
-#define AST_PLACEHOLDER    291
-#define AST_SWITCH         292
-#define AST_DEFAULT        293
-#define AST_SIZEOF         294
-#define AST_COMMENT        295
+#define AST_GVAR          256
+#define AST_DEREF         257
+#define AST_GOTO          258
+#define AST_LABEL         259
+#define AST_ADDR          260
+#define AST_LVAR          261
+#define AST_FUNC          262
+#define AST_DECL          263
+#define AST_STRING        264
+#define AST_FUNCALL       265
+#define AST_LITERAL       266
+#define AST_ARRAY_INIT    267
+#define AST_IF            268
+#define AST_FOR           269
+#define AST_RETURN        270
+#define AST_WHILE         271
+#define AST_OP_ADD        272
+#define AST_CLASS_REF     273
+#define AST_COMPOUND_STMT 274
+#define AST_ASM_STMT      275
+#define AST_ASM_FUNC_BIND 276
+#define AST_ASM_FUNCALL   277
+#define AST_FUNPTR        278
+#define AST_FUNPTR_CALL   279
+#define AST_BREAK         280
+#define AST_CONTINUE      281
+#define AST_DEFAULT_PARAM 282
+#define AST_VAR_ARGS      283
+#define AST_ASM_FUNCDEF   284
+#define AST_CAST          285
+#define AST_FUN_PROTO     286
+#define AST_CASE          287
+#define AST_JUMP          288
+#define AST_EXTERN_FUNC   289
+#define AST_DO_WHILE      290
+#define AST_PLACEHOLDER   291
+#define AST_SWITCH        292
+#define AST_DEFAULT       293
+#define AST_SIZEOF        294
+#define AST_COMMENT       295
 
 /* @Cleanup
- * Urgently get rid of this, we do not need `n` ways of setting a label on 
+ * Urgently get rid of this, we do not need `n` ways of setting a label on
  * an AST it is extremely confusing */
-#define astHackedGetLabel(ast) \
-    ((ast)->kind == AST_GOTO || (ast)->kind == AST_LABEL ? ((ast)->slabel ? (ast)->slabel : (ast)->sval) : \
-    ((ast)->kind == AST_JUMP ? (ast)->jump_label : (ast)->kind == AST_CASE ? (ast)->case_label : NULL))
-
+#define astHackedGetLabel(ast)                                      \
+    ((ast)->kind == AST_GOTO || (ast)->kind == AST_LABEL ?          \
+             ((ast)->slabel ? (ast)->slabel : (ast)->sval) :        \
+             ((ast)->kind == AST_JUMP         ? (ast)->jump_label : \
+                      (ast)->kind == AST_CASE ? (ast)->case_label : \
+                                                NULL))
 
 typedef struct AstType AstType;
 /* Type of the variable or type of return type of a function */
@@ -99,8 +101,7 @@ typedef struct AstType {
     PtrVec *params;
 } AstType;
 
-
-#define AST_FLAG_INLINE (1<<0)
+#define AST_FLAG_INLINE (1 << 0)
 
 typedef struct Ast Ast;
 typedef struct Ast {
@@ -111,7 +112,7 @@ typedef struct Ast {
     long deref_symbol;
     union {
         struct {
-        /* 8, 16, 32, 64 bit number */
+            /* 8, 16, 32, 64 bit number */
             long long i64;
         };
 
@@ -180,8 +181,8 @@ typedef struct Ast {
             /* Declaration */
             List *locals;
             Ast *body;
-            Ast *ref; /* for function pointers, a reference to the variable 
-                       * allows for keeping track of the offset when converting 
+            Ast *ref; /* for function pointers, a reference to the variable
+                       * allows for keeping track of the offset when converting
                        * to assembly. */
             Ast *default_fn; /* For function pointers, allows setting a default
                               * value... we could use this for all default vals
@@ -257,9 +258,9 @@ typedef struct Ast {
             long case_end;
             aoStr *case_label;
             /* Scopes ast nodes to the case label... Think this makes sense;
-             * in my head it does. As then all the top level case nodes 
+             * in my head it does. As then all the top level case nodes
              * have the begining and end ranges... making creating a jump table
-             * feasible... or degrade into a series of 'ifs' if the range is 
+             * feasible... or degrade into a series of 'ifs' if the range is
              * sparse */
             List *case_asts;
         };
@@ -298,14 +299,14 @@ void astMemoryInit(void);
 void astMemoryRelease(void);
 void astMemoryStats(void);
 
-AstType *astTypeCopy(AstType *type);
+AstType *astTypeCopy(const AstType *type);
 void astVectorRelease(PtrVec *vec);
 
 /* Literals */
 Ast *astI64Type(long long val);
 Ast *astF64Type(double val);
 Ast *astCharType(long ch);
-Ast *astString(char *str, int len, long real_len);
+Ast *astString(const char *str, int len, long real_len);
 
 /* Declarations */
 Ast *astDecl(Ast *var, Ast *init);
@@ -315,8 +316,8 @@ Ast *astBinaryOp(long operation, Ast *left, Ast *right, int *_is_err);
 Ast *astUnaryOperator(AstType *type, long kind, Ast *operand);
 
 /* Variable definitions */
-Ast *astLVar(AstType *type, char *name, int len);
-Ast *astGVar(AstType *type, char *name, int len, int is_static);
+Ast *astLVar(AstType *type, const char *name, int len);
+Ast *astGVar(AstType *type, const char *name, int len, int is_static);
 
 /* More beefy data structures */
 Ast *astArrayInit(List *init);
@@ -324,56 +325,57 @@ Ast *astCompountStatement(List *stmts);
 
 /* Control */
 Ast *astFor(Ast *init, Ast *cond, Ast *step, Ast *body, aoStr *for_begin,
-        aoStr *for_middle, aoStr *for_end);
+            aoStr *for_middle, aoStr *for_end);
 Ast *astIf(Ast *cond, Ast *then, Ast *els);
 Ast *astWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
-        aoStr *while_end);
-Ast *astDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin, 
-        aoStr *while_end);
-Ast *astContinue(aoStr *continue_label);
-Ast *astBreak(aoStr *break_label);
-Ast *astCase(aoStr *case_label, long case_begin, long case_end, List *case_asts);
+              aoStr *while_end);
+Ast *astDoWhile(Ast *whilecond, Ast *whilebody, aoStr *while_begin,
+                aoStr *while_end);
+Ast *astContinue(const aoStr *continue_label);
+Ast *astBreak(const aoStr *break_label);
+Ast *astCase(aoStr *case_label, long case_begin, long case_end,
+             List *case_asts);
 /* Do it with lists, then do it with a vector */
 Ast *astSwitch(Ast *cond, PtrVec *cases, Ast *case_default,
-        aoStr *case_end_label, int switch_bounds_checked);
-Ast *astDefault(aoStr *case_label,List *case_asts);
+               aoStr *case_end_label, int switch_bounds_checked);
+Ast *astDefault(aoStr *case_label, List *case_asts);
 
 /* Functions */
-Ast *astFunctionCall(AstType *type, char *fname, int len, PtrVec *argv);
-Ast *astFunction(AstType *rettype, char *fname, int len, PtrVec *params,
+Ast *astFunctionCall(AstType *type, const char *fname, int len, PtrVec *argv);
+Ast *astFunction(AstType *rettype, const char *fname, int len, PtrVec *params,
                  Ast *body, List *locals, int has_var_args);
 Ast *astReturn(Ast *retval, AstType *rettype);
-Ast *astFunctionPtr(AstType *type, char *fname, int len, 
-                    PtrVec *params);
+Ast *astFunctionPtr(AstType *type, const char *fname, int len, PtrVec *params);
 
-Ast *astFunctionPtrCall(AstType *type, char *fname, int len,
-                         PtrVec *argv, Ast *ref);
+Ast *astFunctionPtrCall(AstType *type, const char *fname, int len, PtrVec *argv,
+                        Ast *ref);
 Ast *astFunctionDefaultParam(Ast *var, Ast *init);
 Ast *astVarArgs(void);
 
 Ast *astAsmBlock(aoStr *asm_stmt, List *funcs);
-Ast *astAsmFunctionBind(AstType *rettype, aoStr *asm_fname, 
-        aoStr *fname, PtrVec *params);
+Ast *astAsmFunctionBind(AstType *rettype, aoStr *asm_fname, aoStr *fname,
+                        PtrVec *params);
 Ast *astAsmFunctionCall(AstType *rettype, aoStr *asm_fname, PtrVec *argv);
 Ast *astAsmFunctionDef(aoStr *asm_fname, aoStr *asm_stmt);
 
 /* Only used when transpiling */
 Ast *astSizeOf(AstType *type);
-Ast *astComment(char *comment, int len);
+Ast *astComment(const char *comment, int len);
 
 /* Gotos */
 Ast *astGoto(aoStr *label);
 Ast *astLabel(aoStr *label);
-Ast *astJump(char *jumpname, int len);
+Ast *astJump(const char *jumpname, int len);
 
 /* Pointers */
 AstType *astMakePointerType(AstType *type);
 AstType *astMakeArrayType(AstType *type, int len);
-AstType *astMakeClassField(AstType *type, int offset);
+AstType *astMakeClassField(const AstType *type, int offset);
 AstType *astMakeFunctionType(AstType *rettype, PtrVec *param_types);
 AstType *astConvertArray(AstType *ast_type);
 Ast *astClassRef(AstType *type, Ast *cls, char *field_name);
-AstType *astClassType(StrMap *fields, aoStr *clsname, int size, int is_intrinsic);
+AstType *astClassType(StrMap *fields, aoStr *clsname, int size,
+                      int is_intrinsic);
 Ast *astCast(Ast *var, AstType *to);
 
 AstType *astGetResultType(long op, AstType *a, AstType *b);
@@ -381,37 +383,37 @@ AstType *astTypeCheck(AstType *expected, Ast *ast, long op);
 
 aoStr *astMakeLabel(void);
 aoStr *astMakeTmpName(void);
-int astIsIntType(AstType *type);
-int astIsFloatType(AstType *type);
+int astIsIntType(const AstType *type);
+int astIsFloatType(const AstType *type);
 int astIsVarArg(Ast *ast);
 int astIsRangeOperator(long op);
 Ast *astGlobalCmdArgs(void);
 
-aoStr *astNormaliseFunctionName(char *fname);
+aoStr *astNormaliseFunctionName(const char *fname);
 int astIsAssignment(long op);
 int astIsBinCmp(long op);
 Ast *astMakeForeverSentinal(void);
 Ast *astMakeLoopSentinal(void);
 char *astAnnonymousLabel(void);
 
-int astIsLabelMatch(Ast *ast, aoStr *goto_label);
+int astIsLabelMatch(const Ast *ast, const aoStr *goto_label);
 
 /* For debugging */
-aoStr *astTypeToAoStr(AstType *type);
-char *astTypeToString(AstType *type);
-char *astTypeToColorString(AstType *type);
-aoStr *astTypeToColorAoStr(AstType *type);
+aoStr *astTypeToAoStr(const AstType *type);
+char *astTypeToString(const AstType *type);
+char *astTypeToColorString(const AstType *type);
+aoStr *astTypeToColorAoStr(const AstType *type);
 char *astKindToString(int kind);
-char *astFunctionToString(Ast *func);
-char *astFunctionNameToString(AstType *rettype, char *fname, int len);
+char *astFunctionToString(const Ast *func);
+char *astFunctionNameToString(const AstType *rettype, const char *fname,
+                              int len);
 char *astToString(Ast *ast);
-char *astLValueToString(Ast *ast, unsigned long lexme_flags);
-aoStr *astLValueToAoStr(Ast *ast, unsigned long lexeme_flags);
+char *astLValueToString(const Ast *ast, unsigned long lexme_flags);
+aoStr *astLValueToAoStr(const Ast *ast, unsigned long lexeme_flags);
 void astPrint(Ast *ast);
-void astTypePrint(AstType *type);
+void astTypePrint(const AstType *type);
 void astKindPrint(int kind);
-const char *astTypeKindToHumanReadable(AstType *type);
-const char *astKindToHumanReadable(Ast *ast);
+const char *astTypeKindToHumanReadable(const AstType *type);
+const char *astKindToHumanReadable(const Ast *ast);
 
 #endif
-

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -1,3 +1,5 @@
+#include <sys/time.h>
+
 #include <assert.h>
 #include <ctype.h>
 #include <stddef.h>
@@ -5,7 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include "aostr.h"
@@ -18,20 +19,22 @@
 #include "util.h"
 #include "version.h"
 
-static char *x86_registers = "rax,rbx,rcx,rdx,rsi,rdi,rbp,rsp,r8,r9,r10,r11,r12,"
-    "r13,r14,r15,cs,ds,es,fs,gs,ss,rip,rflags,st0,st1,st2,st3,st4,st5,st6,st7,"
-    "mm0,mm1,mm2,mm3,mm4,mm5,mm6,mm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,"
-    "xmm8,xmm9,xmm10,xmm11,xmm12,xmm13,xmm14,xmm15,ymm0,ymm1,ymm2,ymm3,ymm4,"
-    "ymm5,ymm6,ymm7,ymm8,ymm9,ymm10,ymm11,ymm12,ymm13,ymm14,ymm15,cr0,cr2,"
-    "cr3,cr4,cr8,dr0,dr1,dr2,dr3,dr6,dr7,eax,ebx,ecx,edx,esi,edi,ebp,eip,esp,"
-    "ax,bx,cx,dx,ah,al,bh,bl,ch,cl,dh,dl,"
-    // Not registers but need % in front of them
-    "sil";
+static char *x86_registers =
+        "rax,rbx,rcx,rdx,rsi,rdi,rbp,rsp,r8,r9,r10,r11,r12,"
+        "r13,r14,r15,cs,ds,es,fs,gs,ss,rip,rflags,st0,st1,st2,st3,st4,st5,st6,st7,"
+        "mm0,mm1,mm2,mm3,mm4,mm5,mm6,mm7,xmm0,xmm1,xmm2,xmm3,xmm4,xmm5,xmm6,xmm7,"
+        "xmm8,xmm9,xmm10,xmm11,xmm12,xmm13,xmm14,xmm15,ymm0,ymm1,ymm2,ymm3,ymm4,"
+        "ymm5,ymm6,ymm7,ymm8,ymm9,ymm10,ymm11,ymm12,ymm13,ymm14,ymm15,cr0,cr2,"
+        "cr3,cr4,cr8,dr0,dr1,dr2,dr3,dr6,dr7,eax,ebx,ecx,edx,esi,edi,ebp,eip,esp,"
+        "ax,bx,cx,dx,ah,al,bh,bl,ch,cl,dh,dl,"
+        // Not registers but need % in front of them
+        "sil";
 
-/* eventually it would be nice to remove the dependency on these functions 
+/* eventually it would be nice to remove the dependency on these functions
  * syscall can be used for a lot of them */
-static char *libc_functions = "printf,snprintf,exit,malloc,free,open,read,close,"
-    "exit,system";
+static char *libc_functions =
+        "printf,snprintf,exit,malloc,free,open,read,close,"
+        "exit,system";
 
 typedef struct BuiltInType {
     char *name;
@@ -40,94 +43,93 @@ typedef struct BuiltInType {
     int issigned;
 } BuiltInType;
 
-/* Name, kind, size, issigned, essentially duplicated in the 
+/* Name, kind, size, issigned, essentially duplicated in the
  * lexer */
 static BuiltInType built_in_types[] = {
-    /* XXX: merge with lexers types
-     * Holyc Types */
-    {"U0",AST_TYPE_VOID,0,0},
-    {"Bool",AST_TYPE_CHAR,1,1},
-    {"I8",AST_TYPE_CHAR,1,1},
-    {"U8",AST_TYPE_CHAR,1,0},
-    {"I16",AST_TYPE_INT,2,1},
-    {"U16",AST_TYPE_INT,2,0},
-    {"I32",AST_TYPE_INT,4,1},
-    {"U32",AST_TYPE_INT,4,0},
-    {"I64",AST_TYPE_INT,8,1},
-    {"U64",AST_TYPE_INT,8,0},
-    {"F64",AST_TYPE_FLOAT,8,0},
-    {"inline",AST_TYPE_INLINE,0,0},
-    {"public",AST_TYPE_VIS_MODIFIER,0,0},
-    {"auto",AST_TYPE_AUTO,0,0},
-    {"private",AST_TYPE_VIS_MODIFIER,0,0},
+        /* XXX: merge with lexers types
+         * Holyc Types */
+        {"U0", AST_TYPE_VOID, 0, 0},
+        {"Bool", AST_TYPE_CHAR, 1, 1},
+        {"I8", AST_TYPE_CHAR, 1, 1},
+        {"U8", AST_TYPE_CHAR, 1, 0},
+        {"I16", AST_TYPE_INT, 2, 1},
+        {"U16", AST_TYPE_INT, 2, 0},
+        {"I32", AST_TYPE_INT, 4, 1},
+        {"U32", AST_TYPE_INT, 4, 0},
+        {"I64", AST_TYPE_INT, 8, 1},
+        {"U64", AST_TYPE_INT, 8, 0},
+        {"F64", AST_TYPE_FLOAT, 8, 0},
+        {"inline", AST_TYPE_INLINE, 0, 0},
+        {"public", AST_TYPE_VIS_MODIFIER, 0, 0},
+        {"auto", AST_TYPE_AUTO, 0, 0},
+        {"private", AST_TYPE_VIS_MODIFIER, 0, 0},
 };
 
 static void cctrlAddBuiltinMacros(Cctrl *cc) {
-    long bufsize = sizeof(char)*128;
+    long bufsize = sizeof(char) * 128;
 
     Lexeme *le = lexemeSentinal();
-    if (IS_BSD)   strMapAdd(cc->macro_defs,"IS_BSD",le);
-    if (IS_LINUX) strMapAdd(cc->macro_defs,"IS_LINUX",le);
+    if (IS_BSD)
+        strMapAdd(cc->macro_defs, "IS_BSD", le);
+    if (IS_LINUX)
+        strMapAdd(cc->macro_defs, "IS_LINUX", le);
 
 #ifdef IS_MACOS
-    strMapAdd(cc->macro_defs,"IS_MACOS",le);
+    strMapAdd(cc->macro_defs, "IS_MACOS", le);
 #endif
-    
-    if (IS_X86_64)      {
-        strMapAdd(cc->macro_defs,"IS_X86_64",le);
-        le = lexemeNew("X86_64",6);
+
+    if (IS_X86_64) {
+        strMapAdd(cc->macro_defs, "IS_X86_64", le);
+        le = lexemeNew("X86_64", 6);
         le->tk_type = TK_STR;
-        strMapAdd(cc->macro_defs,"__ARCH__",le);
+        strMapAdd(cc->macro_defs, "__ARCH__", le);
     } else if (IS_ARM_64) {
-        strMapAdd(cc->macro_defs,"IS_ARM_64",le);
-        le = lexemeNew("ARM_64",6);
+        strMapAdd(cc->macro_defs, "IS_ARM_64", le);
+        le = lexemeNew("ARM_64", 6);
         le->tk_type = TK_STR;
-        strMapAdd(cc->macro_defs,"__ARCH__",le);
+        strMapAdd(cc->macro_defs, "__ARCH__", le);
     }
 
     struct timeval tm;
-    gettimeofday(&tm,NULL);
-    long milliseconds = (tm.tv_sec*1000) +
-        (tm.tv_usec/1000);
+    gettimeofday(&tm, NULL);
+    long milliseconds = (tm.tv_sec * 1000) + (tm.tv_usec / 1000);
     time_t seconds = milliseconds / 1000;
-    struct tm *ptm = localtime(&seconds);
+    const struct tm *ptm = localtime(&seconds);
 
     char *time = (char *)malloc(bufsize);
     char *date = (char *)malloc(bufsize);
     char *time_stamp = (char *)malloc(bufsize);
 
-    long len = snprintf(time,bufsize,"%02d:%02d:%02d",
-            ptm->tm_hour,ptm->tm_min,ptm->tm_sec);
+    long len = snprintf(time, bufsize, "%02d:%02d:%02d", ptm->tm_hour,
+                        ptm->tm_min, ptm->tm_sec);
     time[len] = '\0';
-    le = lexemeNew(time,len);
+    le = lexemeNew(time, len);
     le->tk_type = TK_STR;
-    strMapAdd(cc->macro_defs,"__TIME__",le);
+    strMapAdd(cc->macro_defs, "__TIME__", le);
 
-    len = snprintf(date,bufsize,"%04d/%02d/%02d",
-            ptm->tm_year+1900,ptm->tm_mon+1,ptm->tm_mday);
+    len = snprintf(date, bufsize, "%04d/%02d/%02d", ptm->tm_year + 1900,
+                   ptm->tm_mon + 1, ptm->tm_mday);
     date[len] = '\0';
-    le = lexemeNew(date,len);
+    le = lexemeNew(date, len);
     le->tk_type = TK_STR;
-    strMapAdd(cc->macro_defs,"__DATE__",le);
+    strMapAdd(cc->macro_defs, "__DATE__", le);
 
-    len = snprintf(time_stamp,bufsize,
-            "%d-%02d-%02d %02d:%02d:%02d",
-            ptm->tm_year+1900,
-            ptm->tm_mon+1,ptm->tm_mday,ptm->tm_hour,
-            ptm->tm_min,ptm->tm_sec);
+    len = snprintf(time_stamp, bufsize, "%d-%02d-%02d %02d:%02d:%02d",
+                   ptm->tm_year + 1900, ptm->tm_mon + 1, ptm->tm_mday,
+                   ptm->tm_hour, ptm->tm_min, ptm->tm_sec);
     date[len] = '\0';
-    le = lexemeNew(time_stamp,len);
+    le = lexemeNew(time_stamp, len);
     le->tk_type = TK_STR;
-    strMapAdd(cc->macro_defs,"__TIMESTAMP__",le);
+    strMapAdd(cc->macro_defs, "__TIMESTAMP__", le);
 
 #ifdef HCC_LINK_SQLITE3
     le = lexemeSentinal();
-    strMapAdd(cc->macro_defs,"__HCC_LINK_SQLITE3__",le);
+    strMapAdd(cc->macro_defs, "__HCC_LINK_SQLITE3__", le);
 #endif
 
-    le = lexemeNew((char *)cctrlGetVersion(),len);
+    le = lexemeNew((char *)cctrlGetVersion(), len);
     le->tk_type = TK_STR;
-    strMapAdd(cc->macro_defs,"__HCC_VERSION__",le);
+    strMapAdd(cc->macro_defs, "__HCC_VERSION__", le);
 }
 
 Cctrl *ccMacroProcessor(StrMap *macro_defs) {
@@ -157,7 +159,7 @@ Cctrl *cctrlNew(void) {
     cc->ast_list = listNew();
     cc->initalisers = listNew();
     cc->initaliser_locals = listNew();
-    /* These are temoraries that the parser will allocate and 
+    /* These are temoraries that the parser will allocate and
      * NULL out between parses of classes and functions */
     cc->localenv = NULL;
     cc->tmp_rettype = NULL;
@@ -169,23 +171,23 @@ Cctrl *cctrlNew(void) {
     cc->token_buffer = NULL;
 
     int len;
-    aoStr **str_array = aoStrSplit(x86_registers,',',&len);
+    aoStr **str_array = aoStrSplit(x86_registers, ',', &len);
     for (int i = 0; i < len; ++i) {
         char *reg = aoStrMove(str_array[i]);
-        strMapAdd(cc->x86_registers,reg,reg);
+        strMapAdd(cc->x86_registers, reg, reg);
     }
     free(str_array);
 
-    str_array = aoStrSplit(libc_functions,',',&len);
+    str_array = aoStrSplit(libc_functions, ',', &len);
     for (int i = 0; i < len; ++i) {
         char *libc_func = aoStrMove(str_array[i]);
-        strMapAdd(cc->libc_functions,libc_func,libc_func);
+        strMapAdd(cc->libc_functions, libc_func, libc_func);
     }
     free(str_array);
 
     for (int i = 0; i < (int)static_size(built_in_types); ++i) {
         AstType *type = (AstType *)malloc(sizeof(AstType));
-        BuiltInType *built_in = &built_in_types[i]; 
+        BuiltInType *built_in = &built_in_types[i];
         type->size = built_in->size;
         type->issigned = built_in->issigned;
         type->kind = built_in->kind;
@@ -196,17 +198,18 @@ Cctrl *cctrlNew(void) {
     cctrlAddBuiltinMacros(cc);
 
     Ast *cmd_args = astGlobalCmdArgs();
-    listAppend(cc->ast_list,cmd_args->argc);
-    listAppend(cc->ast_list,cmd_args->argv);
-    strMapAdd(cc->global_env,"argc",cmd_args->argc->declvar);
-    strMapAdd(cc->global_env,"argv",cmd_args->argv->declvar);
+    listAppend(cc->ast_list, cmd_args->argc);
+    listAppend(cc->ast_list, cmd_args->argv);
+    strMapAdd(cc->global_env, "argc", cmd_args->argc->declvar);
+    strMapAdd(cc->global_env, "argv", cmd_args->argv->declvar);
     return cc;
 }
 
 static Lexeme *token_ring_buffer[CCTRL_TOKEN_BUFFER_SIZE];
 
 TokenRingBuffer *tokenRingBufferStaticNew(void) {
-    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(
+            sizeof(TokenRingBuffer));
     ring_buffer->tail = 0;
     ring_buffer->head = 0;
     ring_buffer->size = 0;
@@ -219,7 +222,8 @@ TokenRingBuffer *tokenRingBufferStaticNew(void) {
 }
 
 TokenRingBuffer *tokenRingBufferNew(void) {
-    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(
+            sizeof(TokenRingBuffer));
     ring_buffer->tail = 0;
     ring_buffer->head = 0;
     ring_buffer->size = 0;
@@ -233,17 +237,15 @@ ssize_t tokenRingBufferGetIdx(ssize_t idx, size_t capacity) {
 
 void tokenBufferPrint(TokenRingBuffer *ring_buffer) {
     for (int i = 0, idx = ring_buffer->tail; i < ring_buffer->size;
-            i++, idx = tokenRingBufferGetIdx(idx, ring_buffer->capacity)) {
+         i++, idx = tokenRingBufferGetIdx(idx, ring_buffer->capacity)) {
         printf(">> %s\n", lexemeToString(ring_buffer->entries[idx]));
     }
     printf("\n");
 }
 
-
-int tokenRingBufferEmpty(TokenRingBuffer *ring_buffer) {
+int tokenRingBufferEmpty(const TokenRingBuffer *ring_buffer) {
     return ring_buffer->size == 0;
 }
-
 
 /* Add a token to the ring buffer and remove the oldest element */
 void tokenRingBufferPush(TokenRingBuffer *ring_buffer, Lexeme *token) {
@@ -289,15 +291,17 @@ Lexeme *tokenRingBufferPeek(TokenRingBuffer *ring_buffer) {
 }
 
 int tokenRingBufferRewind(TokenRingBuffer *ring_buffer) {
-    //if (tokenRingBufferEmpty(ring_buffer)) { //|| ring_buffer->tail == ring_buffer->head) {
-    //    return 0;
-    //}
+    // if (tokenRingBufferEmpty(ring_buffer)) { //|| ring_buffer->tail ==
+    // ring_buffer->head) {
+    //     return 0;
+    //  }
 
-    Lexeme *token = ring_buffer->entries[ring_buffer->tail];
+    const Lexeme *token = ring_buffer->entries[ring_buffer->tail];
     size_t capacity = ring_buffer->capacity;
     ssize_t offset = 1;
     do {
-        ring_buffer->tail = ((ring_buffer->tail - offset) + capacity) & (capacity-1);
+        ring_buffer->tail = ((ring_buffer->tail - offset) + capacity) &
+                (capacity - 1);
         token = ring_buffer->entries[ring_buffer->tail];
         offset++;
     } while (token && token->tk_type == TK_COMMENT);
@@ -307,8 +311,9 @@ int tokenRingBufferRewind(TokenRingBuffer *ring_buffer) {
 
 void cctrLoadNextTokens(Cctrl *cc, ssize_t token_count) {
     for (ssize_t i = 0; i < token_count; ++i) {
-        Lexeme *token = lexToken(cc->macro_defs,cc->lexer_);
-        if (!token) break;
+        Lexeme *token = lexToken(cc->macro_defs, cc->lexer_);
+        if (!token)
+            break;
         tokenRingBufferPush(cc->token_buffer, token);
     }
 }
@@ -324,7 +329,8 @@ void cctrlInitParse(Cctrl *cc, Lexer *lexer_) {
 void cctrlInitMacroProcessor(Cctrl *cc) {
     cc->lexer_ = NULL;
     /* The caller will tack on the entries and size */
-    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(sizeof(TokenRingBuffer));
+    TokenRingBuffer *ring_buffer = (TokenRingBuffer *)malloc(
+            sizeof(TokenRingBuffer));
     ring_buffer->tail = 0;
     ring_buffer->head = 0;
     ring_buffer->size = 0;
@@ -334,26 +340,27 @@ void cctrlInitMacroProcessor(Cctrl *cc) {
     cc->tmp_func = NULL;
 }
 
-Lexeme *cctrlMaybeExpandToken(Cctrl *cc, Lexeme *token) {
+Lexeme *cctrlMaybeExpandToken(const Cctrl *cc, Lexeme *token) {
     if (token->tk_type != TK_IDENT) {
         return token;
     }
 
-    Lexeme *maybe_define = strMapGetLen(cc->macro_defs, token->start, token->len);
+    Lexeme *maybe_define = strMapGetLen(cc->macro_defs, token->start,
+                                        token->len);
     if (maybe_define) {
         if (cc->flags & CCTRL_PASTE_DEFINES) {
             return token;
         }
         return maybe_define;
     }
-    return token; 
+    return token;
 }
 
 Lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt) {
     assert(cnt > 0);
     /* The -1 is bizzare, however as an argument peeking by `1` you'd
      * expect to see the next token, which is infact `0` */
-    return tokenRingBufferPeekBy(cc->token_buffer, cnt-1);
+    return tokenRingBufferPeekBy(cc->token_buffer, cnt - 1);
 }
 
 Lexeme *cctrlTokenPeek(Cctrl *cc) {
@@ -366,16 +373,16 @@ Lexeme *cctrlTokenPeek(Cctrl *cc) {
             continue;
         }
         cc->lineno = token->line;
-        return cctrlMaybeExpandToken(cc,token);
+        return cctrlMaybeExpandToken(cc, token);
     }
     return NULL;
 }
 
-void cctrlTokenRewind(Cctrl *cc) {
-    TokenRingBuffer *ring_buffer = cc->token_buffer;
-    if (!tokenRingBufferRewind(ring_buffer)) {
-        return;
-    }
+void cctrlTokenRewind(const Cctrl *cc) {
+    // TokenRingBuffer *ring_buffer = cc->token_buffer;
+    // if (!tokenRingBufferRewind(ring_buffer)) {
+    //     return;
+    // }
 }
 
 Lexeme *cctrlTokenGet(Cctrl *cc) {
@@ -383,13 +390,13 @@ Lexeme *cctrlTokenGet(Cctrl *cc) {
     while (token) {
         tokenRingBufferPop(cc->token_buffer);
         if (token->tk_type == TK_COMMENT) {
-            /* XXX: Not really sure what to do with the comments or where they 
+            /* XXX: Not really sure what to do with the comments or where they
              * should go ??*/
             token = tokenRingBufferPeek(cc->token_buffer);
             continue;
         }
         if (cc->token_buffer->size < 3 && cc->lexer_) {
-            cctrLoadNextTokens(cc,5);
+            cctrLoadNextTokens(cc, 5);
         }
         cc->lineno = token->line;
         return cctrlMaybeExpandToken(cc, token);
@@ -401,119 +408,151 @@ aoStr *cctrlSeverityMessage(int severity) {
     aoStr *buf = aoStrNew();
     if (is_terminal) {
         switch (severity) {
-            case CCTRL_ERROR:
-                aoStrCatLen(buf,str_lit(ESC_BOLD_RED));
-                aoStrCatLen(buf,str_lit("error: "));
-                aoStrCatLen(buf,str_lit(ESC_RESET));
-                aoStrCatLen(buf,str_lit(ESC_CLEAR_BOLD));
-                break;
-            case CCTRL_WARN:
-                aoStrCatLen(buf,str_lit(ESC_BOLD_YELLOW));
-                aoStrCatLen(buf,str_lit("warning: "));
-                aoStrCatLen(buf,str_lit(ESC_RESET));
-                break;
-            case CCTRL_INFO:
-                aoStrCatLen(buf,str_lit(ESC_BOLD_CYAN));
-                aoStrCatLen(buf,str_lit("info: "));
-                aoStrCatLen(buf,str_lit(ESC_RESET));
-                break;
-            case CCTRL_ICE: {
-                char *ice_msg = mprintf(ESC_BOLD_RED"INTERNAL COMPILER ERROR"ESC_RESET" - hcc %s: ",
-                                        cctrlGetVersion());
-                aoStrCat(buf,ice_msg);
-                free(ice_msg);
-                break;
-            }
+        case CCTRL_ERROR:
+            aoStrCatLen(buf, str_lit(ESC_BOLD_RED));
+            aoStrCatLen(buf, str_lit("error: "));
+            aoStrCatLen(buf, str_lit(ESC_RESET));
+            aoStrCatLen(buf, str_lit(ESC_CLEAR_BOLD));
+            break;
+        case CCTRL_WARN:
+            aoStrCatLen(buf, str_lit(ESC_BOLD_YELLOW));
+            aoStrCatLen(buf, str_lit("warning: "));
+            aoStrCatLen(buf, str_lit(ESC_RESET));
+            break;
+        case CCTRL_INFO:
+            aoStrCatLen(buf, str_lit(ESC_BOLD_CYAN));
+            aoStrCatLen(buf, str_lit("info: "));
+            aoStrCatLen(buf, str_lit(ESC_RESET));
+            break;
+        case CCTRL_ICE: {
+            char *ice_msg = mprintf(ESC_BOLD_RED
+                                    "INTERNAL COMPILER ERROR" ESC_RESET
+                                    " - hcc %s: ",
+                                    cctrlGetVersion());
+            aoStrCat(buf, ice_msg);
+            free(ice_msg);
+            break;
+        }
         }
     } else {
         switch (severity) {
-            case CCTRL_ERROR: aoStrCatLen(buf,str_lit("error: ")); break;
-            case CCTRL_WARN: aoStrCatLen(buf,str_lit("warning: ")); break;
-            case CCTRL_INFO: aoStrCatLen(buf,str_lit("info: ")); break;
-            case CCTRL_ICE: {
-                char *ice_msg = mprintf("INTERNAL COMPILER ERROR - hcc %s: ",
-                                        cctrlGetVersion());
-                aoStrCat(buf,ice_msg);
-                free(ice_msg);
-                break;
-            }
+        case CCTRL_ERROR:
+            aoStrCatLen(buf, str_lit("error: "));
+            break;
+        case CCTRL_WARN:
+            aoStrCatLen(buf, str_lit("warning: "));
+            break;
+        case CCTRL_INFO:
+            aoStrCatLen(buf, str_lit("info: "));
+            break;
+        case CCTRL_ICE: {
+            char *ice_msg = mprintf("INTERNAL COMPILER ERROR - hcc %s: ",
+                                    cctrlGetVersion());
+            aoStrCat(buf, ice_msg);
+            free(ice_msg);
+            break;
+        }
         }
     }
     return buf;
 }
 
-void cctrlFileAndLine(Cctrl *cc, aoStr *buf, ssize_t lineno, ssize_t char_pos, char *msg, int severity) {
+void cctrlFileAndLine(const Cctrl *cc, aoStr *buf, ssize_t lineno,
+                      ssize_t char_pos, char *msg, int severity) {
     aoStr *severity_msg = cctrlSeverityMessage(severity);
 
-    aoStrCatFmt(buf,"%S%s", severity_msg, msg);
+    aoStrCatFmt(buf, "%S%s", severity_msg, msg);
     if (buf->data[buf->len - 1] != '\n') {
-        aoStrPutChar(buf,'\n');
+        aoStrPutChar(buf, '\n');
     }
 
     if (cc->lexer_) {
         LexFile *file = cc->lexer_->cur_file;
         char *file_name = file->filename->data;
         if (is_terminal) {
-            aoStrCatFmt(buf, " "ESC_CYAN"-->"ESC_RESET" %s:%I",
-                    file_name,
-                    lineno);
+            aoStrCatFmt(buf, " " ESC_CYAN "-->" ESC_RESET " %s:%I", file_name,
+                        lineno);
         } else {
             aoStrCatFmt(buf, " --> %s:%I", file_name, lineno);
         }
         if (char_pos > -1) {
-            aoStrCatFmt(buf,":%I",char_pos+1);
+            aoStrCatFmt(buf, ":%I", char_pos + 1);
         }
-        aoStrPutChar(buf,'\n');
+        aoStrPutChar(buf, '\n');
     } else {
         aoStrCatFmt(buf, "Parsing macro:%I ", lineno);
     }
     aoStrRelease(severity_msg);
 }
 
-char *lexemeToColor(Cctrl *cc, Lexeme *tok, int is_err) {
+char *lexemeToColor(const Cctrl *cc, const Lexeme *tok, int is_err) {
     if (!is_terminal) {
         switch (tok->tk_type) {
-            case TK_KEYWORD: return mprintf("%.*s", tok->len,tok->start);
-            case TK_STR: return mprintf("\"%.*s\"", tok->len,tok->start);
-            case TK_I64: return mprintf("%ld",tok->i64);
-            case TK_F64: return mprintf("%f",tok->f64);
-            case TK_IDENT: return mprintf("%.*s", tok->len,tok->start);
-            default: return mprintf("%.*s",tok->len, tok->start);
+        case TK_KEYWORD:
+            return mprintf("%.*s", tok->len, tok->start);
+        case TK_STR:
+            return mprintf("\"%.*s\"", tok->len, tok->start);
+        case TK_I64:
+            return mprintf("%ld", tok->i64);
+        case TK_F64:
+            return mprintf("%f", tok->f64);
+        case TK_IDENT:
+            return mprintf("%.*s", tok->len, tok->start);
+        default:
+            return mprintf("%.*s", tok->len, tok->start);
         }
-    } else if (is_terminal && is_err) {
+    }
+
+    if (is_err) {
         aoStr *buf = aoStrNew();
-        aoStrCat(buf,ESC_BOLD_RED);
+        aoStrCat(buf, ESC_BOLD_RED);
         switch (tok->tk_type) {
-            case TK_KEYWORD: aoStrCatFmt(buf, "%.*s", tok->len,tok->start); break;
-            case TK_STR: aoStrCatFmt(buf,"\"%.*s\"", tok->len,tok->start); break;
-            case TK_I64: aoStrCatFmt(buf,"%I",tok->i64); break;
-            case TK_F64: aoStrCatFmt(buf,"%f",tok->f64); break;
-            case TK_IDENT: aoStrCatFmt(buf,"%.*s", tok->len,tok->start); break;
-            default: aoStrCatFmt(buf,"%.*s",tok->len, tok->start); break;
+        case TK_KEYWORD:
+            aoStrCatFmt(buf, "%.*s", tok->len, tok->start);
+            break;
+        case TK_STR:
+            aoStrCatFmt(buf, "\"%.*s\"", tok->len, tok->start);
+            break;
+        case TK_I64:
+            aoStrCatFmt(buf, "%I", tok->i64);
+            break;
+        case TK_F64:
+            aoStrCatFmt(buf, "%f", tok->f64);
+            break;
+        case TK_IDENT:
+            aoStrCatFmt(buf, "%.*s", tok->len, tok->start);
+            break;
+        default:
+            aoStrCatFmt(buf, "%.*s", tok->len, tok->start);
+            break;
         }
-        aoStrCat(buf,ESC_RESET);
+        aoStrCat(buf, ESC_RESET);
         return aoStrMove(buf);
-    } else {
-        switch (tok->tk_type) {
-            case TK_KEYWORD: return mprintf(ESC_BLUE"%.*s"ESC_RESET, tok->len, tok->start);
-            case TK_STR: return mprintf(ESC_GREEN"\"%.*s\""ESC_RESET, tok->len,tok->start);
-            case TK_I64: return mprintf(ESC_PURPLE"%ld"ESC_RESET, tok->i64);
-            case TK_F64: return mprintf(ESC_PURPLE"%f"ESC_RESET, tok->f64);
-            case TK_IDENT: {
-                if (cctrlIsKeyword(cc, tok->start, tok->len)) {
-                    return mprintf(ESC_BLUE"%.*s"ESC_RESET,tok->len, tok->start);
-                } else {
-                    return mprintf("%.*s",tok->len, tok->start);
-                }
-            }
-            default: return mprintf("%.*s",tok->len, tok->start);
+    }
+
+    switch (tok->tk_type) {
+    case TK_KEYWORD:
+        return mprintf(ESC_BLUE "%.*s" ESC_RESET, tok->len, tok->start);
+    case TK_STR:
+        return mprintf(ESC_GREEN "\"%.*s\"" ESC_RESET, tok->len, tok->start);
+    case TK_I64:
+        return mprintf(ESC_PURPLE "%ld" ESC_RESET, tok->i64);
+    case TK_F64:
+        return mprintf(ESC_PURPLE "%f" ESC_RESET, tok->f64);
+    case TK_IDENT: {
+        if (cctrlIsKeyword(cc, tok->start, tok->len)) {
+            return mprintf(ESC_BLUE "%.*s" ESC_RESET, tok->len, tok->start);
+        } else {
+            return mprintf("%.*s", tok->len, tok->start);
         }
+    }
+    default:
+        return mprintf("%.*s", tok->len, tok->start);
     }
 }
 
-ssize_t cctrlGetCharErrorIdx(Cctrl *cc, Lexeme *cur_tok,
-                             const char *line_buffer)
-{
+ssize_t cctrlGetCharErrorIdx(const Cctrl *cc, Lexeme *cur_tok,
+                             const char *line_buffer) {
     (void)cc;
     Lexeme tok;
     Lexer l;
@@ -523,14 +562,15 @@ ssize_t cctrlGetCharErrorIdx(Cctrl *cc, Lexeme *cur_tok,
     ssize_t latest_offset = 0;
     int match = 0;
     /* to the beginning of the line */
-    while (lex(&l,&tok)) {
+    while (lex(&l, &tok)) {
         /* We want to find the last instance of the error not the first */
-        if (lexemeEq(cur_tok,&tok)) {
+        if (lexemeEq(cur_tok, &tok)) {
             match = 1;
             latest_offset = offset;
         }
         offset += tok.len;
-        if (cur_tok->tk_type != TK_STR && tok.tk_type == TK_STR) offset++;
+        if (cur_tok->tk_type != TK_STR && tok.tk_type == TK_STR)
+            offset++;
     }
     if (!match) {
         return -1;
@@ -538,9 +578,8 @@ ssize_t cctrlGetCharErrorIdx(Cctrl *cc, Lexeme *cur_tok,
     return latest_offset;
 }
 
-ssize_t cctrlGetErrorIdx(Cctrl *cc, ssize_t line, char ch,
-                         const char *line_buffer)
-{
+ssize_t cctrlGetErrorIdx(const Cctrl *cc, ssize_t line, char ch,
+                         const char *line_buffer) {
     (void)cc;
     (void)line;
     char *ptr = (char *)line_buffer;
@@ -550,22 +589,16 @@ ssize_t cctrlGetErrorIdx(Cctrl *cc, ssize_t line, char ch,
         }
         ptr++;
     }
-    return ptr-line_buffer;
+    return ptr - line_buffer;
 }
 
-void cctrlCreateColoredLine(Cctrl *cc,
-                            aoStr *buf,
-                            ssize_t lineno,
-                            int should_color_err,
-                            char *suggestion,
-                            ssize_t char_pos,
-                            ssize_t *_offset,
-                            ssize_t *_tok_len,
-                            const char *line_buffer)
-{
+void cctrlCreateColoredLine(Cctrl *cc, aoStr *buf, ssize_t lineno,
+                            int should_color_err, char *suggestion,
+                            ssize_t char_pos, ssize_t *_offset,
+                            ssize_t *_tok_len, const char *line_buffer) {
     (void)suggestion;
     if (is_terminal) {
-        aoStrCat(buf, ESC_CYAN"     |\n"ESC_RESET);
+        aoStrCat(buf, ESC_CYAN "     |\n" ESC_RESET);
     } else {
         aoStrCat(buf, "     |\n");
     }
@@ -579,83 +612,86 @@ void cctrlCreateColoredLine(Cctrl *cc,
     lexInit(&l, (char *)line_buffer, CCF_ACCEPT_WHITESPACE);
     ssize_t current_offset = 0;
 
-    /* This assumes we want the last match of an error as opposed to the first */
-    while (lex(&l,&tok)) {
+    /* This assumes we want the last match of an error as opposed to the first
+     */
+    while (lex(&l, &tok)) {
         char *colored_lexeme = NULL;
         int is_err = 0;
         if (should_color_err) {
-            if (cur_tok->tk_type != TK_STR && tok.tk_type == TK_STR) current_offset++;
+            if (cur_tok->tk_type != TK_STR && tok.tk_type == TK_STR)
+                current_offset++;
             if (lexemeEq(cur_tok, &tok)) {
                 if (current_offset == char_pos) {
                     tok_len = tok.len;
                     offset = current_offset;
                     is_err = 1;
-                    if (tok.tk_type == TK_STR) tok_len++;
+                    if (tok.tk_type == TK_STR)
+                        tok_len++;
                 }
             }
         }
 
-        colored_lexeme = lexemeToColor(cc,&tok, is_err && should_color_err);
+        colored_lexeme = lexemeToColor(cc, &tok, is_err && should_color_err);
         aoStrCat(colored_buffer, colored_lexeme);
         free(colored_lexeme);
         current_offset += tok.len;
     }
 
     if (is_terminal) {
-        aoStrCatPrintf(buf, ESC_CYAN"%4ld |"ESC_RESET"    ", lineno);
+        aoStrCatPrintf(buf, ESC_CYAN "%4ld |" ESC_RESET "    ", lineno);
         aoStrCatFmt(buf, "%S\n", colored_buffer);
     } else {
         aoStrCatPrintf(buf, "%4ld |    %s\n", lineno, colored_buffer->data);
     }
-    if (_offset) *_offset = offset;
-    if (_tok_len) *_tok_len = tok_len;
+    if (_offset)
+        *_offset = offset;
+    if (_tok_len)
+        *_tok_len = tok_len;
     aoStrRelease(colored_buffer);
 }
 
-aoStr *cctrlCreateErrorLine(Cctrl *cc,
-                            ssize_t lineno, 
-                            char *msg,
-                            int severity,
-                            char *suggestion)
-{
-    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED : CCTRL_WARN ? ESC_BOLD_YELLOW : ESC_CYAN;
+aoStr *cctrlCreateErrorLine(Cctrl *cc, ssize_t lineno, char *msg, int severity,
+                            char *suggestion) {
+    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED :
+            CCTRL_WARN                                 ? ESC_BOLD_YELLOW :
+                                                         ESC_CYAN;
     if (!cc->lexer_) {
         aoStr *buf = aoStrNew();
-        cctrlFileAndLine(cc,buf,lineno,-1,msg,severity);
+        cctrlFileAndLine(cc, buf, lineno, -1, msg, severity);
         if (is_terminal) {
-            aoStrCat(buf, ESC_CYAN"     |\n"ESC_RESET);
+            aoStrCat(buf, ESC_CYAN "     |\n" ESC_RESET);
         } else {
             aoStrCat(buf, "     |\n");
         }
         return buf;
     }
 
-    const char *line_buffer = lexerReportLine(cc->lexer_,lineno);
+    const char *line_buffer = lexerReportLine(cc->lexer_, lineno);
     Lexeme *cur_tok = cctrlTokenPeek(cc);
     aoStr *buf = aoStrNew();
-    long char_pos = cctrlGetCharErrorIdx(cc,cur_tok, line_buffer);
+    long char_pos = cctrlGetCharErrorIdx(cc, cur_tok, line_buffer);
 
     long offset = -1;
     long tok_len = -1;
 
-    cctrlFileAndLine(cc,buf,cur_tok->line,char_pos,msg,severity);
-    cctrlCreateColoredLine(cc, buf, lineno, 1, suggestion,
-            char_pos, &offset, &tok_len, line_buffer);
+    cctrlFileAndLine(cc, buf, cur_tok->line, char_pos, msg, severity);
+    cctrlCreateColoredLine(cc, buf, lineno, 1, suggestion, char_pos, &offset,
+                           &tok_len, line_buffer);
 
     if (char_pos != -1 && tok_len != -1) {
         if (is_terminal) {
-            aoStrCat(buf, ESC_CYAN"     |    "ESC_RESET);
+            aoStrCat(buf, ESC_CYAN "     |    " ESC_RESET);
         } else {
             aoStrCat(buf, "     |    ");
         }
 
         for (int i = 0; i < char_pos; ++i) {
-            aoStrPutChar(buf,' ');
+            aoStrPutChar(buf, ' ');
         }
 
         if (is_terminal) {
             for (int i = 0; i < tok_len; ++i) {
-                aoStrCatFmt(buf,"%s^%s",color,ESC_RESET);
+                aoStrCatFmt(buf, "%s^%s", color, ESC_RESET);
             }
         } else {
             for (int i = 0; i < tok_len; ++i) {
@@ -665,14 +701,14 @@ aoStr *cctrlCreateErrorLine(Cctrl *cc,
 
         if (suggestion) {
             if (is_terminal) {
-                aoStrCatFmt(buf, "%s %s%s",color,suggestion,ESC_RESET);
+                aoStrCatFmt(buf, "%s %s%s", color, suggestion, ESC_RESET);
             } else {
                 aoStrCatFmt(buf, " %s", suggestion);
             }
         }
     } else {
         if (is_terminal) {
-            aoStrCat(buf, ESC_CYAN"     |"ESC_RESET);
+            aoStrCat(buf, ESC_CYAN "     |" ESC_RESET);
         } else {
             aoStrCat(buf, "     |");
         }
@@ -680,33 +716,36 @@ aoStr *cctrlCreateErrorLine(Cctrl *cc,
     return buf;
 }
 
-aoStr *cctrlMessagVnsPrintF(Cctrl *cc, char *fmt, va_list ap, int severity) {
+aoStr *cctrlMessagVnsPrintF(Cctrl *cc, const char *fmt, va_list ap,
+                            int severity) {
     char *msg = mprintVa(fmt, ap, NULL);
     aoStr *bold_msg = aoStrNew();
     if (is_terminal) {
-        aoStrCatFmt(bold_msg, ESC_BOLD"%s"ESC_CLEAR_BOLD, msg);
+        aoStrCatFmt(bold_msg, ESC_BOLD "%s" ESC_CLEAR_BOLD, msg);
     } else {
         aoStrCatFmt(bold_msg, "%s", msg);
     }
-    Lexeme *cur_tok = cctrlTokenPeek(cc);
-    aoStr *buf = cctrlCreateErrorLine(cc,cur_tok->line,bold_msg->data,severity,NULL);
+    const Lexeme *cur_tok = cctrlTokenPeek(cc);
+    aoStr *buf = cctrlCreateErrorLine(cc, cur_tok->line, bold_msg->data,
+                                      severity, NULL);
     aoStrRelease(bold_msg);
     free(msg);
     return buf;
 }
 
-aoStr *cctrlMessagVnsPrintFWithSuggestion(Cctrl *cc, char *fmt, va_list ap, 
-                                          int severity, char *suggestion)
-{
+aoStr *cctrlMessagVnsPrintFWithSuggestion(Cctrl *cc, const char *fmt,
+                                          va_list ap, int severity,
+                                          char *suggestion) {
     char *msg = mprintVa(fmt, ap, NULL);
     aoStr *bold_msg = aoStrNew();
     if (is_terminal) {
-        aoStrCatFmt(bold_msg, ESC_BOLD"%s"ESC_CLEAR_BOLD, msg);
+        aoStrCatFmt(bold_msg, ESC_BOLD "%s" ESC_CLEAR_BOLD, msg);
     } else {
         aoStrCatFmt(bold_msg, "%s", msg);
     }
-    Lexeme *cur_tok = cctrlTokenPeek(cc);
-    aoStr *buf = cctrlCreateErrorLine(cc,cur_tok->line,bold_msg->data,severity,suggestion);
+    const Lexeme *cur_tok = cctrlTokenPeek(cc);
+    aoStr *buf = cctrlCreateErrorLine(cc, cur_tok->line, bold_msg->data,
+                                      severity, suggestion);
     aoStrRelease(bold_msg);
     free(msg);
     return buf;
@@ -714,35 +753,35 @@ aoStr *cctrlMessagVnsPrintFWithSuggestion(Cctrl *cc, char *fmt, va_list ap,
 
 aoStr *cctrlMessagePrintF(Cctrl *cc, int severity, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,severity);
+    va_start(ap, fmt);
+    aoStr *buf = cctrlMessagVnsPrintF(cc, fmt, ap, severity);
     va_end(ap);
     return buf;
 }
 
 void cctrlInfo(Cctrl *cc, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_INFO);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlMessagVnsPrintF(cc, fmt, ap, CCTRL_INFO);
+    fprintf(stderr, "%s\n", buf->data);
     aoStrRelease(buf);
     va_end(ap);
 }
 
 void cctrlWarning(Cctrl *cc, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_WARN);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlMessagVnsPrintF(cc, fmt, ap, CCTRL_WARN);
+    fprintf(stderr, "%s\n", buf->data);
     aoStrRelease(buf);
     va_end(ap);
 }
 
 void cctrlRaiseException(Cctrl *cc, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_ERROR);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlMessagVnsPrintF(cc, fmt, ap, CCTRL_ERROR);
+    fprintf(stderr, "%s\n", buf->data);
     aoStrRelease(buf);
     va_end(ap);
     exit(EXIT_FAILURE);
@@ -750,9 +789,11 @@ void cctrlRaiseException(Cctrl *cc, char *fmt, ...) {
 
 void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintFWithSuggestion(cc,fmt,ap,CCTRL_ERROR,suggestion);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlMessagVnsPrintFWithSuggestion(cc, fmt, ap,
+                                                          CCTRL_ERROR,
+                                                          suggestion);
+    fprintf(stderr, "%s\n", buf->data);
     aoStrRelease(buf);
     va_end(ap);
     exit(EXIT_FAILURE);
@@ -760,9 +801,9 @@ void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt, ...) {
 
 void cctrlIce(Cctrl *cc, char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_ICE);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlMessagVnsPrintF(cc, fmt, ap, CCTRL_ICE);
+    fprintf(stderr, "%s\n", buf->data);
     aoStrRelease(buf);
     va_end(ap);
     exit(EXIT_FAILURE);
@@ -771,28 +812,32 @@ void cctrlIce(Cctrl *cc, char *fmt, ...) {
 /* Rewind the token buffer until there is a match */
 void cctrlRewindUntilPunctMatch(Cctrl *cc, long ch, int *_count) {
     int count = 0;
-    Lexeme *peek = cctrlTokenPeek(cc);
+    const Lexeme *peek = cctrlTokenPeek(cc);
     while (!tokenPunctIs(peek, ch)) {
         cctrlTokenRewind(cc);
         peek = cctrlTokenPeek(cc);
         count++;
-        if (count > 5) break; // has to be some limit
+        if (count > 5)
+            break; // has to be some limit
     }
-    if (_count) *_count = count;
+    if (_count)
+        *_count = count;
 }
 
-void cctrlRewindUntilStrMatch(Cctrl *cc, char *str, int len, int *_count) {
+void cctrlRewindUntilStrMatch(Cctrl *cc, const char *str, int len,
+                              int *_count) {
     int count = 0;
-    Lexeme *peek = cctrlTokenPeek(cc);
-    while (!(peek->len == len && memcmp(peek->start,str,len) == 0)) {
+    const Lexeme *peek = cctrlTokenPeek(cc);
+    while (!(peek->len == len && memcmp(peek->start, str, len) == 0)) {
         cctrlTokenRewind(cc);
         peek = cctrlTokenPeek(cc);
         count++;
-        if (count > 5) break; // has to be some limit
+        if (count > 5)
+            break; // has to be some limit
     }
-    if (_count) *_count = count;
+    if (_count)
+        *_count = count;
 }
-
 
 /* assert the token we are currently pointing at is a TK_PUNCT and the 'i64'
  * matches 'expected'. Then consume this token else throw an error */
@@ -800,20 +845,21 @@ void cctrlTokenExpect(Cctrl *cc, long expected) {
     Lexeme *tok = cctrlTokenGet(cc);
     if (!tokenPunctIs(tok, expected)) {
         if (!tok) {
-            loggerPanic("line %ld: Ran out of tokens\n",cc->lineno);
+            loggerPanic("line %ld: Ran out of tokens\n", cc->lineno);
         } else {
-            cctrlRewindUntilStrMatch(cc,tok->start,tok->len,NULL);
+            cctrlRewindUntilStrMatch(cc, tok->start, tok->len, NULL);
             cctrlTokenRewind(cc);
-            aoStr *info_msg = cctrlMessagePrintF(cc,CCTRL_INFO,"Previous line was");
+            const aoStr *info_msg = cctrlMessagePrintF(cc, CCTRL_INFO,
+                                                       "Previous line was");
             cctrlTokenGet(cc);
 
-
-            aoStr *err_msg = cctrlMessagePrintF(cc,CCTRL_ERROR,"Syntax error, got an unexpected %s `%.*s`, perhaps you meant `%c`?",
-                    lexemeTypeToString(tok->tk_type), 
-                    tok->len, tok->start,
+            const aoStr *err_msg = cctrlMessagePrintF(
+                    cc, CCTRL_ERROR,
+                    "Syntax error, got an unexpected %s `%.*s`, perhaps you meant `%c`?",
+                    lexemeTypeToString(tok->tk_type), tok->len, tok->start,
                     (char)expected);
 
-            fprintf(stderr,"%s\n%s\n",info_msg->data, err_msg->data);
+            fprintf(stderr, "%s\n%s\n", info_msg->data, err_msg->data);
             aoStrRelease(info_msg);
             aoStrRelease(err_msg);
             exit(EXIT_FAILURE);
@@ -821,46 +867,48 @@ void cctrlTokenExpect(Cctrl *cc, long expected) {
     }
 }
 
-aoStr *cctrlRaiseFromTo(Cctrl *cc, int severity, char *suggestion, char from, 
-                        char to, char *fmt, va_list ap)
-{
-    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED : CCTRL_WARN ? ESC_BOLD_YELLOW : ESC_CYAN;
+aoStr *cctrlRaiseFromTo(Cctrl *cc, int severity, char *suggestion, char from,
+                        char to, const char *fmt, va_list ap) {
+    char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED :
+            CCTRL_WARN                                 ? ESC_BOLD_YELLOW :
+                                                         ESC_CYAN;
     char *msg = mprintVa(fmt, ap, NULL);
     aoStr *bold_msg = aoStrNew();
-    aoStrCatFmt(bold_msg, ESC_BOLD"%s"ESC_CLEAR_BOLD, msg);
+    aoStrCatFmt(bold_msg, ESC_BOLD "%s" ESC_CLEAR_BOLD, msg);
     Lexeme *cur_tok = cctrlTokenPeek(cc);
 
     char *line_buffer = lexerReportLine(cc->lexer_, cur_tok->line);
     aoStr *buf = aoStrNew();
     /* This is not a terribly efficient way of getting an error message */
-    long char_pos = cctrlGetCharErrorIdx(cc,cur_tok, line_buffer);
-    long from_idx = cctrlGetErrorIdx(cc,cur_tok->line,from, line_buffer);
-    long to_idx = cctrlGetErrorIdx(cc,cur_tok->line,to, line_buffer);
+    long char_pos = cctrlGetCharErrorIdx(cc, cur_tok, line_buffer);
+    long from_idx = cctrlGetErrorIdx(cc, cur_tok->line, from, line_buffer);
+    long to_idx = cctrlGetErrorIdx(cc, cur_tok->line, to, line_buffer);
 
     long offset = -1;
     long tok_len = -1;
 
-    cctrlFileAndLine(cc,buf,cur_tok->line,char_pos,bold_msg->data,severity);
-    cctrlCreateColoredLine(cc, buf, cur_tok->line, 0, NULL, char_pos, &offset, &tok_len, 
-            line_buffer);
+    cctrlFileAndLine(cc, buf, cur_tok->line, char_pos, bold_msg->data,
+                     severity);
+    cctrlCreateColoredLine(cc, buf, cur_tok->line, 0, NULL, char_pos, &offset,
+                           &tok_len, line_buffer);
 
     if (from_idx != -1 && to_idx != -1) {
-        aoStrCat(buf, ESC_CYAN"     |    "ESC_RESET);
+        aoStrCat(buf, ESC_CYAN "     |    " ESC_RESET);
         for (int i = 0; i < from_idx; ++i) {
-            aoStrPutChar(buf,' ');
+            aoStrPutChar(buf, ' ');
         }
-        for (int i = 0; i < (to_idx+1)-from_idx; ++i) {
-            aoStrCatFmt(buf,"%s^%s",color,ESC_RESET);
+        for (int i = 0; i < (to_idx + 1) - from_idx; ++i) {
+            aoStrCatFmt(buf, "%s^%s", color, ESC_RESET);
         }
         if (suggestion) {
             if (is_terminal) {
-                aoStrCatFmt(buf,"%s %s%s",color,suggestion,ESC_RESET);
+                aoStrCatFmt(buf, "%s %s%s", color, suggestion, ESC_RESET);
             } else {
                 aoStrCatFmt(buf, " %s", suggestion);
             }
         }
     } else {
-        aoStrCat(buf, ESC_CYAN"     |"ESC_RESET);
+        aoStrCat(buf, ESC_CYAN "     |" ESC_RESET);
     }
 
     aoStrRelease(bold_msg);
@@ -868,31 +916,36 @@ aoStr *cctrlRaiseFromTo(Cctrl *cc, int severity, char *suggestion, char from,
     return buf;
 }
 
-void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from, char to, char *fmt, ...) {
+void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from, char to,
+                               char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlRaiseFromTo(cc,CCTRL_ERROR,suggestion,from,to,fmt,ap);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlRaiseFromTo(cc, CCTRL_ERROR, suggestion, from, to,
+                                        fmt, ap);
+    fprintf(stderr, "%s\n", buf->data);
     va_end(ap);
     aoStrRelease(buf);
     exit(EXIT_FAILURE);
 }
 
-void cctrlWarningFromTo(Cctrl *cc, char *suggestion, char from, char to, char *fmt, ...) {
+void cctrlWarningFromTo(Cctrl *cc, char *suggestion, char from, char to,
+                        char *fmt, ...) {
     va_list ap;
-    va_start(ap,fmt);
-    aoStr *buf = cctrlRaiseFromTo(cc,CCTRL_WARN,suggestion,from,to,fmt,ap);
-    fprintf(stderr,"%s\n",buf->data);
+    va_start(ap, fmt);
+    const aoStr *buf = cctrlRaiseFromTo(cc, CCTRL_WARN, suggestion, from, to,
+                                        fmt, ap);
+    fprintf(stderr, "%s\n", buf->data);
     va_end(ap);
     aoStrRelease(buf);
 }
 
 /* Get variable either from the local or global scope */
-Ast *cctrlGetVar(Cctrl *cc, char *varname, int len) {
+Ast *cctrlGetVar(const Cctrl *cc, char *varname, int len) {
     Ast *ast_var;
     Lexeme *tok;
 
-    if (cc->localenv && (ast_var = strMapGetLen(cc->localenv, varname, len)) != NULL) {
+    if (cc->localenv &&
+        (ast_var = strMapGetLen(cc->localenv, varname, len)) != NULL) {
         return ast_var;
     }
 
@@ -930,43 +983,43 @@ Ast *cctrlGetVar(Cctrl *cc, char *varname, int len) {
     return NULL;
 }
 
-AstType *cctrlGetKeyWord(Cctrl *cc, char *name, int len) {
+AstType *cctrlGetKeyWord(const Cctrl *cc, char *name, int len) {
     AstType *type;
     assert(name != NULL);
-    if ((type = strMapGetLen(cc->symbol_table,name,len)) != NULL) {
+    if ((type = strMapGetLen(cc->symbol_table, name, len)) != NULL) {
         return type;
     }
     /* Classes are types */
-    if ((type = strMapGetLen(cc->clsdefs,name,len)) != NULL) {
+    if ((type = strMapGetLen(cc->clsdefs, name, len)) != NULL) {
         return type;
     }
-    if ((type = strMapGetLen(cc->uniondefs,name,len)) != NULL) {
+    if ((type = strMapGetLen(cc->uniondefs, name, len)) != NULL) {
         return type;
     }
     return NULL;
 }
 
-int cctrlIsKeyword(Cctrl *cc, char *name, int len) {
-    return cctrlGetKeyWord(cc,name,len) != NULL;
+int cctrlIsKeyword(const Cctrl *cc, char *name, int len) {
+    return cctrlGetKeyWord(cc, name, len) != NULL;
 }
 
-void cctrlSetCommandLineDefines(Cctrl *cc, List *defines_list) {
+void cctrlSetCommandLineDefines(const Cctrl *cc, const List *defines_list) {
     listForEach(defines_list) {
-        strMapAdd(cc->macro_defs,(char*)it->value,lexemeSentinal());
+        strMapAdd(cc->macro_defs, (char *)it->value, lexemeSentinal());
     }
 }
 
 /* De-duplicates strings by checking their existance */
-Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, long real_len) {
+Ast *cctrlGetOrSetString(const Cctrl *cc, char *str, int len, long real_len) {
     Ast *ast_str = NULL;
     if (cc->strs) {
         ast_str = strMapGetLen(cc->strs, str, len);
         if (!ast_str) {
-            ast_str = astString(str,len,real_len);
-            strMapAddLen(cc->strs,ast_str->sval->data,len,ast_str);
+            ast_str = astString(str, len, real_len);
+            strMapAddLen(cc->strs, ast_str->sval->data, len, ast_str);
         }
     } else {
-        ast_str = astString(str,len,real_len);
+        ast_str = astString(str, len, real_len);
     }
     return ast_str;
 }

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -6,16 +6,16 @@
 #include "aostr.h"
 #include "ast.h"
 #include "config.h"
-#include "map.h"
 #include "lexer.h"
+#include "map.h"
 
 #define CCTRL_TOKEN_BUFFER_SIZE 16
-#define CCTRL_TOKEN_BUFFER_MASK CCTRL_TOKEN_BUFFER_SIZE-1
+#define CCTRL_TOKEN_BUFFER_MASK CCTRL_TOKEN_BUFFER_SIZE - 1
 
-#define CCTRL_TRANSPILING     (1<<0)
-#define CCTRL_SAVE_ANONYMOUS  (1<<1)
-#define CCTRL_PASTE_DEFINES   (1<<2)
-#define CCTRL_PRESERVE_SIZEOF (1<<3)
+#define CCTRL_TRANSPILING     (1 << 0)
+#define CCTRL_SAVE_ANONYMOUS  (1 << 1)
+#define CCTRL_PASTE_DEFINES   (1 << 2)
+#define CCTRL_PRESERVE_SIZEOF (1 << 3)
 
 /* For messages */
 #define CCTRL_ICE   0
@@ -34,7 +34,7 @@ typedef struct TokenRingBuffer {
 TokenRingBuffer *tokenRingBufferNew(void);
 
 void tokenBufferPrint(TokenRingBuffer *ring_buffer);
-int tokenRingBufferEmpty(TokenRingBuffer *ring_buffer);
+int tokenRingBufferEmpty(const TokenRingBuffer *ring_buffer);
 void tokenRingBufferPush(TokenRingBuffer *ring_buffer, Lexeme *token);
 Lexeme *tokenRingBufferPop(TokenRingBuffer *ring_buffer);
 Lexeme *tokenRingBufferPeek(TokenRingBuffer *ring_buffer);
@@ -58,7 +58,7 @@ typedef struct Cctrl {
     /* Local environment for a function */
     StrMap *localenv;
 
-    /* assembly functions that have been bound to HC, this is the HC 
+    /* assembly functions that have been bound to HC, this is the HC
      * name, not the assembly name */
     StrMap *asm_funcs;
 
@@ -86,7 +86,7 @@ typedef struct Cctrl {
     /* Current function return type */
     AstType *tmp_rettype;
 
-    /* Temporary function parameters, for trying to keep track of function 
+    /* Temporary function parameters, for trying to keep track of function
      * pointers */
     PtrVec *tmp_params;
 
@@ -140,25 +140,28 @@ Lexeme *cctrlTokenGet(Cctrl *cc);
 Lexeme *cctrlTokenPeek(Cctrl *cc);
 Lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt);
 void cctrlInitMacroProcessor(Cctrl *cc);
-void cctrlTokenRewind(Cctrl *cc);
+void cctrlTokenRewind(const Cctrl *cc);
 void cctrlTokenExpect(Cctrl *cc, long expected);
-void cctrlSetCommandLineDefines(Cctrl *cc, List *defines_list);
+void cctrlSetCommandLineDefines(const Cctrl *cc, const List *defines_list);
 
 void cctrlInitParse(Cctrl *cc, Lexer *lexer_);
 
-Ast *cctrlGetVar(Cctrl *cc, char *varname, int len);
-int cctrlIsKeyword(Cctrl *cc, char *name, int len);
-AstType *cctrlGetKeyWord(Cctrl *cc, char *name, int len);
+Ast *cctrlGetVar(const Cctrl *cc, char *varname, int len);
+int cctrlIsKeyword(const Cctrl *cc, char *name, int len);
+AstType *cctrlGetKeyWord(const Cctrl *cc, char *name, int len);
 void cctrlInfo(Cctrl *cc, char *fmt, ...);
 void cctrlWarning(Cctrl *cc, char *fmt, ...);
-void cctrlWarningFromTo(Cctrl *cc, char *suggestion, char from, char to, char *fmt, ...);
-__noreturn void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from, char to, char *fmt, ...);
+void cctrlWarningFromTo(Cctrl *cc, char *suggestion, char from, char to,
+                        char *fmt, ...);
+__noreturn void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion,
+                                          char from, char to, char *fmt, ...);
 __noreturn void cctrlRaiseException(Cctrl *cc, char *fmt, ...);
-__noreturn void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt, ...);
+__noreturn void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt,
+                                     ...);
 __noreturn void cctrlIce(Cctrl *cc, char *fmt, ...);
-Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, long real_len);
+Ast *cctrlGetOrSetString(const Cctrl *cc, char *str, int len, long real_len);
 void cctrlRewindUntilPunctMatch(Cctrl *cc, long ch, int *_count);
-void cctrlRewindUntilStrMatch(Cctrl *cc, char *str, int len, int *_count);
-aoStr *cctrlMessagePrintF(Cctrl *cc, int severity, char *fmt,...);
+void cctrlRewindUntilStrMatch(Cctrl *cc, const char *str, int len, int *_count);
+aoStr *cctrlMessagePrintF(Cctrl *cc, int severity, char *fmt, ...);
 
 #endif // !CCTRL_H

--- a/src/cfg-print.c
+++ b/src/cfg-print.c
@@ -1,44 +1,44 @@
 #include <assert.h>
 #include <errno.h>
+#include <fcntl.h>
+#include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <stdarg.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include "aostr.h"
 #include "ast.h"
-#include "cfg.h"
 #include "cfg-print.h"
+#include "cfg.h"
 #include "lexer.h"
 #include "memory.h"
 #include "util.h"
 
 #define CFG_GRAPHVIZ_ERROR_INVALID_TYPE (0)
 
-#define BB_FMT_BLUE_DOTTED ("    bb%d:s -> bb%d:n [style=\"dotted,bold\",color=blue,weight=10,constraint=false];\n")
-#define BB_FMT_RED_SOLID   ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=firebrick1,weight=10,constraint=true];\n")
-#define BB_FMT_GREEN_SOLID ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=forestgreen,weight=10,constraint=true];\n")
-#define BB_FMT_BLACK_SOLID ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=black,weight=100,constraint=true];\n")
-#define BB_FMT_BLACK_END_NODE ("    bb%d:s -> endbb%d:n [style=\"solid,bold\",color=black,weight=100,constraint=true];\n")
-
+#define BB_FMT_BLUE_DOTTED \
+    ("    bb%d:s -> bb%d:n [style=\"dotted,bold\",color=blue,weight=10,constraint=false];\n")
+#define BB_FMT_RED_SOLID \
+    ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=firebrick1,weight=10,constraint=true];\n")
+#define BB_FMT_GREEN_SOLID \
+    ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=forestgreen,weight=10,constraint=true];\n")
+#define BB_FMT_BLACK_SOLID \
+    ("    bb%d:s -> bb%d:n [style=\"solid,bold\",color=black,weight=100,constraint=true];\n")
+#define BB_FMT_BLACK_END_NODE \
+    ("    bb%d:s -> endbb%d:n [style=\"solid,bold\",color=black,weight=100,constraint=true];\n")
 
 static char *depth_to_loop_color[] = {
-    [0] = "grey88",
-    [1] = "grey78",
-    [2] = "grey68",
-    [3] = "grey58",
-    [4] = "grey48",
-    [5] = "grey38",
-    [6] = "grey28",
-    [7] = "grey28",
-    [8] = "grey18",
+        [0] = "grey88", [1] = "grey78", [2] = "grey68",
+        [3] = "grey58", [4] = "grey48", [5] = "grey38",
+        [6] = "grey28", [7] = "grey28", [8] = "grey18",
 };
 
 static const char *cfgPrintGetLoopColor(int depth) {
-    static int len = sizeof(depth_to_loop_color)/sizeof(depth_to_loop_color[0]);
-    if (depth >= len) return "grey88";
+    static int len = sizeof(depth_to_loop_color) /
+            sizeof(depth_to_loop_color[0]);
+    if (depth >= len)
+        return "grey88";
     return depth_to_loop_color[depth];
 }
 
@@ -47,7 +47,7 @@ typedef struct CfgGraphVizBuilder {
     CFG *cfg;
     /* Need a counter to graphviz does not merge loops */
     int loop_cnt;
-    /* To change the shade of grey based on how deep into a nested loop we 
+    /* To change the shade of grey based on how deep into a nested loop we
      * are */
     int loop_nesting;
 
@@ -62,11 +62,11 @@ typedef struct CfgGraphVizBuilder {
     BasicBlock *return_statements[32];
 } CfgGraphVizBuilder;
 
-static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder,
-        BasicBlock *bb, IntSet *seen);
+static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder, BasicBlock *bb,
+                                 IntSet *seen);
 
 static void cfgGraphVizBuilderInit(CfgGraphVizBuilder *builder) {
-    builder->viz = aoStrAlloc(1<<10);
+    builder->viz = aoStrAlloc(1 << 10);
     builder->loop_nesting = 0;
     builder->loop_cnt = 0;
     builder->break_idx = 0;
@@ -74,28 +74,34 @@ static void cfgGraphVizBuilderInit(CfgGraphVizBuilder *builder) {
     builder->return_idx = 0;
 }
 
-static aoStr *bbAstArrayToString(PtrVec *ast_array, int ast_count) {
-    if (ast_count == 0) return NULL;
+static aoStr *bbAstArrayToString(const PtrVec *ast_array, int ast_count) {
+    if (ast_count == 0)
+        return NULL;
     aoStr *ast_str = aoStrAlloc(256);
-    char *lvalue_str;
     for (int i = 0; i < ast_count; ++i) {
-        Ast *ast = vecGet(Ast *,ast_array,i);
-        lvalue_str = astLValueToString(ast,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
-        aoStrCatPrintf(ast_str,"%s\\l\\\n",lvalue_str);
+        const Ast *ast = vecGet(Ast *, ast_array, i);
+        char *lvalue_str = astLValueToString(ast,
+                                             (LEXEME_ENCODE_PUNCT |
+                                              LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+        aoStrCatPrintf(ast_str, "%s\\l\\\n", lvalue_str);
         if (i + 1 != ast_count) {
-            aoStrPutChar(ast_str,'|');
+            aoStrPutChar(ast_str, '|');
         }
     }
     return ast_str;
 }
 
-static void cfgBranchPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void cfgBranchPrintf(const CfgGraphVizBuilder *builder,
+                            const BasicBlock *bb) {
     char *fillcolor;
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size-1);
-    Ast *cond = (Ast *)bb->ast_array->entries[bb->ast_array->size-1];
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size - 1);
+    const Ast *cond = (Ast *)bb->ast_array->entries[bb->ast_array->size - 1];
 
     assert(cond != NULL);
-    char *lvalue_str = astLValueToString(cond,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+    char *lvalue_str = astLValueToString(cond,
+                                         (LEXEME_ENCODE_PUNCT |
+                                          LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
 
     if (bb->flags & BB_FLAG_LOOP_HEAD) {
         fillcolor = "lightpink";
@@ -103,197 +109,212 @@ static void cfgBranchPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
         fillcolor = "coral";
     }
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=%s,label=\"{\\<bb %d\\>|\n",
-            bb->block_no,
-            fillcolor,
-            bb->block_no);
+            bb->block_no, fillcolor, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"%s\n",internal->data);
+        aoStrCatPrintf(builder->viz, "%s\n", internal->data);
     }
-    aoStrCatPrintf(builder->viz,"if (%s)\\l\\\n}\"];\n\n",lvalue_str);
+    aoStrCatPrintf(builder->viz, "if (%s)\\l\\\n}\"];\n\n", lvalue_str);
 }
 
-static void cfgDoWhileCondPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void cfgDoWhileCondPrintf(const CfgGraphVizBuilder *builder,
+                                 const BasicBlock *bb) {
     char *fillcolor = "lightpink";
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size-1);
-    Ast *cond = (Ast *)bb->ast_array->entries[bb->ast_array->size-1];
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size - 1);
+    const Ast *cond = (Ast *)bb->ast_array->entries[bb->ast_array->size - 1];
 
     if (bb->prev->flags & BB_FLAG_LOOP_HEAD) {
         fillcolor = "lightskyblue";
     }
 
-    char *lvalue_str = astLValueToString(cond,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+    char *lvalue_str = astLValueToString(cond,
+                                         (LEXEME_ENCODE_PUNCT |
+                                          LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=%s,label=\"{\\<bb %d\\>|\n",
-            bb->block_no,
-            fillcolor,
-            bb->block_no);
+            bb->block_no, fillcolor, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"%s\n",internal->data);
+        aoStrCatPrintf(builder->viz, "%s\n", internal->data);
     }
 
-    aoStrCatPrintf(builder->viz,"if (%s)\\l\\\n}\"];\n\n",lvalue_str);
+    aoStrCatPrintf(builder->viz, "if (%s)\\l\\\n}\"];\n\n", lvalue_str);
 }
 
-static void cfgLoopPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size);
+static void cfgLoopPrintf(const CfgGraphVizBuilder *builder,
+                          const BasicBlock *bb) {
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size);
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=lightgreen,label=\"{\\<bb %d\\>|\n",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"%s\n}\"];\n\n",internal->data);
+        aoStrCatPrintf(builder->viz, "%s\n}\"];\n\n", internal->data);
     } else {
-        aoStrCatPrintf(builder->viz,"}\"];\n\n");
+        aoStrCatPrintf(builder->viz, "}\"];\n\n");
     }
-
 }
 
-static void cfgBreakPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size);
+static void cfgBreakPrintf(const CfgGraphVizBuilder *builder,
+                           const BasicBlock *bb) {
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size);
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=violet,label=\"{\\<bb %d\\>\n",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"%s\\l\\\n",internal->data);
+        aoStrCatPrintf(builder->viz, "%s\\l\\\n", internal->data);
     }
-    aoStrCatPrintf(builder->viz,"|break\\l\\\n\n}\"];\n\n");
+    aoStrCatPrintf(builder->viz, "|break\\l\\\n\n}\"];\n\n");
 }
 
-static void cfgDefaultPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size);
-    aoStrCatPrintf(builder->viz,
+static void cfgDefaultPrintf(const CfgGraphVizBuilder *builder,
+                             const BasicBlock *bb) {
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size);
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=lightgrey,label=\"{\\<bb %d\\>",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"|\n%s",internal->data);
+        aoStrCatPrintf(builder->viz, "|\n%s", internal->data);
     }
 
     if (bb->next) {
         aoStrCatPrintf(builder->viz,
-                 "|goto \\<%d bb\\>"
-                 " \n}\"];\n\n",
-                 bb->next->block_no
-                );
+                       "|goto \\<%d bb\\>"
+                       " \n}\"];\n\n",
+                       bb->next->block_no);
     } else {
         loggerWarning("Block unexpectedly terminates: %dbb, type %d\n",
-                bb->block_no, bb->type);
-        aoStrCat(builder->viz,"\n}\"];\n\n");
+                      bb->block_no, bb->type);
+        aoStrCat(builder->viz, "\n}\"];\n\n");
     }
 }
 
-static void cfgHeadPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStrCatPrintf(builder->viz,
+static void cfgHeadPrintf(const CfgGraphVizBuilder *builder,
+                          const BasicBlock *bb) {
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=circle,style=filled,fillcolor=white,label=\"Entry\"];\n",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 }
 
-static void cfgReturnPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size);
+static void cfgReturnPrintf(const CfgGraphVizBuilder *builder,
+                            const BasicBlock *bb) {
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size);
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=lightgrey,label=\"{\\<bb %d\\>",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
     if (internal) {
-        aoStrCatPrintf(builder->viz,"|%s \n}\"];\n\n",internal->data);
+        aoStrCatPrintf(builder->viz, "|%s \n}\"];\n\n", internal->data);
     } else {
         aoStrCat(builder->viz, "|return (void) \n}\"];\n\n");
     }
-    aoStrCatPrintf(builder->viz,
-    "    endbb%d [shape=doublecircle,style=filled,fontcolor=white,fillcolor=black,label=\"\\<end\\>\"];\n\n",
-    bb->block_no
-    );
+    aoStrCatPrintf(
+            builder->viz,
+            "    endbb%d [shape=doublecircle,style=filled,fontcolor=white,fillcolor=black,label=\"\\<end\\>\"];\n\n",
+            bb->block_no);
 }
 
-static void cfgCasePrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void cfgCasePrintf(const CfgGraphVizBuilder *builder,
+                          const BasicBlock *bb) {
     int ast_count = bb->ast_array->size;
-    PtrVec *ast_array = bb->ast_array;
+    const PtrVec *ast_array = bb->ast_array;
     aoStr *ast_str = aoStrAlloc(256);
     char *lvalue_str;
-    Ast *_case = vecGet(Ast *,ast_array,0);
+    const Ast *_case = vecGet(Ast *, ast_array, 0);
 
     for (int i = 1; i < ast_count; ++i) {
-        Ast *ast = vecGet(Ast *,ast_array,i);
-        lvalue_str = astLValueToString(ast,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
-        aoStrCatPrintf(ast_str,"%s\\l\\\n",lvalue_str);
+        const Ast *ast = vecGet(Ast *, ast_array, i);
+        lvalue_str = astLValueToString(ast,
+                                       (LEXEME_ENCODE_PUNCT |
+                                        LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+        aoStrCatPrintf(ast_str, "%s\\l\\\n", lvalue_str);
         if (i + 1 != ast_count) {
-            aoStrPutChar(ast_str,'|');
+            aoStrPutChar(ast_str, '|');
         }
     }
 
-    aoStrCatPrintf(builder->viz,
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=lightgrey,label=\"{\\<bb %d\\>\n",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 
-    lvalue_str = astLValueToString(_case,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
-    aoStrCatPrintf(builder->viz,"|%s",lvalue_str);
+    lvalue_str = astLValueToString(_case,
+                                   (LEXEME_ENCODE_PUNCT |
+                                    LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+    aoStrCatPrintf(builder->viz, "|%s", lvalue_str);
     if (ast_str->len) {
-        aoStrCatPrintf(builder->viz,"|%s",ast_str->data);
+        aoStrCatPrintf(builder->viz, "|%s", ast_str->data);
     }
 
     if (bb->next) {
         aoStrCatPrintf(builder->viz,
-                "|goto \\<%d bb\\>"
-                " \n}\"];\n\n",
-                bb->next->block_no);
+                       "|goto \\<%d bb\\>"
+                       " \n}\"];\n\n",
+                       bb->next->block_no);
     }
-
 }
 
-static void cfgSwitchPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void cfgSwitchPrintf(const CfgGraphVizBuilder *builder,
+                            const BasicBlock *bb) {
     aoStr *ast_str = aoStrAlloc(256);
-    char *lvalue_str;
-    
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size-1);
-    
-    Ast *ast = vecGet(Ast *,bb->ast_array,bb->ast_array->size - 1);
-    lvalue_str = astLValueToString(ast,(LEXEME_ENCODE_PUNCT|LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
-    aoStrCatPrintf(ast_str,"test (%s)\\l\\\n",lvalue_str);
+
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size - 1);
+
+    const Ast *ast = vecGet(Ast *, bb->ast_array, bb->ast_array->size - 1);
+    char *lvalue_str = astLValueToString(ast,
+                                         (LEXEME_ENCODE_PUNCT |
+                                          LEXEME_GRAPH_VIZ_ENCODE_PUNCT));
+    aoStrCatPrintf(ast_str, "test (%s)\\l\\\n", lvalue_str);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,
+        aoStrCatPrintf(
+                builder->viz,
                 "    bb%d [shape=record,style=filled,fillcolor=darkorchid2,label=\"{\\<bb %d\\>|\n%s|%s",
-                bb->block_no,
-                bb->block_no,
-                internal->data,
-                ast_str->data);
+                bb->block_no, bb->block_no, internal->data, ast_str->data);
     } else {
-        aoStrCatPrintf(builder->viz,
+        aoStrCatPrintf(
+                builder->viz,
                 "    bb%d [shape=record,style=filled,fillcolor=darkorchid2,label=\"{\\<bb %d\\>|\n%s",
-                bb->block_no,
-                bb->block_no,
-                ast_str->data);
+                bb->block_no, bb->block_no, ast_str->data);
     }
 
-    aoStrCat(builder->viz,"\n}\"];\n\n");
+    aoStrCat(builder->viz, "\n}\"];\n\n");
 }
 
-static void cfgContinuePrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
-    aoStr *internal = bbAstArrayToString(bb->ast_array,bb->ast_array->size);
-    aoStrCatPrintf(builder->viz,
+static void cfgContinuePrintf(const CfgGraphVizBuilder *builder,
+                              const BasicBlock *bb) {
+    const aoStr *internal = bbAstArrayToString(bb->ast_array,
+                                               bb->ast_array->size);
+    aoStrCatPrintf(
+            builder->viz,
             "    bb%d [shape=record,style=filled,fillcolor=violet,label=\"{\\<bb %d\\>\n",
-            bb->block_no,
-            bb->block_no);
+            bb->block_no, bb->block_no);
 
     if (internal) {
-        aoStrCatPrintf(builder->viz,"|%s",internal->data);
+        aoStrCatPrintf(builder->viz, "|%s", internal->data);
     }
 
-    aoStrCatPrintf(builder->viz,"|continue\\l\\\n\n}\"];\n\n");
+    aoStrCatPrintf(builder->viz, "|continue\\l\\\n\n}\"];\n\n");
 }
 
 /* Side-effect of mutating the loop counter on the builder */
@@ -302,53 +323,71 @@ static void cfgLoopHeadPrintf(CfgGraphVizBuilder *builder) {
     int count = ++builder->loop_cnt;
     const char *loop_color = cfgPrintGetLoopColor(color);
     aoStrCatPrintf(builder->viz,
-            "subgraph cluster1_%d {\nstyle=\"filled\";\n"
-            "color=\"darkgreen\";\n"
-            "fillcolor=\"%s\";\n"
-            "label=\"loop %d\";\n"
-            "labeljust=l;\n"
-            "penwidth=2;\n",
-            count,
-            loop_color,
-            count);
+                   "subgraph cluster1_%d {\nstyle=\"filled\";\n"
+                   "color=\"darkgreen\";\n"
+                   "fillcolor=\"%s\";\n"
+                   "label=\"loop %d\";\n"
+                   "labeljust=l;\n"
+                   "penwidth=2;\n",
+                   count, loop_color, count);
 }
 
-static void bbPrintf(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void bbPrintf(const CfgGraphVizBuilder *builder, const BasicBlock *bb) {
     switch (bb->type) {
-        case BB_HEAD_BLOCK:    cfgHeadPrintf(builder,bb);    break;
-        case BB_LOOP_BLOCK:    cfgLoopPrintf(builder,bb);    break;
-        case BB_DO_WHILE_COND: cfgDoWhileCondPrintf(builder,bb); break;
-        case BB_BRANCH_BLOCK:  cfgBranchPrintf(builder,bb);      break;
-        case BB_BREAK_BLOCK:   cfgBreakPrintf(builder,bb);       break;
-        case BB_END_BLOCK:
-        case BB_RETURN_BLOCK:  cfgReturnPrintf(builder,bb);   break;
-        case BB_CASE:          cfgCasePrintf(builder,bb);     break;
-        case BB_SWITCH:        cfgSwitchPrintf(builder,bb);   break;
-        case BB_CONTINUE:      cfgContinuePrintf(builder,bb); break;
-        default:               cfgDefaultPrintf(builder,bb);  break;
+    case BB_HEAD_BLOCK:
+        cfgHeadPrintf(builder, bb);
+        break;
+    case BB_LOOP_BLOCK:
+        cfgLoopPrintf(builder, bb);
+        break;
+    case BB_DO_WHILE_COND:
+        cfgDoWhileCondPrintf(builder, bb);
+        break;
+    case BB_BRANCH_BLOCK:
+        cfgBranchPrintf(builder, bb);
+        break;
+    case BB_BREAK_BLOCK:
+        cfgBreakPrintf(builder, bb);
+        break;
+    case BB_END_BLOCK:
+    case BB_RETURN_BLOCK:
+        cfgReturnPrintf(builder, bb);
+        break;
+    case BB_CASE:
+        cfgCasePrintf(builder, bb);
+        break;
+    case BB_SWITCH:
+        cfgSwitchPrintf(builder, bb);
+        break;
+    case BB_CONTINUE:
+        cfgContinuePrintf(builder, bb);
+        break;
+    default:
+        cfgDefaultPrintf(builder, bb);
+        break;
     }
 }
 
-static void cfgPrintBreaks(CfgGraphVizBuilder *builder, BasicBlock *bb) {
+static void cfgPrintBreaks(CfgGraphVizBuilder *builder, const BasicBlock *bb) {
     while (builder->break_idx) {
-        int idx = builder->break_idx-1;
-        BasicBlock *break_block = builder->break_blocks[idx];
+        int idx = builder->break_idx - 1;
+        const BasicBlock *break_block = builder->break_blocks[idx];
         builder->break_idx--;
         if (break_block == bb) {
             break;
         }
-        bbPrintf(builder,break_block);
+        bbPrintf(builder, break_block);
     }
 }
 
 /**
- * @Hack 
- * We do this to ensure everything inside of the do while loop body gets 
- * printed. Otherwise the next pointer of the condition will start exploring 
- * nodes outside of the loop prematurely. 
+ * @Hack
+ * We do this to ensure everything inside of the do while loop body gets
+ * printed. Otherwise the next pointer of the condition will start exploring
+ * nodes outside of the loop prematurely.
  *
  * Adding it to the seen set means it will never get explored. */
-static BasicBlock *cfgGetHandleDoWhileHead(IntSet *seen, BasicBlock *bb) {
+static BasicBlock *cfgGetHandleDoWhileHead(IntSet *seen, const BasicBlock *bb) {
     BasicBlock *while_cond = NULL;
     if (bb->flags & BB_FLAG_LOOP_HEAD) {
         IntMapIterator *it = intMapIteratorNew(bb->prev_blocks);
@@ -363,33 +402,35 @@ static BasicBlock *cfgGetHandleDoWhileHead(IntSet *seen, BasicBlock *bb) {
         intMapIteratorRelease(it);
 
         if (while_cond) {
-            intSetAdd(seen,while_cond->block_no);
+            intSetAdd(seen, while_cond->block_no);
         }
     }
     return while_cond;
 }
 
-char *cfgGraphVizError(CfgGraphVizBuilder *builder, BasicBlock *bb, int error_code) {
+char *cfgGraphVizError(const CfgGraphVizBuilder *builder, const BasicBlock *bb,
+                       int error_code) {
     switch (error_code) {
-        case CFG_GRAPHVIZ_ERROR_INVALID_TYPE: {
-            char *type_string = bbTypeToString(bb->type);
-            char *error = mprintf("%s() has an invalid type '%s' for bb%d\n",
-                    builder->cfg->ref_fname->data, type_string, bb->block_no);
-            return error;
-        }
-        default:
-            loggerPanic("Unknown error code: %d\n", error_code);
+    case CFG_GRAPHVIZ_ERROR_INVALID_TYPE: {
+        char *type_string = bbTypeToString(bb->type);
+        char *error = mprintf("%s() has an invalid type '%s' for bb%d\n",
+                              builder->cfg->ref_fname->data, type_string,
+                              bb->block_no);
+        return error;
+    }
+    default:
+        loggerPanic("Unknown error code: %d\n", error_code);
     }
 }
 
-static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder,
-                                 BasicBlock *bb,
-                                 IntSet *seen)
-{
-    BasicBlock *while_cond = cfgGetHandleDoWhileHead(seen,bb);
+static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder, BasicBlock *bb,
+                                 IntSet *seen) {
+    const BasicBlock *while_cond = cfgGetHandleDoWhileHead(seen, bb);
 
-    if (intSetHas(seen,bb->block_no)) return;
-    else intSetAdd(seen,bb->block_no);
+    if (intSetHas(seen, bb->block_no))
+        return;
+    else
+        intSetAdd(seen, bb->block_no);
 
     if (bb->flags & BB_FLAG_LOOP_HEAD) {
         builder->loop_nesting++;
@@ -397,146 +438,148 @@ static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder,
     }
 
     switch (bb->type) {
-        case BB_CONTINUE:
-        case BB_LOOP_BLOCK:
-            bbPrintf(builder,bb);
-            if (bb->flags & BB_FLAG_UNCONDITIONAL_JUMP && bb->next) {
-                cfgCreatePictureUtil(builder,bb->next,seen);
-            }
-            break;
-
-        case BB_DO_WHILE_COND:
-            if (bb->flags & BB_FLAG_LOOP_HEAD) {
-               builder->loop_stack[builder->loop_idx++] = bb;
-               /* Push the head onto the stack so that we can bookend the 
-                * break clauses and scope them to the current loop */
-               builder->break_blocks[builder->break_idx++] = bb;
-            }
-
-            cfgDoWhileCondPrintf(builder,bb);
-            if (bb->flags & BB_FLAG_LOOP_HEAD) {
-                cfgCreatePictureUtil(builder,bb->next,seen);
-            }
-
-            if ((bb->flags & BB_FLAG_LOOP_END) && !bb->visited) {
-                aoStrCat(builder->viz,"}\n");
-                bb->visited++;
-            }
-
-            if (bb->flags & BB_FLAG_LOOP_END) {
-                while (builder->break_idx) {
-                    int idx = builder->break_idx-1;
-                    BasicBlock *break_block = builder->break_blocks[idx];
-                    builder->break_idx--;
-                    if (break_block == bb) {
-                        break;
-                    }
-                    bbPrintf(builder,break_block);
-                }
-            }
-            break;
-
-        case BB_BRANCH_BLOCK: {
-            if (bb->flags & BB_FLAG_LOOP_HEAD) {
-                builder->loop_stack[builder->loop_idx++] = bb;
-                /* Push the head onto the stack so that we can bookend the 
-                 * break clauses and scope them to the current loop */
-                builder->break_blocks[builder->break_idx++] = bb;
-            }
-
-            cfgBranchPrintf(builder,bb);
-            cfgCreatePictureUtil(builder,bb->_if,seen);
-
-            /* @Bug - should know how many loops a block ends */
-            IntMapIterator *it = intMapIteratorNew(bb->_else->prev_blocks);
-            IntMapNode *entry;
-            int loop_ends = 0;
-            while ((entry = intMapNext(it)) != NULL) {
-                BasicBlock *prev = (BasicBlock *)entry->value;
-                if (prev->flags & BB_FLAG_LOOP_HEAD) {
-                    loop_ends++;
-                }
-            }
-            intMapIteratorRelease(it);
-
-            if ((bb->_else->flags & BB_FLAG_LOOP_END) && bb->_else->visited != loop_ends) {
-                builder->loop_nesting--;
-                bb->_else->visited++;
-                aoStrCat(builder->viz,"}\n");
-            }
-
-            cfgCreatePictureUtil(builder,bb->_else,seen);
-
-            if (bb->_else->flags & BB_FLAG_LOOP_END) {
-                cfgPrintBreaks(builder,bb);
-            }
-            break;
+    case BB_CONTINUE:
+    case BB_LOOP_BLOCK:
+        bbPrintf(builder, bb);
+        if (bb->flags & BB_FLAG_UNCONDITIONAL_JUMP && bb->next) {
+            cfgCreatePictureUtil(builder, bb->next, seen);
         }
+        break;
 
-        case BB_SWITCH: {
-            bbPrintf(builder,bb);
-            for (int i = 0; i < bb->next_blocks->size; ++i) {
-                BasicBlock *it = vecGet(BasicBlock *,bb->next_blocks,i);
-                cfgCreatePictureUtil(builder,it,seen);
-            }
-            cfgCreatePictureUtil(builder,bb->next,seen);
-            break;
-        }
-
-        case BB_GOTO:
-            bbPrintf(builder,bb);
-            if (bbPrevCnt(bb->next) >= 1 || bb->flags & BB_FLAG_UNCONDITIONAL_JUMP) {
-                cfgCreatePictureUtil(builder,bb->next,seen);
-            }
-            if (bb->flags & BB_FLAG_LOOP_HEAD) {
-                if (bb->prev && bb->prev->type == BB_DO_WHILE_COND) {
-                    cfgCreatePictureUtil(builder,bb->prev->next,seen);
-                }
-            }
-            break;
-
-        case BB_CASE:
-        case BB_CONTROL_BLOCK:
-        case BB_HEAD_BLOCK: {
-            bbPrintf(builder,bb);
-            cfgCreatePictureUtil(builder,bb->next,seen);
-            break;
-        }
-
-        case BB_BREAK_BLOCK:
+    case BB_DO_WHILE_COND:
+        if (bb->flags & BB_FLAG_LOOP_HEAD) {
+            builder->loop_stack[builder->loop_idx++] = bb;
+            /* Push the head onto the stack so that we can bookend the
+             * break clauses and scope them to the current loop */
             builder->break_blocks[builder->break_idx++] = bb;
-            break;
-
-        case BB_END_BLOCK:
-        case BB_RETURN_BLOCK:
-            if (!(builder->return_idx < 32)) {
-                assert(builder->return_idx < 32);
-            }
-            builder->return_statements[builder->return_idx++] = bb;
-            break;
-
-        default: {
-            char *error = cfgGraphVizError(builder,bb,
-                    CFG_GRAPHVIZ_ERROR_INVALID_TYPE);
-            loggerWarning("%s\n",error);
-            break;
         }
+
+        cfgDoWhileCondPrintf(builder, bb);
+        if (bb->flags & BB_FLAG_LOOP_HEAD) {
+            cfgCreatePictureUtil(builder, bb->next, seen);
+        }
+
+        if ((bb->flags & BB_FLAG_LOOP_END) && !bb->visited) {
+            aoStrCat(builder->viz, "}\n");
+            bb->visited++;
+        }
+
+        if (bb->flags & BB_FLAG_LOOP_END) {
+            while (builder->break_idx) {
+                int idx = builder->break_idx - 1;
+                const BasicBlock *break_block = builder->break_blocks[idx];
+                builder->break_idx--;
+                if (break_block == bb) {
+                    break;
+                }
+                bbPrintf(builder, break_block);
+            }
+        }
+        break;
+
+    case BB_BRANCH_BLOCK: {
+        if (bb->flags & BB_FLAG_LOOP_HEAD) {
+            builder->loop_stack[builder->loop_idx++] = bb;
+            /* Push the head onto the stack so that we can bookend the
+             * break clauses and scope them to the current loop */
+            builder->break_blocks[builder->break_idx++] = bb;
+        }
+
+        cfgBranchPrintf(builder, bb);
+        cfgCreatePictureUtil(builder, bb->_if, seen);
+
+        /* @Bug - should know how many loops a block ends */
+        IntMapIterator *it = intMapIteratorNew(bb->_else->prev_blocks);
+        IntMapNode *entry;
+        int loop_ends = 0;
+        while ((entry = intMapNext(it)) != NULL) {
+            const BasicBlock *prev = (BasicBlock *)entry->value;
+            if (prev->flags & BB_FLAG_LOOP_HEAD) {
+                loop_ends++;
+            }
+        }
+        intMapIteratorRelease(it);
+
+        if ((bb->_else->flags & BB_FLAG_LOOP_END) &&
+            bb->_else->visited != loop_ends) {
+            builder->loop_nesting--;
+            bb->_else->visited++;
+            aoStrCat(builder->viz, "}\n");
+        }
+
+        cfgCreatePictureUtil(builder, bb->_else, seen);
+
+        if (bb->_else->flags & BB_FLAG_LOOP_END) {
+            cfgPrintBreaks(builder, bb);
+        }
+        break;
+    }
+
+    case BB_SWITCH: {
+        bbPrintf(builder, bb);
+        for (int i = 0; i < bb->next_blocks->size; ++i) {
+            BasicBlock *it = vecGet(BasicBlock *, bb->next_blocks, i);
+            cfgCreatePictureUtil(builder, it, seen);
+        }
+        cfgCreatePictureUtil(builder, bb->next, seen);
+        break;
+    }
+
+    case BB_GOTO:
+        bbPrintf(builder, bb);
+        if (bbPrevCnt(bb->next) >= 1 ||
+            bb->flags & BB_FLAG_UNCONDITIONAL_JUMP) {
+            cfgCreatePictureUtil(builder, bb->next, seen);
+        }
+        if (bb->flags & BB_FLAG_LOOP_HEAD) {
+            if (bb->prev && bb->prev->type == BB_DO_WHILE_COND) {
+                cfgCreatePictureUtil(builder, bb->prev->next, seen);
+            }
+        }
+        break;
+
+    case BB_CASE:
+    case BB_CONTROL_BLOCK:
+    case BB_HEAD_BLOCK: {
+        bbPrintf(builder, bb);
+        cfgCreatePictureUtil(builder, bb->next, seen);
+        break;
+    }
+
+    case BB_BREAK_BLOCK:
+        builder->break_blocks[builder->break_idx++] = bb;
+        break;
+
+    case BB_END_BLOCK:
+    case BB_RETURN_BLOCK:
+        if (!(builder->return_idx < 32)) {
+            assert(builder->return_idx < 32);
+        }
+        builder->return_statements[builder->return_idx++] = bb;
+        break;
+
+    default: {
+        const char *error = cfgGraphVizError(builder, bb,
+                                             CFG_GRAPHVIZ_ERROR_INVALID_TYPE);
+        loggerWarning("%s\n", error);
+        break;
+    }
     }
 
     /* XXX: hack for do while loop */
     if (while_cond) {
-        cfgDoWhileCondPrintf(builder,while_cond);
+        cfgDoWhileCondPrintf(builder, while_cond);
         if (while_cond->flags & BB_FLAG_LOOP_END) {
             builder->loop_nesting--;
-            aoStrCat(builder->viz,"}\n");
+            aoStrCat(builder->viz, "}\n");
         }
 
         if (while_cond->next) {
-            cfgCreatePictureUtil(builder,while_cond->next,seen);
+            cfgCreatePictureUtil(builder, while_cond->next, seen);
         }
 
         if (while_cond->flags & BB_FLAG_LOOP_END) {
-            cfgPrintBreaks(builder,while_cond);
+            cfgPrintBreaks(builder, while_cond);
         }
     }
 }
@@ -547,18 +590,19 @@ static void cfgCreatePicture(CfgGraphVizBuilder *builder, CFG *cfg) {
     builder->break_idx = 0;
     builder->loop_idx = 0;
     builder->cfg = cfg;
-    cfgCreatePictureUtil(builder,cfg->head,seen);
-    /* Returns always exit the scope of where ever they are placed, so saving 
+    cfgCreatePictureUtil(builder, cfg->head, seen);
+    /* Returns always exit the scope of where ever they are placed, so saving
      * them till the end makes sense */
     for (int i = 0; i < builder->return_idx; ++i) {
-        cfgReturnPrintf(builder,builder->return_statements[i]);
+        cfgReturnPrintf(builder, builder->return_statements[i]);
     }
     intSetRelease(seen);
 }
 
-static void cfgGraphVizAddMappings(CfgGraphVizBuilder *builder, CFG *cfg) {
-    loggerDebug("Creating mappings for: %s, size: %lu\n",
-            cfg->ref_fname->data,cfg->no_to_block->size);
+static void cfgGraphVizAddMappings(const CfgGraphVizBuilder *builder,
+                                   const CFG *cfg) {
+    loggerDebug("Creating mappings for: %s, size: %lu\n", cfg->ref_fname->data,
+                cfg->no_to_block->size);
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
 
@@ -566,136 +610,110 @@ static void cfgGraphVizAddMappings(CfgGraphVizBuilder *builder, CFG *cfg) {
         BasicBlock *cur = (BasicBlock *)entry->value;
 
         switch (cur->type) {
-            case BB_CONTINUE: {
-                aoStrCatPrintf(builder->viz,
-                        BB_FMT_BLUE_DOTTED,
-                        cur->block_no,
-                        cur->prev->block_no);
-                break;
+        case BB_CONTINUE: {
+            aoStrCatPrintf(builder->viz, BB_FMT_BLUE_DOTTED, cur->block_no,
+                           cur->prev->block_no);
+            break;
+        }
+
+        case BB_LOOP_BLOCK: {
+            aoStrCatPrintf(builder->viz, BB_FMT_BLUE_DOTTED, cur->block_no,
+                           cur->prev->block_no);
+            if (cur->flags & BB_FLAG_UNCONDITIONAL_JUMP && cur->next) {
+                aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID, cur->block_no,
+                               cur->next->block_no);
             }
+            break;
+        }
 
-            case BB_LOOP_BLOCK: {
-                aoStrCatPrintf(builder->viz,
-                        BB_FMT_BLUE_DOTTED,
-                        cur->block_no,
-                        cur->prev->block_no);
-                if (cur->flags & BB_FLAG_UNCONDITIONAL_JUMP && cur->next) {
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLACK_SOLID,
-                            cur->block_no,
-                            cur->next->block_no);
-                }
-                break;
+        case BB_DO_WHILE_COND:
+            aoStrCatPrintf(builder->viz, BB_FMT_BLUE_DOTTED, cur->block_no,
+                           cur->prev->block_no);
+            if (cur->next) {
+                aoStrCatPrintf(builder->viz, BB_FMT_RED_SOLID, cur->block_no,
+                               cur->next->block_no);
             }
+            break;
 
-            case BB_DO_WHILE_COND:
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLUE_DOTTED,
-                            cur->block_no,
-                            cur->prev->block_no);
-                    if (cur->next) {
-                        aoStrCatPrintf(builder->viz,
-                                BB_FMT_RED_SOLID,
-                                cur->block_no,
-                                cur->next->block_no);
-                    }
-                break;
+        case BB_BRANCH_BLOCK:
+            aoStrCatPrintf(builder->viz, BB_FMT_RED_SOLID, cur->block_no,
+                           cur->_else->block_no);
+            aoStrCatPrintf(builder->viz, BB_FMT_GREEN_SOLID, cur->block_no,
+                           cur->_if->block_no);
+            break;
 
-            case BB_BRANCH_BLOCK:
-                aoStrCatPrintf(builder->viz,
-                        BB_FMT_RED_SOLID,
-                        cur->block_no,
-                        cur->_else->block_no);
-                aoStrCatPrintf(builder->viz,
-                        BB_FMT_GREEN_SOLID,
-                        cur->block_no,
-                        cur->_if->block_no);
-                break;
-
-            case BB_GOTO:
-                if (cur->flags & (BB_FLAG_GOTO_LOOP)) {
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLUE_DOTTED,
-                            cur->block_no,
-                            cur->prev->block_no);
-                } else {
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLACK_SOLID,
-                            cur->block_no,
-                            cur->next->block_no);
-                }
-                break;
-
-            case BB_CONTROL_BLOCK:
-            case BB_HEAD_BLOCK:
-            case BB_CASE:
-            case BB_BREAK_BLOCK: {
-                aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID,
-                        cur->block_no,
-                        cur->next->block_no);
-                break;
+        case BB_GOTO:
+            if (cur->flags & (BB_FLAG_GOTO_LOOP)) {
+                aoStrCatPrintf(builder->viz, BB_FMT_BLUE_DOTTED, cur->block_no,
+                               cur->prev->block_no);
+            } else {
+                aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID, cur->block_no,
+                               cur->next->block_no);
             }
+            break;
 
-            case BB_SWITCH: {
-                for (int i = 0; i < cur->next_blocks->size; ++i) {
-                    BasicBlock *bb = vecGet(BasicBlock *,cur->next_blocks,i);
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLACK_SOLID,
-                            cur->block_no,
-                            bb->block_no);
-                }
-                if (cur->next) {
-                    aoStrCatPrintf(builder->viz,
-                            BB_FMT_BLACK_SOLID,
-                            cur->block_no,
-                            cur->next->block_no);
-                }
-                break;
+        case BB_CONTROL_BLOCK:
+        case BB_HEAD_BLOCK:
+        case BB_CASE:
+        case BB_BREAK_BLOCK: {
+            aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID, cur->block_no,
+                           cur->next->block_no);
+            break;
+        }
+
+        case BB_SWITCH: {
+            for (int i = 0; i < cur->next_blocks->size; ++i) {
+                const BasicBlock *bb = vecGet(BasicBlock *, cur->next_blocks,
+                                              i);
+                aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID, cur->block_no,
+                               bb->block_no);
             }
+            if (cur->next) {
+                aoStrCatPrintf(builder->viz, BB_FMT_BLACK_SOLID, cur->block_no,
+                               cur->next->block_no);
+            }
+            break;
+        }
 
-            /* Add a fake node so it is obvious that it is the end */
-            case BB_END_BLOCK:
-            case BB_RETURN_BLOCK: 
-                aoStrCatPrintf(builder->viz,
-                        BB_FMT_BLACK_END_NODE,
-                        cur->block_no,
-                        cur->block_no);
-                break;
+        /* Add a fake node so it is obvious that it is the end */
+        case BB_END_BLOCK:
+        case BB_RETURN_BLOCK:
+            aoStrCatPrintf(builder->viz, BB_FMT_BLACK_END_NODE, cur->block_no,
+                           cur->block_no);
+            break;
 
-            default:
-                loggerWarning("Unhandled! loopidx=%ld: bb%d %s\n",
-                    it->idx,cur->block_no,bbToString(cur));
+        default:
+            loggerWarning("Unhandled! loopidx=%ld: bb%d %s\n", (long)it->idx,
+                          cur->block_no, bbToString(cur));
         }
     }
     loggerDebug("Created mapping for: %s\n", cfg->ref_fname->data);
     intMapIteratorRelease(it);
 }
 
-
 void cfgBuilderWriteToFile(CfgGraphVizBuilder *builder, char *filename);
 static void cfgCreateGraphViz(CfgGraphVizBuilder *builder, CFG *cfg) {
     aoStrCatPrintf(builder->viz,
-            "overlap=false;\n"
-            "subgraph \"cluster_%s\" {\n"
-            "    style=\"dashed\";\n"
-            "    color=\"black\";\n"
-            "    label=\"%s()\";\n",
-            cfg->ref_fname->data,
-            cfg->ref_fname->data);
+                   "overlap=false;\n"
+                   "subgraph \"cluster_%s\" {\n"
+                   "    style=\"dashed\";\n"
+                   "    color=\"black\";\n"
+                   "    label=\"%s()\";\n",
+                   cfg->ref_fname->data, cfg->ref_fname->data);
 
-    cfgCreatePicture(builder,cfg);
+    cfgCreatePicture(builder, cfg);
     /* Connects the nodes together in graphviz */
-    cfgGraphVizAddMappings(builder,cfg);
+    cfgGraphVizAddMappings(builder, cfg);
 
-    aoStrCatPrintf(builder->viz,"}//ending function\n\n");
+    aoStrCatPrintf(builder->viz, "}//ending function\n\n");
 }
 
 void cfgBuilderWriteToFile(CfgGraphVizBuilder *builder, char *filename) {
     aoStr *cfg_string = builder->viz;
-    int fd = open(filename,O_CREAT|O_TRUNC|O_RDWR,0644);
+    int fd = open(filename, O_CREAT | O_TRUNC | O_RDWR, 0644);
     if (fd == -1) {
-        loggerPanic("Failed to open file '%s': %s\n",
-                filename,strerror(errno));
+        loggerPanic("Failed to open file '%s': %s\n", filename,
+                    strerror(errno));
     }
 
     ssize_t written = write(fd, cfg_string->data, cfg_string->len);
@@ -710,19 +728,19 @@ void cfgToFile(CFG *cfg, char *filename) {
     CfgGraphVizBuilder builder;
 
     cfgGraphVizBuilderInit(&builder);
-    cfgCreateGraphViz(&builder,cfg);
-    cfgBuilderWriteToFile(&builder,filename);
+    cfgCreateGraphViz(&builder, cfg);
+    cfgBuilderWriteToFile(&builder, filename);
 }
 
-void cfgsToFile(PtrVec *cfgs, char *filename) {
+void cfgsToFile(const PtrVec *cfgs, char *filename) {
     CfgGraphVizBuilder builder;
 
     cfgGraphVizBuilderInit(&builder);
 
-    aoStrCat(builder.viz,"digraph user_program {\n ");
+    aoStrCat(builder.viz, "digraph user_program {\n ");
     for (int i = 0; i < cfgs->size; ++i) {
-        cfgCreateGraphViz(&builder,(CFG *)cfgs->entries[i]);
+        cfgCreateGraphViz(&builder, (CFG *)cfgs->entries[i]);
     }
     aoStrCatPrintf(builder.viz, "} // ending graph\n");
-    cfgBuilderWriteToFile(&builder,filename);
+    cfgBuilderWriteToFile(&builder, filename);
 }

--- a/src/cfg-print.h
+++ b/src/cfg-print.h
@@ -5,6 +5,6 @@
 #include "map.h"
 
 void cfgToFile(CFG *cfg, char *filename);
-void cfgsToFile(PtrVec *cfgs, char *filename);
+void cfgsToFile(const PtrVec *cfgs, char *filename);
 
 #endif

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -1,7 +1,7 @@
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "aostr.h"
 #include "ast.h"
@@ -14,7 +14,6 @@
 
 static void cfgHandleAstNode(CFGBuilder *builder, Ast *ast);
 static void cfgLinkLeaves(IntMap *map, BasicBlock *bb, BasicBlock *dest);
-
 
 void cfgBuilderRelease(CFGBuilder *builder, int free_builder) {
     if (builder) {
@@ -30,7 +29,8 @@ void bbInit(void *_bb) {
     bb->block_no = -1;
 }
 
-static void cfgBuilderInit(CFGBuilder *builder, Cctrl *cc, IntMap *leaf_cache, int block_no) {
+static void cfgBuilderInit(CFGBuilder *builder, Cctrl *cc, IntMap *leaf_cache,
+                           int block_no) {
     MemPool *block_pool = memPoolNew(2048);
 
     builder->cc = cc;
@@ -44,48 +44,49 @@ static void cfgBuilderInit(CFGBuilder *builder, Cctrl *cc, IntMap *leaf_cache, i
     builder->unresolved_gotos = listNew();
     builder->resolved_labels = strMapNew(16);
 
-    strMapSetFreeKey(builder->resolved_labels,NULL);
-    strMapSetFreeValue(builder->resolved_labels,NULL);
+    strMapSetFreeKey(builder->resolved_labels, NULL);
+    strMapSetFreeValue(builder->resolved_labels, NULL);
 }
 
-static void cfgBuilderClearLeafCache(CFGBuilder *builder) {
+static void cfgBuilderClearLeafCache(const CFGBuilder *builder) {
     intMapClear(builder->leaf_cache);
 }
 
-static void bbAddPrev(BasicBlock *bb, BasicBlock *prev) {
-    intMapAdd(bb->prev_blocks,prev->block_no,prev);
+static void bbAddPrev(const BasicBlock *bb, BasicBlock *prev) {
+    intMapAdd(bb->prev_blocks, prev->block_no, prev);
 }
 
-static void bbRemovePrev(BasicBlock *bb, int prev_block_no) {
-    intMapDelete(bb->prev_blocks,prev_block_no);
+static void bbRemovePrev(const BasicBlock *bb, int prev_block_no) {
+    intMapDelete(bb->prev_blocks, prev_block_no);
 }
 
-int bbPrevHas(BasicBlock *bb, int block_no) {
-    return intMapHas(bb->prev_blocks,block_no);
+int bbPrevHas(const BasicBlock *bb, int block_no) {
+    return intMapHas(bb->prev_blocks, block_no);
 }
 
-int bbIsType(BasicBlock *bb, enum bbType type) {
+int bbIsType(const BasicBlock *bb, enum bbType type) {
     return bb->type == type;
 }
 
-int bbOneOfType(BasicBlock *bb, int cnt, int types[]) {
+int bbOneOfType(const BasicBlock *bb, int cnt, const int types[]) {
     for (int i = 0; i < cnt; ++i) {
-        if (bb->type == types[i]) return 1;
+        if (bb->type == types[i])
+            return 1;
     }
     return 0;
 }
 
-int bbAstCount(BasicBlock *bb) {
+int bbAstCount(const BasicBlock *bb) {
     return bb->ast_array->size;
 }
 
-void bbAstAdd(BasicBlock *bb, Ast *ast) {
-    ptrVecPush(bb->ast_array,ast);
+void bbAstAdd(const BasicBlock *bb, Ast *ast) {
+    ptrVecPush(bb->ast_array, ast);
 }
 
 void bbSetPrevPtr(BasicBlock *bb, BasicBlock *prev) {
     bb->prev = prev;
-} 
+}
 
 void bbSetIf(BasicBlock *bb, BasicBlock *_if) {
     bb->_if = _if;
@@ -109,7 +110,7 @@ void bbSetType(BasicBlock *bb, enum bbType type) {
     bb->type = type;
 }
 
-int bbIsLoopEnd(BasicBlock *bb) {
+int bbIsLoopEnd(const BasicBlock *bb) {
     return bb->flags & BB_FLAG_LOOP_END;
 }
 
@@ -117,27 +118,40 @@ static void cfgBuilderSetBlock(CFGBuilder *builder, BasicBlock *bb) {
     builder->bb = bb;
 }
 
-int bbIsLoopControl(BasicBlock *bb) {
-    return bbIsType(bb,BB_CONTINUE) || bbIsType(bb,BB_BREAK_BLOCK);
+int bbIsLoopControl(const BasicBlock *bb) {
+    return bbIsType(bb, BB_CONTINUE) || bbIsType(bb, BB_BREAK_BLOCK);
 }
 
 char *bbTypeToString(int type) {
     switch (type) {
-        case BB_GARBAGE:       return "BB_GARBAGE";
-        case BB_END_BLOCK:     return "BB_END_BLOCK";
-        case BB_HEAD_BLOCK:    return "BB_HEAD_BLOCK";
-        case BB_CONTROL_BLOCK: return "BB_CONTROL_BLOCK";
-        case BB_BRANCH_BLOCK:  return "BB_BRANCH_BLOCK";
-        case BB_LOOP_BLOCK:    return "BB_LOOP_BLOCK";
-        case BB_RETURN_BLOCK:  return "BB_RETURN_BLOCK";
-        case BB_BREAK_BLOCK:   return "BB_BREAK_BLOCK";
-        case BB_DO_WHILE_COND: return "BB_DO_WHILE_COND";
-        case BB_GOTO:          return "BB_GOTO";
-        case BB_SWITCH:        return "BB_SWITCH";
-        case BB_CASE:          return "BB_CASE";
-        case BB_CONTINUE:      return "BB_CONTINUE";
-        default:
-            loggerPanic("Unknown type: %d\n", type);
+    case BB_GARBAGE:
+        return "BB_GARBAGE";
+    case BB_END_BLOCK:
+        return "BB_END_BLOCK";
+    case BB_HEAD_BLOCK:
+        return "BB_HEAD_BLOCK";
+    case BB_CONTROL_BLOCK:
+        return "BB_CONTROL_BLOCK";
+    case BB_BRANCH_BLOCK:
+        return "BB_BRANCH_BLOCK";
+    case BB_LOOP_BLOCK:
+        return "BB_LOOP_BLOCK";
+    case BB_RETURN_BLOCK:
+        return "BB_RETURN_BLOCK";
+    case BB_BREAK_BLOCK:
+        return "BB_BREAK_BLOCK";
+    case BB_DO_WHILE_COND:
+        return "BB_DO_WHILE_COND";
+    case BB_GOTO:
+        return "BB_GOTO";
+    case BB_SWITCH:
+        return "BB_SWITCH";
+    case BB_CASE:
+        return "BB_CASE";
+    case BB_CONTINUE:
+        return "BB_CONTINUE";
+    default:
+        loggerPanic("Unknown type: %d\n", type);
     }
 }
 
@@ -155,15 +169,16 @@ void cfgPrintAstArray(BasicBlock *bb) {
 #endif
 
 char *bbFlagsToString(unsigned int flags) {
-    if (!flags) return mprintf("(NO_FLAGS)");
+    if (!flags)
+        return mprintf("(NO_FLAGS)");
     aoStr *str = aoStrNew();
     int has_flag = 0;
 
-#define _concat_flag(str_flag) \
-    has_flag ? aoStrCat(str,"|"str_flag) : aoStrCat(str,str_flag); \
+#define _concat_flag(str_flag)                                        \
+    has_flag ? aoStrCat(str, "|" str_flag) : aoStrCat(str, str_flag); \
     has_flag = 1;
 
-    aoStrPutChar(str,'(');
+    aoStrPutChar(str, '(');
     if (flags & BB_FLAG_IF_BRANCH) {
         _concat_flag("BB_FLAG_IF_BRANCH");
     }
@@ -209,11 +224,11 @@ char *bbFlagsToString(unsigned int flags) {
     if (flags & BB_FLAG_HAD_NO_ELSE) {
         _concat_flag("BB_FLAG_HAD_NO_ELSE");
     }
-    aoStrPutChar(str,')');
+    aoStrPutChar(str, ')');
 
 #undef _concat_flag
 
-    return aoStrMove(str); 
+    return aoStrMove(str);
 }
 
 #define BB_FMT_TYPE_CHARS 18
@@ -221,21 +236,21 @@ char *bbFlagsToString(unsigned int flags) {
 char *bbToString(BasicBlock *bb) {
     aoStr *str = aoStrNew();
     char *str_flags = bbFlagsToString(bb->flags);
-    char *str_type =  bbTypeToString(bb->type);
-    char *str_prev =  bbPreviousBlockNumbersToString(bb);
+    char *str_type = bbTypeToString(bb->type);
+    char *str_prev = bbPreviousBlockNumbersToString(bb);
 
-    aoStrCatPrintf(str,"bb%d type = %-*s, flags = %-*s, %s, ",
-            bb->block_no,
-            BB_FMT_TYPE_CHARS,
-            str_type,
-            BB_FMT_FLAG_CHARS,
-            str_flags,
-            str_prev);
+    aoStrCatPrintf(str, "bb%d type = %-*s, flags = %-*s, %s, ", bb->block_no,
+                   BB_FMT_TYPE_CHARS, str_type, BB_FMT_FLAG_CHARS, str_flags,
+                   str_prev);
 
-    if (bb->next)  aoStrCatPrintf(str,"next = bb%d, ",bb->next->block_no);
-    if (bb->_if)   aoStrCatPrintf(str,"if = bb%d, ",bb->_if->block_no);
-    if (bb->_else) aoStrCatPrintf(str,"else = bb%d ",bb->_else->block_no);
-    if (bb->prev)  aoStrCatPrintf(str,"prev_ptr = bb%d ",bb->prev->block_no);
+    if (bb->next)
+        aoStrCatPrintf(str, "next = bb%d, ", bb->next->block_no);
+    if (bb->_if)
+        aoStrCatPrintf(str, "if = bb%d, ", bb->_if->block_no);
+    if (bb->_else)
+        aoStrCatPrintf(str, "else = bb%d ", bb->_else->block_no);
+    if (bb->prev)
+        aoStrCatPrintf(str, "prev_ptr = bb%d ", bb->prev->block_no);
     return aoStrMove(str);
 }
 
@@ -246,55 +261,58 @@ char *bbPreviousBlockNumbersToString(BasicBlock *bb) {
 char *bbToJSON(BasicBlock *bb) {
     aoStr *str = aoStrNew();
     char *str_flags = bbFlagsToString(bb->flags);
-    char *str_type =  bbTypeToString(bb->type);
-    char *str_prev =  bbPreviousBlockNumbersToString(bb);
+    char *str_type = bbTypeToString(bb->type);
+    char *str_prev = bbPreviousBlockNumbersToString(bb);
     char *str_prev_ptr = NULL;
 
     if (bb->prev) {
         str_prev_ptr = mprintf("bb%d", bb->prev->block_no);
     }
 
-    aoStrCat(str,"{\n");
-    aoStrCatPrintf(str,"    \"block_no\": \"bb%d\",\n",bb->block_no);
-    aoStrCatPrintf(str,"    \"type\": \"%s\",\n", str_type);
-    aoStrCatPrintf(str,"    \"flags\": \"%s\",\n", str_flags);
-    aoStrCatPrintf(str,"    \"prev_nodes\": \"%s\",\n", str_prev);
-    aoStrCatPrintf(str,"    \"prev_ptr\": \"%s\",\n", str_prev_ptr ? str_prev_ptr : "(null)");
+    aoStrCat(str, "{\n");
+    aoStrCatPrintf(str, "    \"block_no\": \"bb%d\",\n", bb->block_no);
+    aoStrCatPrintf(str, "    \"type\": \"%s\",\n", str_type);
+    aoStrCatPrintf(str, "    \"flags\": \"%s\",\n", str_flags);
+    aoStrCatPrintf(str, "    \"prev_nodes\": \"%s\",\n", str_prev);
+    aoStrCatPrintf(str, "    \"prev_ptr\": \"%s\",\n",
+                   str_prev_ptr ? str_prev_ptr : "(null)");
     if (bbIsType(bb, BB_BRANCH_BLOCK)) {
-        if (bb->_if)   aoStrCatPrintf(str,"    \"if\": \"bb%d\",\n",bb->_if->block_no);
-        if (bb->_else) aoStrCatPrintf(str,"    \"else\": \"bb%d\"\n",bb->_else->block_no);
+        if (bb->_if)
+            aoStrCatPrintf(str, "    \"if\": \"bb%d\",\n", bb->_if->block_no);
+        if (bb->_else)
+            aoStrCatPrintf(str, "    \"else\": \"bb%d\"\n",
+                           bb->_else->block_no);
     } else {
-        if (bb->next) aoStrCatPrintf(str,"    \"next\": \"bb%d\"\n",bb->next->block_no);
+        if (bb->next)
+            aoStrCatPrintf(str, "    \"next\": \"bb%d\"\n", bb->next->block_no);
     }
 
-    aoStrCat(str,"}\n");
+    aoStrCat(str, "}\n");
     return aoStrMove(str);
 }
 
 void bbPrintNoAst(BasicBlock *bb) {
-    char *bb_string = bbToString(bb);
-    printf("%s\n",bb_string);
+    const char *bb_string = bbToString(bb);
+    printf("%s\n", bb_string);
 }
 
 void bbPrint(BasicBlock *bb) {
     assert(bb != NULL);
     char *bb_str = bbToString(bb);
-    aoStr *str = aoStrDupRaw((char*)bb_str, strlen(bb_str)); 
-    aoStrPutChar(str,'\n');
+    aoStr *str = aoStrDupRaw((char *)bb_str, strlen(bb_str));
+    aoStrPutChar(str, '\n');
     for (int i = 0; i < bb->ast_array->size; ++i) {
-        char *ast_str = astLValueToString(bb->ast_array->entries[i],0);
-        aoStrCat(str,ast_str);
-        aoStrPutChar(str,'\n');
+        const char *ast_str = astLValueToString(bb->ast_array->entries[i], 0);
+        aoStrCat(str, ast_str);
+        aoStrPutChar(str, '\n');
     }
-    printf("========\n%s========\n",str->data);
+    printf("========\n%s========\n", str->data);
 }
 
-
-static BasicBlock *cfgBuilderAllocBasicBlock(CFGBuilder *builder,
-                                             int type,
-                                             unsigned int flags)
-{
-    BasicBlock *bb = (BasicBlock *)memPoolAlloc(builder->block_pool, sizeof(BasicBlock));
+static BasicBlock *cfgBuilderAllocBasicBlock(CFGBuilder *builder, int type,
+                                             unsigned int flags) {
+    BasicBlock *bb = (BasicBlock *)memPoolAlloc(builder->block_pool,
+                                                sizeof(BasicBlock));
 
     bb->type = type;
     bb->flags = 0;
@@ -319,117 +337,119 @@ static CFG *cfgNew(aoStr *fname, BasicBlock *head_block) {
     return cfg;
 }
 
-/* Sometimes the block that has been allocated and exists on the builder 
- * can be used i.e there are no asts in the array. 
+/* Sometimes the block that has been allocated and exists on the builder
+ * can be used i.e there are no asts in the array.
  * Other times we need to allocate a new block */
 static BasicBlock *cfgSelectOrCreateBlock(CFGBuilder *builder, int type,
-        unsigned int flags)
-{
+                                          unsigned int flags) {
     BasicBlock *bb = NULL;
     if (bbAstCount(builder->bb) == 0 && !bbIsLoopControl(builder->bb)) {
         bb = builder->bb;
-        bbSetType(bb,type);
+        bbSetType(bb, type);
     } else {
-        bb = cfgBuilderAllocBasicBlock(builder,type,0);
-        bbSetPrevPtr(bb,builder->bb);
-        bbSetNext(builder->bb,bb);
+        bb = cfgBuilderAllocBasicBlock(builder, type, 0);
+        bbSetPrevPtr(bb, builder->bb);
+        bbSetNext(builder->bb, bb);
     }
-    /* If the block is being recycled it could have flags that are needed on it 
+    /* If the block is being recycled it could have flags that are needed on it
      * so OR in the new flags as opposed to setting them */
     bb->flags |= flags;
     return bb;
 }
 
-static void cgfHandleBranchBlock(CFGBuilder *builder, Ast *ast) {
+static void cgfHandleBranchBlock(CFGBuilder *builder, const Ast *ast) {
     /**
      * c-code:
-     * +--------------------------+                                           
-     * | I64 x = 10;              |                                           
+     * +--------------------------+
+     * | I64 x = 10;              |
      * | I64 y;                   |
      * | y = x * 89 + 1;          |
-     * | if (x == 10) {           |                                           
-     * |    y = 42;               |                                           
-     * | } else if (x == 21) {    |                                            
-     * |    y = 99;               |                                           
-     * | } else {                 |                                           
-     * |    y = 69;               |                                           
-     * |    if (y == 69) {        |                                           
-     * |       printf("69\n");    |                                           
-     * |    }                     |                                           
-     * | }                        |                                           
-     * | printf("%ld\n",y);       |                                           
-     * | if (x == 12) {           |                                           
+     * | if (x == 10) {           |
+     * |    y = 42;               |
+     * | } else if (x == 21) {    |
+     * |    y = 99;               |
+     * | } else {                 |
+     * |    y = 69;               |
+     * |    if (y == 69) {        |
+     * |       printf("69\n");    |
+     * |    }                     |
+     * | }                        |
+     * | printf("%ld\n",y);       |
+     * | if (x == 12) {           |
      * |    printf("kowabunga\n");|
-     * | }                        | 
-     * | return 10;               |                                           
-     * +--------------------------+                                           
+     * | }                        |
+     * | return 10;               |
+     * +--------------------------+
      */
     int in_conditional = builder->flags & CFG_BUILDER_FLAG_IN_CONDITIONAL;
 
     builder->flags |= CFG_BUILDER_FLAG_IN_CONDITIONAL;
 
-    BasicBlock *cond = cfgSelectOrCreateBlock(builder,BB_BRANCH_BLOCK,0);
-    BasicBlock *else_body = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,BB_FLAG_ELSE_BRANCH);
-    BasicBlock *if_body = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,BB_FLAG_IF_BRANCH);
-    BasicBlock *new_block;
+    BasicBlock *cond = cfgSelectOrCreateBlock(builder, BB_BRANCH_BLOCK, 0);
+    BasicBlock *else_body = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                      BB_FLAG_ELSE_BRANCH);
+    BasicBlock *if_body = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                    BB_FLAG_IF_BRANCH);
 
     /* Ensure the new nodes point to the branch head */
-    bbSetPrevPtr(if_body,cond);
-    bbSetPrevPtr(else_body,cond);
+    bbSetPrevPtr(if_body, cond);
+    bbSetPrevPtr(else_body, cond);
 
     /* Set the if and else branches of the node */
-    bbSetIf(cond,if_body);
-    bbSetElse(cond,else_body);
+    bbSetIf(cond, if_body);
+    bbSetElse(cond, else_body);
 
+    cfgBuilderSetBlock(builder, cond);
+    cfgHandleAstNode(builder, ast->cond);
 
-    cfgBuilderSetBlock(builder,cond);
-    cfgHandleAstNode(builder,ast->cond);
-
-    cfgBuilderSetBlock(builder,if_body);
+    cfgBuilderSetBlock(builder, if_body);
     /* Start of a new basic block */
-    cfgHandleAstNode(builder,ast->then);
+    cfgHandleAstNode(builder, ast->then);
 
     if (ast->els) {
-        cfgBuilderSetBlock(builder,else_body);
-        cfgHandleAstNode(builder,ast->els);
+        cfgBuilderSetBlock(builder, else_body);
+        cfgHandleAstNode(builder, ast->els);
 
-        /* This means the node has changed, and thus the next block needs 
+        /* This means the node has changed, and thus the next block needs
          * to be this branch */
         if (builder->bb != else_body) {
             if (!bbIsType(builder->bb, BB_CONTINUE)) {
-                bbSetPrevPtr(builder->bb,cond);
+                bbSetPrevPtr(builder->bb, cond);
             }
-            /* Join */ 
-            bbSetNext(cond,builder->bb);
+            /* Join */
+            bbSetNext(cond, builder->bb);
         } else {
-            new_block = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
-            bbSetNext(cond,new_block);
-            bbSetPrevPtr(new_block,else_body);
-            cfgBuilderSetBlock(builder,new_block);
+            BasicBlock *new_block = cfgBuilderAllocBasicBlock(builder,
+                                                              BB_CONTROL_BLOCK,
+                                                              0);
+            bbSetNext(cond, new_block);
+            bbSetPrevPtr(new_block, else_body);
+            cfgBuilderSetBlock(builder, new_block);
         }
     } else {
         cond->flags |= BB_FLAG_HAD_NO_ELSE;
-        /* If the current node is not the if then it will be the next node. 
+        /* If the current node is not the if then it will be the next node.
          * Presumably at this point in time it is empty and yet to be set. */
         if (builder->bb != if_body) {
-            bbSetNext(cond,builder->bb);
+            bbSetNext(cond, builder->bb);
         }
 
         /* Continue must point back to the loop head */
-        if (!bbIsType(builder->bb,BB_CONTINUE)) {
-            bbSetPrevPtr(builder->bb,cond);
+        if (!bbIsType(builder->bb, BB_CONTINUE)) {
+            bbSetPrevPtr(builder->bb, cond);
         }
 
-        int is_next_return = if_body->next && !bbIsType(if_body->next,BB_RETURN_BLOCK);
+        int is_next_return = if_body->next &&
+                !bbIsType(if_body->next, BB_RETURN_BLOCK);
 
-        /* Set the node subsequent to both paths of the if and else as the 
+        /* Set the node subsequent to both paths of the if and else as the
          * next pointer */
         if (!bbIsLoopControl(if_body) && !is_next_return) {
-            bbSetNext(cond,else_body);
+            bbSetNext(cond, else_body);
         }
-        cfgBuilderSetBlock(builder,else_body);
+        cfgBuilderSetBlock(builder, else_body);
     }
-  
+
     if (!in_conditional) {
         builder->flags &= ~(CFG_BUILDER_FLAG_IN_CONDITIONAL);
     }
@@ -448,50 +468,50 @@ static void cfgHandleForLoop(CFGBuilder *builder, Ast *ast) {
     BasicBlock *bb_init = NULL;
 
     if (ast_init) {
-        /* This is straight line code, there is no need to allocate or do 
+        /* This is straight line code, there is no need to allocate or do
          * any basic block manipulation. Thus */
-        if (bbIsType(builder->bb,BB_CONTROL_BLOCK)) {
-            bb_init = builder->bb;
-        } else {
-            bb_init = cfgSelectOrCreateBlock(builder,BB_CONTROL_BLOCK,0);
-            cfgBuilderSetBlock(builder,bb_init);
+        if (!bbIsType(builder->bb, BB_CONTROL_BLOCK)) {
+            bb_init = cfgSelectOrCreateBlock(builder, BB_CONTROL_BLOCK, 0);
+            cfgBuilderSetBlock(builder, bb_init);
         }
-        cfgHandleAstNode(builder,ast_init);
+        cfgHandleAstNode(builder, ast_init);
     }
 
-    BasicBlock *bb_cond = cfgSelectOrCreateBlock(builder,BB_BRANCH_BLOCK,
-            BB_FLAG_LOOP_HEAD|BB_FLAG_FOR_LOOP);
-    if (ast_step) bb_cond->flags |= BB_FLAG_FOR_LOOP_HAS_STEP;
+    BasicBlock *bb_cond = cfgSelectOrCreateBlock(builder, BB_BRANCH_BLOCK,
+                                                 BB_FLAG_LOOP_HEAD |
+                                                         BB_FLAG_FOR_LOOP);
+    if (ast_step)
+        bb_cond->flags |= BB_FLAG_FOR_LOOP_HAS_STEP;
 
     if (ast_cond == NULL) {
         ast_cond = astMakeForeverSentinal();
     }
 
     BasicBlock *bb_cond_else = cfgBuilderAllocBasicBlock(builder,
-                                                         BB_CONTROL_BLOCK,0);
+                                                         BB_CONTROL_BLOCK, 0);
     /* Body may or may not be a Loop, we correct it in the if condition with
      * builder->bb != bb_body */
-    BasicBlock *bb_body = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
+    BasicBlock *bb_body = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                    0);
 
     /* Jump into loop body if condition is met */
-    bbSetIf(bb_cond,bb_body);
+    bbSetIf(bb_cond, bb_body);
     /* Else move past loop body */
-    bbSetElse(bb_cond,bb_cond_else);
+    bbSetElse(bb_cond, bb_cond_else);
     /* And the previously met block was the condition */
-    bbSetPrevPtr(bb_cond_else,bb_cond);
-    bbSetPrevPtr(bb_body,bb_cond);
-
+    bbSetPrevPtr(bb_cond_else, bb_cond);
+    bbSetPrevPtr(bb_body, bb_cond);
 
     builder->bb_cur_loop = bb_cond;
 
-    cfgBuilderSetBlock(builder,bb_cond);
-    cfgHandleAstNode(builder,ast_cond);
+    cfgBuilderSetBlock(builder, bb_cond);
+    cfgHandleAstNode(builder, ast_cond);
 
     /* Forms a loop, though this should be picked up by the if condition
      * below, This can be unset by the above call so reset it. */
-    bbSetPrevPtr(bb_body,bb_cond);
+    bbSetPrevPtr(bb_body, bb_cond);
 
-    /* Body exists within a loop 
+    /* Body exists within a loop
      *
      * This c code:
      * +--------------------------------+
@@ -510,12 +530,12 @@ static void cfgHandleForLoop(CFGBuilder *builder, Ast *ast) {
      * | y = 420;           |
      * | i = 0;             |<- forinit.
      * +--------------------+
-     *           |          
-     *           V          
+     *           |
+     *           V
      * +--------------------+
      * | BB2:               |<- forcond is this whole block.
      * +--------------------+
-     * | if i < 10          |         
+     * | if i < 10          |
      * |    goto BB3;       |--------+
      * | else               |        |
      * |    goto BB4;       |--------+
@@ -538,30 +558,30 @@ static void cfgHandleForLoop(CFGBuilder *builder, Ast *ast) {
      **/
 
     /* @Wrong? Is this actually wrong?
-     * We realistically do not want to be merging these two together in the 
+     * We realistically do not want to be merging these two together in the
      * same unit.
      *
      * Think step should be separate and that bb_body->next always should point
      * to it?
      * */
-    cfgBuilderSetBlock(builder,bb_body);
-    cfgHandleAstNode(builder,ast_body);
+    cfgBuilderSetBlock(builder, bb_body);
+    cfgHandleAstNode(builder, ast_body);
 
     /* If there is a step add that as the last node to the body of the loop */
     if (!bbIsLoopControl(bb_body) && ast_step) {
-        cfgHandleAstNode(builder,ast_step);
+        cfgHandleAstNode(builder, ast_step);
     }
 
     /* This means we had branches or possibly inner loops in our loop */
     if (builder->bb != bb_body || !builder->bb->next) {
-        bbSetType(builder->bb,BB_LOOP_BLOCK);
-        bbSetPrevPtr(builder->bb,bb_cond);
+        bbSetType(builder->bb, BB_LOOP_BLOCK);
+        bbSetPrevPtr(builder->bb, bb_cond);
         /* So we can access the loop block from the head of the condition */
-        bbSetNext(bb_cond,builder->bb);
+        bbSetNext(bb_cond, builder->bb);
     }
 
     /* This is a loop which immediately hit a break; */
-    if (bbIsType(builder->bb,BB_BREAK_BLOCK) && bbIsLoopEnd(builder->bb)) {
+    if (bbIsType(builder->bb, BB_BREAK_BLOCK) && bbIsLoopEnd(builder->bb)) {
         builder->bb->flags |= BB_FLAG_REDUNDANT_LOOP;
         builder->bb->flags &= ~(BB_FLAG_LOOP_END);
         bb_cond->flags &= ~BB_FLAG_LOOP_HEAD;
@@ -569,7 +589,7 @@ static void cfgHandleForLoop(CFGBuilder *builder, Ast *ast) {
     }
 
     bbSetLoopEnd(bb_cond_else);
-    cfgBuilderSetBlock(builder,bb_cond_else);
+    cfgBuilderSetBlock(builder, bb_cond_else);
 
     if (!bb_prev_loop) {
         builder->flags &= ~(CFG_BUILDER_FLAG_IN_LOOP);
@@ -578,56 +598,58 @@ static void cfgHandleForLoop(CFGBuilder *builder, Ast *ast) {
     builder->bb_cur_loop = bb_prev_loop;
 }
 
-static void cfgHandleWhileLoop(CFGBuilder *builder, Ast *ast) {
+static void cfgHandleWhileLoop(CFGBuilder *builder, const Ast *ast) {
     Ast *ast_cond = ast->whilecond;
     Ast *ast_body = ast->whilebody;
-    
+
     builder->flags |= CFG_BUILDER_FLAG_IN_LOOP;
     BasicBlock *bb_prev_loop = builder->bb_cur_loop;
 
-    BasicBlock *bb_cond = cfgSelectOrCreateBlock(builder,BB_BRANCH_BLOCK,
-            (BB_FLAG_LOOP_HEAD|BB_FLAG_WHILE_LOOP));
-    BasicBlock *bb_body = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
+    BasicBlock *bb_cond = cfgSelectOrCreateBlock(builder, BB_BRANCH_BLOCK,
+                                                 (BB_FLAG_LOOP_HEAD |
+                                                  BB_FLAG_WHILE_LOOP));
+    BasicBlock *bb_body = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                    0);
     BasicBlock *bb_cond_else = cfgBuilderAllocBasicBlock(builder,
-                                                         BB_CONTROL_BLOCK,0);
+                                                         BB_CONTROL_BLOCK, 0);
 
     /* Jump into loop body if condition is met */
-    bbSetIf(bb_cond,bb_body);
+    bbSetIf(bb_cond, bb_body);
 
     /* Else move past loop body */
-    bbSetElse(bb_cond,bb_cond_else);
+    bbSetElse(bb_cond, bb_cond_else);
     bbSetLoopEnd(bb_cond_else);
 
     /* And the previously met block was the condition */
-    bbSetPrevPtr(bb_cond_else,bb_cond);
+    bbSetPrevPtr(bb_cond_else, bb_cond);
 
     builder->bb_cur_loop = bb_cond;
 
-    cfgBuilderSetBlock(builder,bb_cond);
-    cfgHandleAstNode(builder,ast_cond);
+    cfgBuilderSetBlock(builder, bb_cond);
+    cfgHandleAstNode(builder, ast_cond);
 
     /* Forms a loop, though this should be picked up by the if condition
      * below */
-    bbSetPrevPtr(bb_body,bb_cond);
+    bbSetPrevPtr(bb_body, bb_cond);
 
-    cfgBuilderSetBlock(builder,bb_body);
+    cfgBuilderSetBlock(builder, bb_body);
     if (ast_body) {
-        cfgHandleAstNode(builder,ast_body);
+        cfgHandleAstNode(builder, ast_body);
     }
 
     /* This means we had branches or possibly inner loops in our loop */
     if (builder->bb != bb_body || !builder->bb->next) {
-        bbSetType(builder->bb,BB_LOOP_BLOCK);
+        bbSetType(builder->bb, BB_LOOP_BLOCK);
         if (bbAstCount(builder->bb) == 0) {
-            ptrVecPush(builder->bb->ast_array,astMakeLoopSentinal());
+            ptrVecPush(builder->bb->ast_array, astMakeLoopSentinal());
         }
         /* So we can access the loop block from the head of the condition */
-        bbSetNext(bb_cond,builder->bb);
-        bbSetPrevPtr(builder->bb,bb_cond);
+        bbSetNext(bb_cond, builder->bb);
+        bbSetPrevPtr(builder->bb, bb_cond);
     }
-    
+
     /* This is a loop which immediately hit a break; */
-    if (bbIsType(builder->bb,BB_BREAK_BLOCK) && bbIsLoopEnd(builder->bb)) {
+    if (bbIsType(builder->bb, BB_BREAK_BLOCK) && bbIsLoopEnd(builder->bb)) {
         builder->bb->flags |= BB_FLAG_REDUNDANT_LOOP;
         builder->bb->flags &= ~(BB_FLAG_LOOP_END);
         bb_cond->flags &= ~BB_FLAG_LOOP_HEAD;
@@ -635,7 +657,7 @@ static void cfgHandleWhileLoop(CFGBuilder *builder, Ast *ast) {
     }
 
     bbSetLoopEnd(bb_cond_else);
-    cfgBuilderSetBlock(builder,bb_cond_else);
+    cfgBuilderSetBlock(builder, bb_cond_else);
 
     if (!bb_prev_loop) {
         builder->flags &= ~(CFG_BUILDER_FLAG_IN_LOOP);
@@ -644,13 +666,13 @@ static void cfgHandleWhileLoop(CFGBuilder *builder, Ast *ast) {
     builder->bb_cur_loop = bb_prev_loop;
 }
 
-static void cfgHandleDoWhileLoop(CFGBuilder *builder, Ast *ast) {
+static void cfgHandleDoWhileLoop(CFGBuilder *builder, const Ast *ast) {
     Ast *ast_cond = ast->whilecond;
     Ast *ast_body = ast->whilebody;
 
     BasicBlock *bb_prev_loop = builder->bb_cur_loop;
-    BasicBlock *bb_do_body = cfgSelectOrCreateBlock(builder,
-            BB_CONTROL_BLOCK, BB_FLAG_LOOP_HEAD);
+    BasicBlock *bb_do_body = cfgSelectOrCreateBlock(builder, BB_CONTROL_BLOCK,
+                                                    BB_FLAG_LOOP_HEAD);
 
     /*
      * do {
@@ -664,27 +686,27 @@ static void cfgHandleDoWhileLoop(CFGBuilder *builder, Ast *ast) {
     builder->bb_cur_loop = bb_do_body;
     builder->flags |= CFG_BUILDER_FLAG_IN_LOOP;
 
-    cfgBuilderSetBlock(builder,bb_do_body);
-    cfgHandleAstNode(builder,ast_body);
+    cfgBuilderSetBlock(builder, bb_do_body);
+    cfgHandleAstNode(builder, ast_body);
 
-    /* converge all orphans in the do while body to point to the node in the 
+    /* converge all orphans in the do while body to point to the node in the
      * while(...) */
-    BasicBlock *bb_do_cond = cfgSelectOrCreateBlock(builder,
-            BB_DO_WHILE_COND,0);
-    cfgLinkLeaves(builder->leaf_cache,builder->bb,bb_do_cond);
+    BasicBlock *bb_do_cond = cfgSelectOrCreateBlock(builder, BB_DO_WHILE_COND,
+                                                    0);
+    cfgLinkLeaves(builder->leaf_cache, builder->bb, bb_do_cond);
     cfgBuilderClearLeafCache(builder);
 
     /* Form the loop */
-    bbSetPrevPtr(bb_do_cond,bb_do_body);
+    bbSetPrevPtr(bb_do_cond, bb_do_body);
     bbSetLoopEnd(bb_do_cond);
 
-
     BasicBlock *bb_do_while_next = cfgBuilderAllocBasicBlock(builder,
-            BB_CONTROL_BLOCK, 0);
+                                                             BB_CONTROL_BLOCK,
+                                                             0);
     bb_do_cond->next = bb_do_while_next;
 
-    cfgBuilderSetBlock(builder,bb_do_cond);
-    cfgHandleAstNode(builder,ast_cond);
+    cfgBuilderSetBlock(builder, bb_do_cond);
+    cfgHandleAstNode(builder, ast_cond);
 
     if (!bb_prev_loop) {
         builder->flags &= ~(CFG_BUILDER_FLAG_IN_LOOP);
@@ -696,107 +718,108 @@ static void cfgHandleDoWhileLoop(CFGBuilder *builder, Ast *ast) {
     builder->bb_cur_loop = bb_prev_loop;
 }
 
-static void cfgHandleGoto(CFGBuilder *builder, Ast *ast) {
+static void cfgHandleGoto(const CFGBuilder *builder, Ast *ast) {
     BasicBlock *dest;
-    aoStr *label = astHackedGetLabel(ast);
+    const aoStr *label = astHackedGetLabel(ast);
 
-    bbSetType(builder->bb,BB_GOTO);
+    bbSetType(builder->bb, BB_GOTO);
 
     if (builder->flags & CFG_BUILDER_FLAG_IN_LOOP) {
         builder->bb->flags |= BB_FLAG_LOOP_JUMP;
     }
 
-    /* Try straight out the gate to resolve the goto otherwise save it for 
+    /* Try straight out the gate to resolve the goto otherwise save it for
      * later */
-    if ((dest = strMapGetLen(builder->resolved_labels,label->data,
-            label->len)) != NULL)
-    {
-        /* This forms a loop but over a potentially large number of graph nodes 
-         * making it difficult to classify as a _conventional_ loop. 
+    if ((dest = strMapGetLen(builder->resolved_labels, label->data,
+                             label->len)) != NULL) {
+        /* This forms a loop but over a potentially large number of graph nodes
+         * making it difficult to classify as a _conventional_ loop.
          * Do we want an intermediary node? */
-        bbSetPrevPtr(builder->bb,dest);
+        bbSetPrevPtr(builder->bb, dest);
         builder->bb->flags |= BB_FLAG_GOTO_LOOP;
-        bbSetNext(builder->bb,NULL);
+        bbSetNext(builder->bb, NULL);
     } else {
-        listAppend(builder->unresolved_gotos,builder->bb);
+        listAppend(builder->unresolved_gotos, builder->bb);
     }
 
     /* This should just push the ast to to ast_array */
-    ptrVecPush(builder->bb->ast_array,ast);
+    ptrVecPush(builder->bb->ast_array, ast);
 
     /* If this is an unconditional jump */
     if (!(builder->flags & CFG_BUILDER_FLAG_IN_CONDITIONAL)) {
-       builder->bb->flags |= BB_FLAG_UNCONDITIONAL_JUMP;
+        builder->bb->flags |= BB_FLAG_UNCONDITIONAL_JUMP;
     }
 }
 
 static void cfgHandleReturn(CFGBuilder *builder, Ast *ast) {
-    BasicBlock *bb_return = cfgSelectOrCreateBlock(builder,BB_RETURN_BLOCK,0);
-    BasicBlock *bb_after = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
-    bbSetNext(bb_return,NULL);
+    BasicBlock *bb_return = cfgSelectOrCreateBlock(builder, BB_RETURN_BLOCK, 0);
+    BasicBlock *bb_after = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                     0);
+    bbSetNext(bb_return, NULL);
 
-    ptrVecPush(bb_return->ast_array,ast);
-    cfgBuilderSetBlock(builder,bb_after);
+    ptrVecPush(bb_return->ast_array, ast);
+    cfgBuilderSetBlock(builder, bb_after);
 }
 
-/* Splitting the label makes sense else we get into a situation where we have 
+/* Splitting the label makes sense else we get into a situation where we have
  * multiple goto labels in the same block and the code paths get muddled. */
 static void cfgHandleLabel(CFGBuilder *builder, Ast *ast) {
-    BasicBlock *bb_label = cfgSelectOrCreateBlock(builder,
-            BB_CONTROL_BLOCK,BB_FLAG_LABEL);
+    BasicBlock *bb_label = cfgSelectOrCreateBlock(builder, BB_CONTROL_BLOCK,
+                                                  BB_FLAG_LABEL);
     /* We want the label in the newly allocated block */
-    ptrVecPush(bb_label->ast_array,ast);
+    ptrVecPush(bb_label->ast_array, ast);
     aoStr *label = astHackedGetLabel(ast);
-    strMapAdd(builder->resolved_labels,label->data,bb_label);
-    cfgBuilderSetBlock(builder,bb_label);
+    strMapAdd(builder->resolved_labels, label->data, bb_label);
+    cfgBuilderSetBlock(builder, bb_label);
 }
 
 static void cfgHandleBreak(CFGBuilder *builder) {
-    if (builder->flags & CFG_BUILDER_FLAG_IN_LOOP && 
-            !(builder->flags & CFG_BUILDER_FLAG_IN_SWITCH)) {
-        bbSetType(builder->bb,BB_BREAK_BLOCK);
-        bbSetNext(builder->bb,builder->bb_cur_loop->_else);
+    if (builder->flags & CFG_BUILDER_FLAG_IN_LOOP &&
+        !(builder->flags & CFG_BUILDER_FLAG_IN_SWITCH)) {
+        bbSetType(builder->bb, BB_BREAK_BLOCK);
+        bbSetNext(builder->bb, builder->bb_cur_loop->_else);
     } else {
         builder->bb->flags |= BB_FLAG_CASE_BREAK;
     }
 }
 
-static void cfgHandleCompound(CFGBuilder *builder, Ast *ast) {
-    if (listEmpty(ast->stms)) return;
+static void cfgHandleCompound(CFGBuilder *builder, const Ast *ast) {
+    if (listEmpty(ast->stms))
+        return;
     listForEach(ast->stms) {
-        Ast *ast_node = cast(Ast *,it->value);
-        cfgHandleAstNode(builder,ast_node);
+        Ast *ast_node = cast(Ast *, it->value);
+        cfgHandleAstNode(builder, ast_node);
     }
 }
 
 static void cfgHandleContinue(CFGBuilder *builder) {
     assert(builder->flags & CFG_BUILDER_FLAG_IN_LOOP);
-    BasicBlock *bb_continue = cfgSelectOrCreateBlock(builder,BB_CONTINUE,0);
-    bbSetPrevPtr(bb_continue,builder->bb_cur_loop);
-    bbAddPrev(builder->bb_cur_loop,builder->bb);
+    BasicBlock *bb_continue = cfgSelectOrCreateBlock(builder, BB_CONTINUE, 0);
+    bbSetPrevPtr(bb_continue, builder->bb_cur_loop);
+    bbAddPrev(builder->bb_cur_loop, builder->bb);
     if (bb_continue != builder->bb) {
         loggerWarning("On a different node. builder bb%d and continue bb%d\n",
-                builder->bb->block_no, bb_continue->block_no);
-        bbSetNext(builder->bb,bb_continue);
+                      builder->bb->block_no, bb_continue->block_no);
+        bbSetNext(builder->bb, bb_continue);
     }
-    cfgBuilderSetBlock(builder,bb_continue);
+    cfgBuilderSetBlock(builder, bb_continue);
 }
 
 static void cfgHandleCase(CFGBuilder *builder, BasicBlock *bb_end, Ast *ast) {
     BasicBlock *bb_switch = builder->bb;
-    BasicBlock *bb_case = cfgBuilderAllocBasicBlock(builder,BB_CASE,0);
-    ptrVecPush(bb_switch->next_blocks,bb_case);
+    BasicBlock *bb_case = cfgBuilderAllocBasicBlock(builder, BB_CASE, 0);
+    ptrVecPush(bb_switch->next_blocks, bb_case);
 
-    /* so we can access begining and end while in the basic block and always 
+    /* so we can access begining and end while in the basic block and always
      * know it is the first node in the ast array  */
-    cfgBuilderSetBlock(builder,bb_case);
-    ptrVecPush(bb_case->ast_array,ast);
-    bbSetPrevPtr(bb_case,bb_switch);
+    cfgBuilderSetBlock(builder, bb_case);
+    ptrVecPush(bb_case->ast_array, ast);
+    bbSetPrevPtr(bb_case, bb_switch);
 
     if (!listEmpty(ast->case_asts)) {
         listForEach(ast->case_asts) {
             Ast *case_ast = (Ast *)it->value;
-            cfgHandleAstNode(builder,case_ast);
+            cfgHandleAstNode(builder, case_ast);
         }
     }
 
@@ -804,24 +827,25 @@ static void cfgHandleCase(CFGBuilder *builder, BasicBlock *bb_end, Ast *ast) {
         builder->bb->flags |= BB_FLAG_CASE_OWNED;
     }
 
-    bbSetPrevPtr(bb_end,builder->bb);
-    bbSetNext(builder->bb,bb_end);
-    bbAddPrev(bb_case,bb_switch);
+    bbSetPrevPtr(bb_end, builder->bb);
+    bbSetNext(builder->bb, bb_end);
+    bbAddPrev(bb_case, bb_switch);
 }
 
-/* The first and last items of the next_blocks array are the switch condition 
+/* The first and last items of the next_blocks array are the switch condition
  * and the next block respectively. This is easier to manage and theoretically
  * are different blocks but connected to the switch */
-static void cfgHandleSwitch(CFGBuilder *builder, Ast *ast) {
-    BasicBlock *bb_switch = cfgSelectOrCreateBlock(builder,BB_SWITCH,0);
-    BasicBlock *bb_end = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
+static void cfgHandleSwitch(CFGBuilder *builder, const Ast *ast) {
+    BasicBlock *bb_switch = cfgSelectOrCreateBlock(builder, BB_SWITCH, 0);
+    BasicBlock *bb_end = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK,
+                                                   0);
 
     int sp = 0;
     int prev_in_switch = builder->flags & CFG_BUILDER_FLAG_IN_SWITCH;
     static BasicBlock *bb_stack[128];
 
-    cfgBuilderSetBlock(builder,bb_switch);
-    cfgHandleAstNode(builder,ast->switch_cond);
+    cfgBuilderSetBlock(builder, bb_switch);
+    cfgHandleAstNode(builder, ast->switch_cond);
     bb_switch->next_blocks = ptrVecNew();
 
     if (!ast->switch_bounds_checked) {
@@ -831,16 +855,16 @@ static void cfgHandleSwitch(CFGBuilder *builder, Ast *ast) {
 
     /* ??? - This has the potential to be a crazy loop */
     for (int i = 0; i < ast->cases->size; ++i) {
-        cfgBuilderSetBlock(builder,bb_switch);
+        cfgBuilderSetBlock(builder, bb_switch);
         Ast *_case = (Ast *)ast->cases->entries[i];
-        cfgHandleCase(builder,bb_end,_case);
+        cfgHandleCase(builder, bb_end, _case);
 
         if (bbAstCount(builder->bb) == 1) {
             bb_stack[sp++] = builder->bb;
         } else if (sp) {
-            for (int i = 0; i < sp; i++) {
-                BasicBlock *stackable = bb_stack[i];
-                bbSetNext(stackable,builder->bb);
+            for (int j = 0; j < sp; j++) {
+                BasicBlock *stackable = bb_stack[j];
+                bbSetNext(stackable, builder->bb);
             }
             sp = 0;
         }
@@ -848,68 +872,72 @@ static void cfgHandleSwitch(CFGBuilder *builder, Ast *ast) {
 
     /* wrong ?*/
     if (ast->case_default != NULL) {
-        cfgBuilderSetBlock(builder,bb_switch);
-        cfgHandleCase(builder,bb_end,ast->case_default);
+        cfgBuilderSetBlock(builder, bb_switch);
+        cfgHandleCase(builder, bb_end, ast->case_default);
     }
 
-    cfgLinkLeaves(builder->leaf_cache,bb_switch,bb_end);
+    cfgLinkLeaves(builder->leaf_cache, bb_switch, bb_end);
     cfgBuilderClearLeafCache(builder);
 
-    bbSetNext(bb_switch,bb_end);
-    bbSetPrevPtr(bb_end,bb_switch);
+    bbSetNext(bb_switch, bb_end);
+    bbSetPrevPtr(bb_end, bb_switch);
 
-    cfgBuilderSetBlock(builder,bb_end);
+    cfgBuilderSetBlock(builder, bb_end);
     if (!prev_in_switch) {
         builder->flags &= ~(CFG_BUILDER_FLAG_IN_SWITCH);
-    } 
+    }
 }
 
-/* Top down through the tree finding blocks which are not pointing to anything */
+/* Top down through the tree finding blocks which are not pointing to anything
+ */
 static void cfgLinkLeaves(IntMap *map, BasicBlock *bb, BasicBlock *dest) {
-    if (!intMapHas(map,bb->block_no)) {
-        intMapAdd(map,bb->block_no,NULL);
+    if (!intMapHas(map, bb->block_no)) {
+        intMapAdd(map, bb->block_no, NULL);
         switch (bb->type) {
-            case BB_SWITCH:
-                for (int i = 0; i < bb->next_blocks->size; ++i) {
-                    cfgLinkLeaves(map,bb->next_blocks->entries[i],dest);
-                }
-                /* Fallthrough to set switches next pointer */ 
-            case BB_DO_WHILE_COND:
-            case BB_CASE:
-            case BB_CONTROL_BLOCK:
-                if      (bb == bb->next)   bbSetNext(bb,dest);
-                else if (bb->next == NULL) bbSetNext(bb,dest);
-                else if (bbAstCount(bb->next) == 0 && !bbIsLoopControl(bb->next)) bbSetNext(bb,dest);
-                else cfgLinkLeaves(map,bb->next,dest);
-                break;
+        case BB_SWITCH:
+            for (int i = 0; i < bb->next_blocks->size; ++i) {
+                cfgLinkLeaves(map, bb->next_blocks->entries[i], dest);
+            }
+            /* Fallthrough to set switches next pointer */
+        case BB_DO_WHILE_COND:
+        case BB_CASE:
+        case BB_CONTROL_BLOCK:
+            if (bb == bb->next)
+                bbSetNext(bb, dest);
+            else if (bb->next == NULL)
+                bbSetNext(bb, dest);
+            else if (bbAstCount(bb->next) == 0 && !bbIsLoopControl(bb->next))
+                bbSetNext(bb, dest);
+            else
+                cfgLinkLeaves(map, bb->next, dest);
+            break;
 
-            case BB_BRANCH_BLOCK:
-                cfgLinkLeaves(map,bb->_if,dest);
-                cfgLinkLeaves(map,bb->_else,dest);
-                break;
+        case BB_BRANCH_BLOCK:
+            cfgLinkLeaves(map, bb->_if, dest);
+            cfgLinkLeaves(map, bb->_else, dest);
+            break;
         }
     }
 }
 
 static BasicBlock *cfgMergeBranches(CFGBuilder *builder, BasicBlock *pre,
-        BasicBlock *post)
-{ 
+                                    BasicBlock *post) {
     IntMap *leaf_cache = builder->leaf_cache;
     BasicBlock *join = post;
     if (bbAstCount(post) > 0 && !bbIsLoopControl(post)) {
-        join = cfgBuilderAllocBasicBlock(builder,BB_CONTROL_BLOCK,0);
-        bbSetPrevPtr(join,post);
-        bbSetNext(post,join);
+        join = cfgBuilderAllocBasicBlock(builder, BB_CONTROL_BLOCK, 0);
+        bbSetPrevPtr(join, post);
+        bbSetNext(post, join);
     }
-    cfgLinkLeaves(leaf_cache,pre,join);
+    cfgLinkLeaves(leaf_cache, pre, join);
     cfgBuilderClearLeafCache(builder);
     return join;
 }
 
 /**
- * This function is crucial. It sets the type of block based on the AST. 
+ * This function is crucial. It sets the type of block based on the AST.
  * @DataFlow Jamesbarford 2024/08/28
- * TODO: This function should be the one responsible for converting the ast 
+ * TODO: This function should be the one responsible for converting the ast
  * into IR and adding what a block defines or modifies which will make liveness
  * analysis easier along with dataflow.
  * */
@@ -918,168 +946,187 @@ static void cfgHandleAstNode(CFGBuilder *builder, Ast *ast) {
     int kind = ast->kind;
     BasicBlock *bb = builder->bb;
 
-    /* We are only interested in the AST nodes that are the start of a new 
-     * basic block or a top level `I64 x = 10;` type declaration or assignment 
-     * 
+    /* We are only interested in the AST nodes that are the start of a new
+     * basic block or a top level `I64 x = 10;` type declaration or assignment
+     *
      * A new basic block will start with an `if`, `for`, `while`, `goto` */
     switch (kind) {
-        case AST_BREAK:         cfgHandleBreak(builder);        break;
-        case AST_COMPOUND_STMT: cfgHandleCompound(builder,ast); break;
-        case AST_CONTINUE:      cfgHandleContinue(builder);     break;
-        case AST_DO_WHILE: {
-            cfgHandleDoWhileLoop(builder,ast);
-            break;
+    case AST_BREAK:
+        cfgHandleBreak(builder);
+        break;
+    case AST_COMPOUND_STMT:
+        cfgHandleCompound(builder, ast);
+        break;
+    case AST_CONTINUE:
+        cfgHandleContinue(builder);
+        break;
+    case AST_DO_WHILE: {
+        cfgHandleDoWhileLoop(builder, ast);
+        break;
+    }
+
+    case AST_FOR: {
+        BasicBlock *pre = builder->bb;
+        cfgHandleForLoop(builder, ast);
+        /* this is the loop back */
+        if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
+            pre = pre->next;
         }
+        BasicBlock *post = builder->bb;
+        BasicBlock *join = cfgMergeBranches(builder, pre, post);
+        cfgBuilderSetBlock(builder, join);
+        break;
+    }
 
-        case AST_FOR: {
-            BasicBlock *pre = builder->bb;
-            cfgHandleForLoop(builder,ast);
-            /* this is the loop back */
-            if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
-                pre = pre->next;
-            }
-            BasicBlock *post = builder->bb;
-            BasicBlock *join = cfgMergeBranches(builder,pre,post);
-            cfgBuilderSetBlock(builder,join);
-            break;
+    case AST_WHILE: {
+        BasicBlock *pre = builder->bb;
+        cfgHandleWhileLoop(builder, ast);
+        BasicBlock *post = builder->bb;
+        if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
+            pre = pre->next;
         }
+        BasicBlock *join = cfgMergeBranches(builder, pre, post);
+        cfgBuilderSetBlock(builder, join);
+        break;
+    }
 
-        case AST_WHILE: {
-            BasicBlock *pre = builder->bb;
-            cfgHandleWhileLoop(builder,ast);
-            BasicBlock *post = builder->bb;
-            if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
-                pre = pre->next;
-            }
-            BasicBlock *join = cfgMergeBranches(builder,pre,post);
-            cfgBuilderSetBlock(builder,join);
-            break;
+    case AST_IF: {
+        BasicBlock *pre = builder->bb;
+        cgfHandleBranchBlock(builder, ast);
+        if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
+            pre = pre->next;
         }
+        BasicBlock *post = builder->bb;
+        BasicBlock *join = cfgMergeBranches(builder, pre, post);
+        cfgBuilderSetBlock(builder, join);
+        break;
+    }
 
-        case AST_IF: {
-            BasicBlock *pre = builder->bb;
-            cgfHandleBranchBlock(builder,ast);
-            BasicBlock *post;
-            if (!bbIsType(pre, BB_BRANCH_BLOCK)) {
-                pre = pre->next;
-            }
-            post = builder->bb;
-            BasicBlock *join = cfgMergeBranches(builder,pre,post);
-            cfgBuilderSetBlock(builder,join);
-            break;
-        }
+    case AST_SWITCH: {
+        cfgHandleSwitch(builder, ast);
+        break;
+    }
 
-        case AST_SWITCH: {
-            cfgHandleSwitch(builder,ast);
-            break;
-        }
+    case AST_GOTO:
+        cfgHandleGoto(builder, ast);
+        break;
+    case AST_LABEL:
+        cfgHandleLabel(builder, ast);
+        break;
+    case AST_RETURN:
+        cfgHandleReturn(builder, ast);
+        break;
+    case AST_JUMP:
+        cfgHandleGoto(builder, ast);
+        break;
 
-        case AST_GOTO:         cfgHandleGoto(builder,ast);   break;
-        case AST_LABEL:        cfgHandleLabel(builder,ast);  break;
-        case AST_RETURN:       cfgHandleReturn(builder,ast); break;
-        case AST_JUMP:         cfgHandleGoto(builder,ast);   break;
+    case AST_CASE: {
+        loggerPanic("Case should be handled by switch function\n");
+    }
 
-        case AST_CASE: {
-            loggerPanic("Case should be handled by switch function\n");
-        }
+    /* Should never hit this */
+    case AST_FUNC:
+        break;
 
-        /* Should never hit this */
-        case AST_FUNC: break;
-
-        case AST_ADDR:
-        case AST_ASM_FUNCDEF:
-        case AST_ASM_FUNC_BIND:
-        case AST_ASM_STMT:
-        case AST_CAST:
-        case AST_CLASS_REF:
-        case AST_DEFAULT_PARAM:
-        case AST_DEREF:
-        case AST_EXTERN_FUNC:
-        case AST_FUNPTR:
-        case AST_FUN_PROTO:
-        case AST_LITERAL:
-        case AST_OP_ADD:
-        case AST_PLACEHOLDER:
-        case AST_STRING:
-        case AST_VAR_ARGS:
-        case TK_PRE_PLUS_PLUS:
-        case TK_PLUS_PLUS:   
-        case TK_PRE_MINUS_MINUS:
-        case TK_MINUS_MINUS:
-        case AST_ARRAY_INIT:
-        case AST_ASM_FUNCALL:
-        case AST_FUNCALL:
-        case AST_FUNPTR_CALL:
-        case AST_LVAR:
-            ptrVecPush(bb->ast_array,ast);
-            break;
-        /* Start of a variable being alive (possibly?) */
-        case AST_DECL:
-        default:
-            /* Need to look at this for binary operators */
-            ptrVecPush(bb->ast_array,ast);
-            break;
+    case AST_ADDR:
+    case AST_ASM_FUNCDEF:
+    case AST_ASM_FUNC_BIND:
+    case AST_ASM_STMT:
+    case AST_CAST:
+    case AST_CLASS_REF:
+    case AST_DEFAULT_PARAM:
+    case AST_DEREF:
+    case AST_EXTERN_FUNC:
+    case AST_FUNPTR:
+    case AST_FUN_PROTO:
+    case AST_LITERAL:
+    case AST_OP_ADD:
+    case AST_PLACEHOLDER:
+    case AST_STRING:
+    case AST_VAR_ARGS:
+    case TK_PRE_PLUS_PLUS:
+    case TK_PLUS_PLUS:
+    case TK_PRE_MINUS_MINUS:
+    case TK_MINUS_MINUS:
+    case AST_ARRAY_INIT:
+    case AST_ASM_FUNCALL:
+    case AST_FUNCALL:
+    case AST_FUNPTR_CALL:
+    case AST_LVAR:
+        ptrVecPush(bb->ast_array, ast);
+        break;
+    /* Start of a variable being alive (possibly?) */
+    case AST_DECL:
+    default:
+        /* Need to look at this for binary operators */
+        ptrVecPush(bb->ast_array, ast);
+        break;
     }
 }
 
 /* Remove nodes from the ast array that are before the label */
-//static void cfgRemoveNodesBeforeLabel(BasicBlock *bb_dest, aoStr *goto_label) {
-//    int collect = 0;
-//    int new_size = 0;
-//    Ast *ast = bb_dest->ast_array->entries[0];
-//    /* If the first node in this block is the goto label we do not need 
-//     * to do anything */
-//    if (astIsLabelMatch(ast,goto_label)) return;
+// static void cfgRemoveNodesBeforeLabel(BasicBlock *bb_dest, aoStr *goto_label)
+// {
+//     int collect = 0;
+//     int new_size = 0;
+//     Ast *ast = bb_dest->ast_array->entries[0];
+//     /* If the first node in this block is the goto label we do not need
+//      * to do anything */
+//     if (astIsLabelMatch(ast,goto_label)) return;
 //
-//    for (int i = 1; i < bb_dest->ast_array->size; ++i) {
-//        ast = vecGet(Ast *,bb_dest->ast_array,i);
-//        if (collect) {
-//            bb_dest->ast_array->entries[new_size++] = ast;
-//        } else {
-//            if (astIsLabelMatch(ast,goto_label)) {
-//                /* Start adding nodes now that we have seen the label */
-//                collect = 1;
-//                bb_dest->ast_array->entries[new_size++] = ast;
-//            }
-//        }
-//    }
-//    /* The entries pointer array will have nodes from the previous array and 
-//     * possibly doubles, however we won't reach them as we truncate the vectors 
-//     * size */
-//    bb_dest->ast_array->size = new_size;
-//}
+//     for (int i = 1; i < bb_dest->ast_array->size; ++i) {
+//         ast = vecGet(Ast *,bb_dest->ast_array,i);
+//         if (collect) {
+//             bb_dest->ast_array->entries[new_size++] = ast;
+//         } else {
+//             if (astIsLabelMatch(ast,goto_label)) {
+//                 /* Start adding nodes now that we have seen the label */
+//                 collect = 1;
+//                 bb_dest->ast_array->entries[new_size++] = ast;
+//             }
+//         }
+//     }
+//     /* The entries pointer array will have nodes from the previous array and
+//      * possibly doubles, however we won't reach them as we truncate the
+//      vectors
+//      * size */
+//     bb_dest->ast_array->size = new_size;
+// }
 
-/* a lot of the code in this function is absolutely ridiculous, as 
+/* a lot of the code in this function is absolutely ridiculous, as
  * what you can do with goto is absolutely ridiculous */
 static void cfgRelocateGoto(CFGBuilder *builder, BasicBlock *bb_goto,
-        BasicBlock *bb_dest, aoStr *goto_label)
-{
+                            BasicBlock *bb_dest, const aoStr *goto_label) {
     /* Can happen... if the block we want to goto is itself */
     if (bb_goto == bb_dest) {
         return;
     }
 
-    BasicBlock *bb_prev = bb_goto->prev;
+    const BasicBlock *bb_prev = bb_goto->prev;
 
-    if (bbIsType(bb_dest,BB_LOOP_BLOCK) && !(bb_goto->flags & BB_FLAG_LOOP_JUMP)) {
+    if (bbIsType(bb_dest, BB_LOOP_BLOCK) &&
+        !(bb_goto->flags & BB_FLAG_LOOP_JUMP)) {
         if (bbIsType(bb_prev, BB_BRANCH_BLOCK)) {
-            if (bb_prev->_if == bb_goto) bb_goto->flags |= BB_FLAG_IF_BRANCH;
-            else                         bb_goto->flags |= BB_FLAG_ELSE_BRANCH;
+            if (bb_prev->_if == bb_goto)
+                bb_goto->flags |= BB_FLAG_IF_BRANCH;
+            else
+                bb_goto->flags |= BB_FLAG_ELSE_BRANCH;
         }
 
         PtrVec *dest_ast_array = bb_dest->ast_array;
         BasicBlock *loop_cond = bb_dest->prev;
-        BasicBlock *loop_back = cfgBuilderAllocBasicBlock(builder,BB_LOOP_BLOCK,0);
+        BasicBlock *loop_back = cfgBuilderAllocBasicBlock(builder,
+                                                          BB_LOOP_BLOCK, 0);
 
         Ast *asts_to_move[100];
         int ast_move_cnt = 0;
 
-        /* We need to get the statements that happened before the 
+        /* We need to get the statements that happened before the
          * label */
         for (int i = 0; i < dest_ast_array->size; ++i) {
             Ast *needle = dest_ast_array->entries[i];
-            if (needle->kind == AST_LABEL && aoStrCmp(goto_label,
-                        astHackedGetLabel(needle))) {
+            if (needle->kind == AST_LABEL &&
+                aoStrCmp(goto_label, astHackedGetLabel(needle))) {
                 break;
             } else {
                 asts_to_move[ast_move_cnt++] = needle;
@@ -1088,7 +1135,7 @@ static void cfgRelocateGoto(CFGBuilder *builder, BasicBlock *bb_goto,
 
         /* Add asts from the loop_cond */
         for (int i = 0; i < ast_move_cnt; ++i) {
-            ptrVecPush(loop_back->ast_array,asts_to_move[i]);
+            ptrVecPush(loop_back->ast_array, asts_to_move[i]);
         }
 
         /* resize the array */
@@ -1096,63 +1143,67 @@ static void cfgRelocateGoto(CFGBuilder *builder, BasicBlock *bb_goto,
 
         /* Remove asts that no longer exist in the block */
         for (int i = 0; i < dest_ast_array->size; ++i) {
-            dest_ast_array->entries[i] = dest_ast_array->entries[ast_move_cnt+i];
+            dest_ast_array->entries[i] =
+                    dest_ast_array->entries[ast_move_cnt + i];
         }
 
-
         /* Obvious, the goto has to point to it's destination */
-        bbSetNext(bb_goto,bb_dest);
+        bbSetNext(bb_goto, bb_dest);
 
-        /* Destination, whatever it might be, is the loop head 
+        /* Destination, whatever it might be, is the loop head
          * @Test - how does this work if we jump into an if branch?*/
-        bbSetNext(bb_dest,loop_cond);
-        bbSetPrevPtr(bb_dest,bb_goto);
+        bbSetNext(bb_dest, loop_cond);
+        bbSetPrevPtr(bb_dest, bb_goto);
         bb_dest->flags = BB_FLAG_LOOP_HEAD;
-        bbSetType(bb_dest,BB_CONTROL_BLOCK);
+        bbSetType(bb_dest, BB_CONTROL_BLOCK);
 
-        bbSetPrevPtr(loop_back,bb_dest);
+        bbSetPrevPtr(loop_back, bb_dest);
 
         /* the loop condition is now after the goto's destination */
         loop_cond->_if = loop_back;
         bbSetLoopEnd(loop_cond->_else);
-        bbSetType(loop_cond,BB_BRANCH_BLOCK);
+        bbSetType(loop_cond, BB_BRANCH_BLOCK);
         loop_cond->flags = 0;
 
-        bbAddPrev(loop_back,loop_cond);
-        bbAddPrev(loop_back,bb_dest);
-        bbAddPrev(bb_dest,loop_back);
-    } else if (bbIsType(bb_goto,BB_LOOP_BLOCK)) {
+        bbAddPrev(loop_back, loop_cond);
+        bbAddPrev(loop_back, bb_dest);
+        bbAddPrev(bb_dest, loop_back);
+    } else if (bbIsType(bb_goto, BB_LOOP_BLOCK)) {
         BasicBlock *bb_loop_head = bb_goto->prev;
-        bbAddPrev(bb_dest,bb_goto);
-        bbSetType(bb_goto,BB_CONTROL_BLOCK);
-        bbSetNext(bb_goto,bb_dest);
+        bbAddPrev(bb_dest, bb_goto);
+        bbSetType(bb_goto, BB_CONTROL_BLOCK);
+        bbSetNext(bb_goto, bb_dest);
         bb_goto->flags &= ~(BB_FLAG_LOOP_END);
         bb_loop_head->flags &= ~(BB_FLAG_LOOP_HEAD);
         bb_loop_head->_else->flags &= ~(BB_FLAG_LOOP_END);
     } else {
-        bbAddPrev(bb_dest,bb_goto);
+        bbAddPrev(bb_dest, bb_goto);
 
         /* Making a backwards goto loop */
-        if (bb_goto->flags & BB_FLAG_GOTO_LOOP) bbSetPrevPtr(bb_goto,bb_dest);
-        else                                    bbSetNext(bb_goto,bb_dest);
+        if (bb_goto->flags & BB_FLAG_GOTO_LOOP)
+            bbSetPrevPtr(bb_goto, bb_dest);
+        else
+            bbSetNext(bb_goto, bb_dest);
 
         /* We don't want to destroy the loop */
-        if (!bbIsType(bb_dest,BB_LOOP_BLOCK) &&
-                !(bb_dest->flags & BB_FLAG_GOTO_LOOP)) {
-            bbSetPrevPtr(bb_dest,bb_goto);
+        if (!bbIsType(bb_dest, BB_LOOP_BLOCK) &&
+            !(bb_dest->flags & BB_FLAG_GOTO_LOOP)) {
+            bbSetPrevPtr(bb_dest, bb_goto);
         }
     }
 }
 
 static void cfgAdjacencyPrintBlock(BasicBlock *bb, int is_parent) {
-    char *bb_string = bbToJSON(bb);
-    if (is_parent) printf("%s\n",bb_string);
-    else           printf("child %s\n",bb_string);
+    const char *bb_string = bbToJSON(bb);
+    if (is_parent)
+        printf("%s\n", bb_string);
+    else
+        printf("child %s\n", bb_string);
 }
 
-BasicBlock *cfgVecFindBlock(PtrVec *vec, int block_no, int *_idx) {
+BasicBlock *cfgVecFindBlock(const PtrVec *vec, int block_no, int *_idx) {
     for (int i = 0; i < vec->size; ++i) {
-        BasicBlock *bb = vecGet(BasicBlock *,vec,i);
+        BasicBlock *bb = vecGet(BasicBlock *, vec, i);
         if (bb->block_no == block_no) {
             *_idx = i;
             return bb;
@@ -1162,22 +1213,22 @@ BasicBlock *cfgVecFindBlock(PtrVec *vec, int block_no, int *_idx) {
     return NULL;
 }
 
-void cfgAdjacencyListPrint(CFG *cfg) {
+void cfgAdjacencyListPrint(const CFG *cfg) {
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
-    IntSetIterator *set_iter;
-    long block_no;
 
     while ((entry = intMapNext(it)) != NULL) {
         BasicBlock *parent = (BasicBlock *)entry->value;
-        IntSet *iset = (IntSet *)intMapGet(cfg->graph,entry->key);
+        IntSet *iset = (IntSet *)intMapGet(cfg->graph, entry->key);
+        long block_no;
 
-        cfgAdjacencyPrintBlock(parent,1);
+        cfgAdjacencyPrintBlock(parent, 1);
 
-        set_iter = intSetIteratorNew(iset);
+        IntSetIterator *set_iter = intSetIteratorNew(iset);
         while ((block_no = intSetNext(set_iter)) != HT_DELETED) {
-            BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,block_no);
-            cfgAdjacencyPrintBlock(bb,0);
+            BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,
+                                                     block_no);
+            cfgAdjacencyPrintBlock(bb, 0);
         }
         printf("====\n");
         intSetIteratorRelease(set_iter);
@@ -1186,246 +1237,249 @@ void cfgAdjacencyListPrint(CFG *cfg) {
 }
 
 /* Print the Adjacency list graph representation */
-void cfgAdjacencyListPrintShallow(CFG *cfg) {
+void cfgAdjacencyListPrintShallow(const CFG *cfg) {
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
 
     while ((entry = intMapNext(it)) != NULL) {
         BasicBlock *bb = (BasicBlock *)entry->value;
-        char *bb_string = bbToJSON(bb);
-        printf("%s\n====\n",bb_string);
+        const char *bb_string = bbToJSON(bb);
+        printf("%s\n====\n", bb_string);
     }
     intMapIteratorRelease(it);
 }
 
-aoStr *cdfAdjacencyListToJSON(CFG *cfg) {
+aoStr *cdfAdjacencyListToJSON(const CFG *cfg) {
     aoStr *json = aoStrNew();
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
 
     aoStrCatPrintf(json, "{\n");
     while ((entry = intMapNext(it)) != NULL) {
-        BasicBlock *parent = (BasicBlock *)entry->value;
-        IntSet *iset = (IntSet *)intMapGet(cfg->graph,entry->key);
+        const BasicBlock *parent = (BasicBlock *)entry->value;
+        IntSet *iset = (IntSet *)intMapGet(cfg->graph, entry->key);
 
         aoStrCatPrintf(json, "    %d: [", parent->block_no);
         IntSetIterator *set_iter = intSetIteratorNew(iset);
         long block_no;
         while ((block_no = intSetNext(set_iter)) != HT_DELETED) {
-            BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,block_no);
-            aoStrCatPrintf(json,"%d",bb->block_no);
+            BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,
+                                                     block_no);
+            aoStrCatPrintf(json, "%d", bb->block_no);
             if (set_iter->idx + 1 != iset->size) {
-                aoStrCat(json,", ");
+                aoStrCat(json, ", ");
             }
         }
         intSetIteratorRelease(set_iter);
-        aoStrCat(json,"]");
+        aoStrCat(json, "]");
 
         if (it->idx + 1 != it->map->size) {
-            aoStrCat(json,",");
+            aoStrCat(json, ",");
         }
-        aoStrPutChar(json,'\n');
+        aoStrPutChar(json, '\n');
     }
-    aoStrPutChar(json,'}');
+    aoStrPutChar(json, '}');
 
     intMapIteratorRelease(it);
     return json;
 }
 
-int cfgRelinkVector(IntMap *map, BasicBlock *parent, BasicBlock *child,
-        BasicBlock *bb)
-{
-    IntSet *iset = intMapGet(map,parent->block_no);
+int cfgRelinkVector(const IntMap *map, const BasicBlock *parent,
+                    BasicBlock *child, BasicBlock *bb) {
+    IntSet *iset = intMapGet(map, parent->block_no);
     loggerWarning("Vector relinking. Parent bb%d, child bb%d, block: bb%d\n",
-            parent->block_no, child->block_no, bb->block_no);
+                  parent->block_no, child->block_no, bb->block_no);
     if (iset) {
-        intSetRemove(iset,bb->block_no);
-        intSetAdd(iset,child->block_no);
+        intSetRemove(iset, bb->block_no);
+        intSetAdd(iset, child->block_no);
         /* @Bug - this is close but not quite working when creating strings.HC
          * CFG */
         child->flags |= bb->flags;
         if (bbAstCount(bb) == 0) {
-            bbSetType(bb,BB_GARBAGE);
+            bbSetType(bb, BB_GARBAGE);
         }
         return 1;
     }
-    loggerWarning("fail 2 relink: %d\n",bb->block_no);
-    bbSetType(bb,BB_GARBAGE);
+    loggerWarning("fail 2 relink: %d\n", bb->block_no);
+    bbSetType(bb, BB_GARBAGE);
     return 0;
 }
 
 /* Returns the parent */
-BasicBlock *bbRelinkControl(IntMap *map, BasicBlock *bb) {
-     /* @Bug
-      * What if the map has had deletions? */
-    BasicBlock *parent = intMapGetAt(bb->prev_blocks,0);
+BasicBlock *bbRelinkControl(const IntMap *map, BasicBlock *bb) {
+    /* @Bug
+     * What if the map has had deletions? */
+    BasicBlock *parent = intMapGetAt(bb->prev_blocks, 0);
     BasicBlock *child = bb->next;
 
-    if (bbIsType(child,BB_CONTROL_BLOCK) && bbIsType(bb,BB_CONTROL_BLOCK)) {
+    if (bbIsType(child, BB_CONTROL_BLOCK) && bbIsType(bb, BB_CONTROL_BLOCK)) {
         if (child->flags & BB_FLAG_CASE_OWNED) {
-            if (bbAstCount(child) == 0 && child->next && bbAstCount(child->next) > 0) {
+            if (bbAstCount(child) == 0 && child->next &&
+                bbAstCount(child->next) > 0) {
                 child = child->next;
             }
         }
     }
 
     switch (parent->type) {
-        case BB_CONTROL_BLOCK: {
-            bbSetNext(parent,child);
-            bbSetPrevPtr(child,parent);
-            bbSetType(bb,BB_GARBAGE);
-            break;
-        }
+    case BB_CONTROL_BLOCK: {
+        bbSetNext(parent, child);
+        bbSetPrevPtr(child, parent);
+        bbSetType(bb, BB_GARBAGE);
+        break;
+    }
 
-        case BB_BRANCH_BLOCK: {
-            if (parent->_if == bb) {
-                bbSetIf(parent,child);
-                bbAddPrev(child,parent->_if);
-            } else if (parent->_else == bb) {
-                bbSetElse(parent,child);
-                if (bb == child) {
-                    bbSetType(bb,BB_END_BLOCK);
-                    bbSetNext(bb,NULL);
-                    return bb;
-                }
-            } else {
-                loggerPanic("Could neither relink if or else branch");
-                return NULL;
+    case BB_BRANCH_BLOCK: {
+        if (parent->_if == bb) {
+            bbSetIf(parent, child);
+            bbAddPrev(child, parent->_if);
+        } else if (parent->_else == bb) {
+            bbSetElse(parent, child);
+            if (bb == child) {
+                bbSetType(bb, BB_END_BLOCK);
+                bbSetNext(bb, NULL);
+                return bb;
             }
-            bbAddPrev(child,parent);
-            break;
+        } else {
+            loggerPanic("Could neither relink if or else branch");
+            return NULL;
         }
-        default:
-            loggerPanic("Could not handle parent bb:%d of type = %s\n",
+        bbAddPrev(child, parent);
+        break;
+    }
+    default:
+        loggerPanic("Could not handle parent bb:%d of type = %s\n",
                     parent->block_no, bbTypeToString(parent->type));
     }
-    cfgRelinkVector(map,parent,child,bb);
+    cfgRelinkVector(map, parent, child, bb);
     return child;
 }
 
 /* Remove the basic block from:
- * - The block number to block hashtable 
+ * - The block number to block hashtable
  * - All sets with the node as a previous
  */
-void cfgDeleteBasicBlock(CFG *cfg, BasicBlock *bb_del) {
+void cfgDeleteBasicBlock(const CFG *cfg, BasicBlock *bb_del) {
     IntMapIterator *it = intMapIteratorNew(cfg->graph);
     IntMapNode *entry;
-    bbSetType(bb_del,BB_GARBAGE);
+    bbSetType(bb_del, BB_GARBAGE);
     while ((entry = intMapNext(it)) != NULL) {
-        if (entry->key == bb_del->block_no) continue;
+        if (entry->key == bb_del->block_no)
+            continue;
         IntSet *bb_connections = (IntSet *)entry->value;
-        BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,entry->key);
+        const BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,
+                                                       entry->key);
         /* Remove node as a previous link */
-        intMapDelete(bb->prev_blocks,bb->block_no);
+        intMapDelete(bb->prev_blocks, bb->block_no);
         /* Remove this node as a connection */
-        intSetRemove(bb_connections,bb_del->block_no);
+        intSetRemove(bb_connections, bb_del->block_no);
     }
     /* Remove node from both lookup tables */
-    intMapDelete(cfg->graph,bb_del->block_no);
-    intMapDelete(cfg->no_to_block,bb_del->block_no);
+    intMapDelete(cfg->graph, bb_del->block_no);
+    intMapDelete(cfg->no_to_block, bb_del->block_no);
 }
 
-/* For when the next pointer of a switch is a dead end, the most likely 
- * cause of this is that it is nested in a conditional branch and does not 
+/* For when the next pointer of a switch is a dead end, the most likely
+ * cause of this is that it is nested in a conditional branch and does not
  * point to the node beyond the branch. */
-static void cfgRelinkSwitch(CFG *cfg, BasicBlock *bb_switch) {
+static void cfgRelinkSwitch(const CFG *cfg, BasicBlock *bb_switch) {
     BasicBlock *dest = NULL;
     BasicBlock *bb_end = bb_switch->next;
 
-    if (bb_switch->flags & (BB_FLAG_IF_BRANCH|BB_FLAG_ELSE_BRANCH)) {
-        BasicBlock *cond = bb_switch->prev;
-        bbSetType(bb_end,BB_GARBAGE);
+    if (bb_switch->flags & (BB_FLAG_IF_BRANCH | BB_FLAG_ELSE_BRANCH)) {
+        const BasicBlock *cond = bb_switch->prev;
+        bbSetType(bb_end, BB_GARBAGE);
         if (cond->flags & BB_FLAG_HAD_NO_ELSE) {
             dest = cond->_else;
         } else {
             dest = cond->next;
         }
         IntMap *cache = intMapNew(32);
-        PtrVec *blocks = bb_switch->next_blocks;
-        /* Recurse through the graph linking all leaf nodes to the destination 
+        const PtrVec *blocks = bb_switch->next_blocks;
+        /* Recurse through the graph linking all leaf nodes to the destination
          * node, this is fairly expensive. */
         for (int i = 0; i < blocks->size; ++i) {
-            BasicBlock *bb_case = vecGet(BasicBlock *,blocks,i);
-            cfgLinkLeaves(cache,bb_case,dest);
+            BasicBlock *bb_case = vecGet(BasicBlock *, blocks, i);
+            cfgLinkLeaves(cache, bb_case, dest);
         }
         intMapRelease(cache);
-        bbSetNext(bb_switch,dest);
-        cfgDeleteBasicBlock(cfg,bb_end);
+        bbSetNext(bb_switch, dest);
+        cfgDeleteBasicBlock(cfg, bb_end);
     } else {
         /* legitimately the switch does not have anything after it */
-        bbSetType(bb_end,BB_END_BLOCK);
+        bbSetType(bb_end, BB_END_BLOCK);
     }
 }
 
-static IntSet *cfgCreateSwitchAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateSwitchAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     IntSet *iset = intSetNew(16);
     for (int i = 0; i < bb->next_blocks->size; ++i) {
-        BasicBlock *bb_case = (BasicBlock *)bb->next_blocks->entries[i];
-        intSetAdd(iset,bb_case->block_no);
-        bbAddPrev(bb_case,bb);
+        const BasicBlock *bb_case = (BasicBlock *)bb->next_blocks->entries[i];
+        intSetAdd(iset, bb_case->block_no);
+        bbAddPrev(bb_case, bb);
     }
 
-    if (bbIsType(bb->next,BB_CONTROL_BLOCK) && bbAstCount(bb->next) == 0) {
-        cfgRelinkSwitch(cfg,bb);
+    if (bbIsType(bb->next, BB_CONTROL_BLOCK) && bbAstCount(bb->next) == 0) {
+        cfgRelinkSwitch(cfg, bb);
     } else {
-        intSetAdd(iset,bb->next->block_no);
-        bbAddPrev(bb->next,bb);
+        intSetAdd(iset, bb->next->block_no);
+        bbAddPrev(bb->next, bb);
     }
     return iset;
 }
 
 /* This is a check for an orphaned node */
-static IntSet *cfgCreateControlAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateControlAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     /* @Bug
-     * This is where a return block is the next, potentially there 
+     * This is where a return block is the next, potentially there
      * is not next either */
     if (!bb->prev) {
-        bbSetType(bb,BB_GARBAGE);
+        bbSetType(bb, BB_GARBAGE);
         return NULL;
     }
 
-    /* @Bug 
+    /* @Bug
      * This happens with a case */
-    if (bb->prev_blocks->size == 0 && bbAstCount(bb) == 0 && 
-            (bb->flags & (BB_FLAG_CASE_BREAK|BB_FLAG_CASE_OWNED))) 
-    {
-        bbSetType(bb,BB_GARBAGE);
+    if (bb->prev_blocks->size == 0 && bbAstCount(bb) == 0 &&
+        (bb->flags & (BB_FLAG_CASE_BREAK | BB_FLAG_CASE_OWNED))) {
+        bbSetType(bb, BB_GARBAGE);
         return NULL;
     }
 
-    if (!(bb->flags & BB_FLAG_CASE_OWNED) && (bbAstCount(bb) == 0 || bb->next == NULL)) {
+    if (!(bb->flags & BB_FLAG_CASE_OWNED) &&
+        (bbAstCount(bb) == 0 || bb->next == NULL)) {
         if (bbAstCount(bb) > 0) {
-            bbSetType(bb,BB_END_BLOCK);
+            bbSetType(bb, BB_END_BLOCK);
         } else {
             if (bb->next) {
-                loggerWarning("GARBAGE: bb%d\n",bb->block_no);
-                bbRelinkControl(cfg->graph,bb);
+                loggerWarning("GARBAGE: bb%d\n", bb->block_no);
+                bbRelinkControl(cfg->graph, bb);
                 if (bbIsType(bb, BB_GARBAGE)) {
-                    cfgDeleteBasicBlock(cfg,bb);
+                    cfgDeleteBasicBlock(cfg, bb);
                     return NULL;
                 }
             } else {
                 if (bb->prev && bbIsType(bb->prev, BB_SWITCH)) {
-                    bbSetType(bb,BB_END_BLOCK);
+                    bbSetType(bb, BB_END_BLOCK);
                     IntSet *iset = intSetNew(8);
                     return iset;
                 } else {
-                    bbSetType(bb,BB_GARBAGE);
+                    bbSetType(bb, BB_GARBAGE);
                     return NULL;
                 }
             }
         }
     } else if (bb->next == bb) {
         IntSet *iset = intSetNew(8);
-        intSetAdd(iset,bb->next->block_no);
-        bbSetType(bb,BB_END_BLOCK);
-        bbSetNext(bb,NULL);
+        intSetAdd(iset, bb->next->block_no);
+        bbSetType(bb, BB_END_BLOCK);
+        bbSetNext(bb, NULL);
         return iset;
     }
     if (!bbIsType(bb, BB_END_BLOCK)) {
         IntSet *iset = intSetNew(8);
-        intSetAdd(iset,bb->next->block_no);
-        bbAddPrev(bb->next,bb);
+        intSetAdd(iset, bb->next->block_no);
+        bbAddPrev(bb->next, bb);
         return iset;
     } else {
         IntSet *iset = intSetNew(8);
@@ -1433,82 +1487,82 @@ static IntSet *cfgCreateControlAdjacencyList(CFG *cfg, BasicBlock *bb) {
     }
 }
 
-static IntSet *cfgCreateGotoAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateGotoAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     (void)cfg;
     IntSet *iset = intSetNew(8);
     if (bb->flags & BB_FLAG_GOTO_LOOP) {
-        intSetAdd(iset,bb->prev->block_no);
-        bbAddPrev(bb->prev,bb);
+        intSetAdd(iset, bb->prev->block_no);
+        bbAddPrev(bb->prev, bb);
     } else {
-        intSetAdd(iset,bb->next->block_no);
-        bbAddPrev(bb->next,bb);
+        intSetAdd(iset, bb->next->block_no);
+        bbAddPrev(bb->next, bb);
     }
     return iset;
 }
 
-static IntSet *cfgCreateBranchAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateBranchAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     (void)cfg;
     IntSet *iset = intSetNew(8);
-    intSetAdd(iset,bb->_if->block_no);
-    intSetAdd(iset,bb->_else->block_no);
-    bbAddPrev(bb->_if,bb);
-    bbAddPrev(bb->_else,bb);
+    intSetAdd(iset, bb->_if->block_no);
+    intSetAdd(iset, bb->_else->block_no);
+    bbAddPrev(bb->_if, bb);
+    bbAddPrev(bb->_else, bb);
     return iset;
 }
 
-static IntSet *cfgCreateContinueAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateContinueAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     (void)cfg;
     IntSet *iset = intSetNew(8);
-    BasicBlock *loop_head = bb->prev;
+    const BasicBlock *loop_head = bb->prev;
 
     assert(bb->prev != NULL);
 
-    intSetAdd(iset,bb->prev->block_no);
-    bbAddPrev(loop_head,bb);
+    intSetAdd(iset, bb->prev->block_no);
+    bbAddPrev(loop_head, bb);
 
     if (bb->next) {
-        bbRemovePrev(bb->next,bb->block_no);
-        bbSetNext(bb,NULL);
+        bbRemovePrev(bb->next, bb->block_no);
+        bbSetNext(bb, NULL);
     }
 
-    if (loop_head->flags & (BB_FLAG_FOR_LOOP|BB_FLAG_FOR_LOOP_HAS_STEP)) {
-        BasicBlock *loop_block = loop_head->next;
+    if (loop_head->flags & (BB_FLAG_FOR_LOOP | BB_FLAG_FOR_LOOP_HAS_STEP)) {
+        const BasicBlock *loop_block = loop_head->next;
         /* this push to the bb->ast_array is ok*/
-        ptrVecPush(bb->ast_array,vecTail(Ast *,loop_block->ast_array));
+        ptrVecPush(bb->ast_array, vecTail(Ast *, loop_block->ast_array));
     }
     return iset;
 }
 
-static IntSet *cfgCreateLoopAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateLoopAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     (void)cfg;
     IntSet *iset = intSetNew(8);
-    BasicBlock *loop_head = bb->prev;
-    intSetAdd(iset,loop_head->block_no);
-    bbAddPrev(loop_head,bb);
+    const BasicBlock *loop_head = bb->prev;
+    intSetAdd(iset, loop_head->block_no);
+    bbAddPrev(loop_head, bb);
     return iset;
 }
 
-static IntSet *cfgCreateDoWhileAdjacencyList(CFG *cfg, BasicBlock *bb) {
+static IntSet *cfgCreateDoWhileAdjacencyList(const CFG *cfg, BasicBlock *bb) {
     (void)cfg;
     IntSet *iset = intSetNew(16);
-    BasicBlock *loop_head = bb->prev;
-    bbAddPrev(loop_head,bb);
+    const BasicBlock *loop_head = bb->prev;
+    bbAddPrev(loop_head, bb);
     if (bb->next) {
-        bbAddPrev(bb->next,bb);
+        bbAddPrev(bb->next, bb);
     }
-    intSetAdd(iset,loop_head->block_no);
+    intSetAdd(iset, loop_head->block_no);
     return iset;
 }
 
 /**
- * This is for creating a very compact control flow graph that feels more like 
- * a classical datascructure than the basic block node graph. It's significantly 
+ * This is for creating a very compact control flow graph that feels more like
+ * a classical datascructure than the basic block node graph. It's significantly
  * faster to traverse and also easier to reason with.
  *
- * This also fixes orphaned nodes, so is acting like a final check before 
+ * This also fixes orphaned nodes, so is acting like a final check before
  * handing off to the next step.
  * */
-void cfgBuildAdjacencyList(CFG *cfg) {
+void cfgBuildAdjacencyList(const CFG *cfg) {
     IntSet *iset;
     MemPoolIterator *it = memPoolIteratorNew(cfg->_memory);
     BasicBlock *bb;
@@ -1519,111 +1573,113 @@ void cfgBuildAdjacencyList(CFG *cfg) {
 
         /* The order of _if _else and prev/next is of PARAMOUNT importance */
         switch (bb->type) {
-            case BB_BREAK_BLOCK:
-            case BB_HEAD_BLOCK:
-            case BB_CASE:
-                iset = intSetNew(16);
-                intSetAdd(iset,bb->next->block_no);
-                bbAddPrev(bb->next,bb);
-                break;
-            case BB_RETURN_BLOCK:
-            case BB_END_BLOCK:
-                iset = intSetNew(8);
-                break;
-            case BB_CONTROL_BLOCK:
-                iset = cfgCreateControlAdjacencyList(cfg,bb);
-                if (!iset) continue;
-                break;
-            case BB_GOTO:
-                iset = cfgCreateGotoAdjacencyList(cfg,bb); 
-                break;
-            case BB_BRANCH_BLOCK:
-                iset = cfgCreateBranchAdjacencyList(cfg,bb);
-                break;
-            case BB_SWITCH:
-                iset = cfgCreateSwitchAdjacencyList(cfg,bb);
-                break;
-            case BB_CONTINUE:
-                iset = cfgCreateContinueAdjacencyList(cfg,bb);
-                break;
-            case BB_LOOP_BLOCK:
-                iset = cfgCreateLoopAdjacencyList(cfg,bb);
-                break;
-            case BB_DO_WHILE_COND:
-                iset = cfgCreateDoWhileAdjacencyList(cfg,bb);
-                break;
+        case BB_BREAK_BLOCK:
+        case BB_HEAD_BLOCK:
+        case BB_CASE:
+            iset = intSetNew(16);
+            intSetAdd(iset, bb->next->block_no);
+            bbAddPrev(bb->next, bb);
+            break;
+        case BB_RETURN_BLOCK:
+        case BB_END_BLOCK:
+            iset = intSetNew(8);
+            break;
+        case BB_CONTROL_BLOCK:
+            iset = cfgCreateControlAdjacencyList(cfg, bb);
+            if (!iset)
+                continue;
+            break;
+        case BB_GOTO:
+            iset = cfgCreateGotoAdjacencyList(cfg, bb);
+            break;
+        case BB_BRANCH_BLOCK:
+            iset = cfgCreateBranchAdjacencyList(cfg, bb);
+            break;
+        case BB_SWITCH:
+            iset = cfgCreateSwitchAdjacencyList(cfg, bb);
+            break;
+        case BB_CONTINUE:
+            iset = cfgCreateContinueAdjacencyList(cfg, bb);
+            break;
+        case BB_LOOP_BLOCK:
+            iset = cfgCreateLoopAdjacencyList(cfg, bb);
+            break;
+        case BB_DO_WHILE_COND:
+            iset = cfgCreateDoWhileAdjacencyList(cfg, bb);
+            break;
 
-            default:
-                loggerPanic("Unhandled type: %s\n", bbTypeToString(bb->type));
+        default:
+            loggerPanic("Unhandled type: %s\n", bbTypeToString(bb->type));
         }
-        intMapAdd(cfg->no_to_block,bb->block_no,bb);
-        intMapAdd(cfg->graph,bb->block_no,iset);
+        intMapAdd(cfg->no_to_block, bb->block_no, bb);
+        intMapAdd(cfg->graph, bb->block_no, iset);
     }
     memPoolIteratorRelease(it);
 }
 
-/* Given a parent with no code paths to the node remove the node from all of 
+/* Given a parent with no code paths to the node remove the node from all of
  * it's child nodes */
-void cfgRemoveNodeFromChild(BasicBlock *parent) {
+void cfgRemoveNodeFromChild(const BasicBlock *parent) {
     switch (parent->type) {
-        case BB_GARBAGE:
-        case BB_END_BLOCK:
-        case BB_HEAD_BLOCK:
-        case BB_RETURN_BLOCK:
-            break;
+    case BB_GARBAGE:
+    case BB_END_BLOCK:
+    case BB_HEAD_BLOCK:
+    case BB_RETURN_BLOCK:
+        break;
 
-        case BB_CONTROL_BLOCK: {
-            bbRemovePrev(parent->next,parent->block_no);
-            break;
+    case BB_CONTROL_BLOCK: {
+        bbRemovePrev(parent->next, parent->block_no);
+        break;
+    }
+
+    case BB_BRANCH_BLOCK:
+        bbRemovePrev(parent->_if, parent->block_no);
+        bbRemovePrev(parent->_else, parent->block_no);
+        break;
+
+    case BB_LOOP_BLOCK:
+        bbRemovePrev(parent->prev, parent->block_no);
+        break;
+
+    case BB_BREAK_BLOCK:
+        bbRemovePrev(parent->next, parent->block_no);
+        break;
+
+    case BB_DO_WHILE_COND:
+        bbRemovePrev(parent->prev, parent->block_no);
+        if (parent->next) {
+            bbRemovePrev(parent->next, parent->block_no);
         }
+        break;
 
-        case BB_BRANCH_BLOCK:
-            bbRemovePrev(parent->_if,parent->block_no);
-            bbRemovePrev(parent->_else,parent->block_no);
-            break;
+    case BB_GOTO:
+        if (parent->flags & (BB_FLAG_GOTO_LOOP)) {
+            bbRemovePrev(parent->prev, parent->block_no);
+        } else {
+            bbRemovePrev(parent->next, parent->block_no);
+        }
+        break;
 
-        case BB_LOOP_BLOCK:
-            bbRemovePrev(parent->prev,parent->block_no);
-            break;
+    case BB_SWITCH:
+        /* We're nuking the thing after the switch */
+        bbRemovePrev(parent->next, parent->block_no);
+        break;
 
-        case BB_BREAK_BLOCK:
-            bbRemovePrev(parent->next,parent->block_no);
-            break;
+    case BB_CASE:
+        loggerPanic("Cannot have an orphaned case\n");
+        break;
 
-        case BB_DO_WHILE_COND:
-            bbRemovePrev(parent->prev,parent->block_no);
-            if (parent->next) {
-                bbRemovePrev(parent->next,parent->block_no);
-            }
-            break;
-
-        case BB_GOTO:
-            if (parent->flags & (BB_FLAG_GOTO_LOOP)) {
-                bbRemovePrev(parent->prev,parent->block_no);
-            } else {
-                bbRemovePrev(parent->next,parent->block_no);
-            }
-            break;
-
-        case BB_SWITCH:
-            /* We're nuking the thing after the switch */
-            bbRemovePrev(parent->next,parent->block_no);
-            break;
-
-        case BB_CASE:
-            loggerPanic("Cannot have an orphaned case\n");
-            break;
-
-        case BB_CONTINUE:
-            loggerWarning("Continue nuked\n");
-            bbRemovePrev(parent->prev,parent->block_no);
-            break;
+    case BB_CONTINUE:
+        loggerWarning("Continue nuked\n");
+        bbRemovePrev(parent->prev, parent->block_no);
+        break;
+    default:;
     }
 }
 
-/* BFS flagging nodes as deleted and removing from their childrens previous 
+/* BFS flagging nodes as deleted and removing from their childrens previous
  * array */
-void cfgRemoveUnreachableNodes(CFG *cfg) {
+void cfgRemoveUnreachableNodes(const CFG *cfg) {
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
     int ids[64];
@@ -1632,20 +1688,20 @@ void cfgRemoveUnreachableNodes(CFG *cfg) {
     while ((entry = intMapNext(it)) != NULL) {
         BasicBlock *bb = (BasicBlock *)entry->value;
         if (!bbIsType(bb, BB_HEAD_BLOCK) && bbPrevCnt(bb) == 0) {
-            /* Node can be deleted and we need to nuke all paths from it, 
+            /* Node can be deleted and we need to nuke all paths from it,
              * deleting nodes if their previous contained only this node */
             ids[id_cnt++] = bb->block_no;
             loggerWarning("Unreachable: %s\n", bbToString(bb));
             cfgRemoveNodeFromChild(bb);
-            bbSetType(bb,BB_GARBAGE);
+            bbSetType(bb, BB_GARBAGE);
         }
     }
     intMapIteratorRelease(it);
 
     for (int i = 0; i < id_cnt; ++i) {
         int block_no = ids[i];
-        intMapDelete(cfg->graph,block_no);
-        intMapDelete(cfg->no_to_block,block_no);
+        intMapDelete(cfg->graph, block_no);
+        intMapDelete(cfg->no_to_block, block_no);
     }
 }
 
@@ -1654,17 +1710,17 @@ static void cfgConstructFunction(CFGBuilder *builder, List *stmts) {
     if (!listEmpty(stmts)) {
         builder->ast_list = stmts;
         listForEach(stmts) {
-            Ast *ast = cast(Ast *,it->value);
+            Ast *ast = cast(Ast *, it->value);
             builder->ast_iter = it;
-            cfgHandleAstNode(builder,ast);
+            cfgHandleAstNode(builder, ast);
         }
     }
 
     /* Reconcile any non linear jumps */
     listForEach(builder->unresolved_gotos) {
-        BasicBlock *bb_goto = cast(BasicBlock *,it->value);
+        BasicBlock *bb_goto = cast(BasicBlock *, it->value);
         BasicBlock *bb_dest = NULL;
-        Ast *ast = NULL; 
+        Ast *ast = NULL;
 
         for (int i = 0; i < bb_goto->ast_array->size; ++i) {
             ast = (Ast *)bb_goto->ast_array->entries[i];
@@ -1673,75 +1729,75 @@ static void cfgConstructFunction(CFGBuilder *builder, List *stmts) {
             }
         }
 
-        aoStr *goto_label = astHackedGetLabel(ast);
-        aoStr *dest_label = astHackedGetLabel(ast);
+        assert(ast != NULL);
+        const aoStr *goto_label = astHackedGetLabel(ast);
+        const aoStr *dest_label = astHackedGetLabel(ast);
 
         assert(ast->kind == AST_GOTO || ast->kind == AST_JUMP);
 
-        bb_dest = strMapGetLen(builder->resolved_labels,dest_label->data,
-                dest_label->len);
+        bb_dest = strMapGetLen(builder->resolved_labels, dest_label->data,
+                               dest_label->len);
 
         assert(bb_dest != NULL);
-        cfgRelocateGoto(builder,bb_goto,bb_dest,goto_label);
+        cfgRelocateGoto(builder, bb_goto, bb_dest, goto_label);
     }
 }
 
-
-static CFG *cfgCreateForFunction(Cctrl *cc, Ast *ast_fn, IntMap *leaf_cache, int *_block_no) {
+static CFG *cfgCreateForFunction(Cctrl *cc, const Ast *ast_fn,
+                                 IntMap *leaf_cache, int *_block_no) {
     CFGBuilder builder;
     *_block_no += 1;
 
-    cfgBuilderInit(&builder,cc,leaf_cache,*_block_no);
+    cfgBuilderInit(&builder, cc, leaf_cache, *_block_no);
 
     loggerDebug("creating CFG for: %s\n", ast_fn->fname->data);
 
-    BasicBlock *bb = cfgBuilderAllocBasicBlock(&builder,BB_HEAD_BLOCK,0);
-    BasicBlock *bb_next = cfgBuilderAllocBasicBlock(&builder,BB_CONTROL_BLOCK,0);
-    CFG *cfg = cfgNew(ast_fn->fname,bb);
-    bbSetNext(bb,bb_next);
-    bbSetPrevPtr(bb_next,bb);
+    BasicBlock *bb = cfgBuilderAllocBasicBlock(&builder, BB_HEAD_BLOCK, 0);
+    BasicBlock *bb_next = cfgBuilderAllocBasicBlock(&builder, BB_CONTROL_BLOCK,
+                                                    0);
+    CFG *cfg = cfgNew(ast_fn->fname, bb);
+    bbSetNext(bb, bb_next);
+    bbSetPrevPtr(bb_next, bb);
     builder.cfg = cfg;
     builder.bb = bb_next;
-    cfgConstructFunction(&builder,ast_fn->body->stms);
+    cfgConstructFunction(&builder, ast_fn->body->stms);
 
     /* This is a function with no body */
     if (builder.bb == bb->next && !bbIsType(bb->next, BB_RETURN_BLOCK)) {
         BasicBlock *bb_return = cfgBuilderAllocBasicBlock(&builder,
-                                                          BB_RETURN_BLOCK,0);
-        bbSetNext(bb->next,bb_return);
-        bbSetPrevPtr(bb_return,bb->next);
-        bbSetNext(bb_return,NULL);
-        intMapAdd(cfg->no_to_block,bb_return->block_no,bb_return);
+                                                          BB_RETURN_BLOCK, 0);
+        bbSetNext(bb->next, bb_return);
+        bbSetPrevPtr(bb_return, bb->next);
+        bbSetNext(bb_return, NULL);
+        intMapAdd(cfg->no_to_block, bb_return->block_no, bb_return);
     }
 
     cfg->bb_count = builder.bb_count;
     cfg->_memory = builder.block_pool;
-    *_block_no = builder.bb_block_no+1;
+    *_block_no = builder.bb_block_no + 1;
     cfgBuildAdjacencyList(cfg);
     cfgRemoveUnreachableNodes(cfg);
 
     strMapRelease(builder.resolved_labels);
-    listRelease(builder.unresolved_gotos,NULL);
+    listRelease(builder.unresolved_gotos, NULL);
     return cfg;
 }
 
 static void _bbFindAllLoopNodes(BasicBlock *loop_head, BasicBlock *bb,
-        IntMap *nodes, int loop_cnt)
-{
+                                IntMap *nodes, int loop_cnt) {
     int is_start_of_new_loop = bb != loop_head && bb->flags & BB_FLAG_LOOP_HEAD;
-    int types[] = {BB_END_BLOCK,BB_RETURN_BLOCK,BB_HEAD_BLOCK};
+    int types[] = {BB_END_BLOCK, BB_RETURN_BLOCK, BB_HEAD_BLOCK};
 
     if (bbIsLoopEnd(bb)) {
         if (bb->prev == loop_head) {
-            intMapAdd(nodes,bb->block_no,bb);
-            loop_cnt--;
+            intMapAdd(nodes, bb->block_no, bb);
             return;
         }
         if (loop_cnt > 1) {
-            intMapAdd(nodes,bb->block_no,bb);
+            intMapAdd(nodes, bb->block_no, bb);
         }
-    } else if (!bbOneOfType(bb,sizeof(types)/sizeof(types[0]),types)) {
-        intMapAdd(nodes,bb->block_no,bb);
+    } else if (!bbOneOfType(bb, sizeof(types) / sizeof(types[0]), types)) {
+        intMapAdd(nodes, bb->block_no, bb);
     }
 
     if (is_start_of_new_loop) {
@@ -1750,66 +1806,63 @@ static void _bbFindAllLoopNodes(BasicBlock *loop_head, BasicBlock *bb,
 
     if (bbIsType(bb, BB_BREAK_BLOCK)) {
         /* Add it and it is up to the caller to handle what a break means */
-        intMapAdd(nodes,bb->block_no,bb);
+        intMapAdd(nodes, bb->block_no, bb);
         return;
     }
 
     switch (bb->type) {
-        case BB_RETURN_BLOCK:
-        case BB_END_BLOCK:
-        case BB_HEAD_BLOCK:
-        case BB_LOOP_BLOCK:
-            break;
+    case BB_RETURN_BLOCK:
+    case BB_END_BLOCK:
+    case BB_HEAD_BLOCK:
+    case BB_LOOP_BLOCK:
+        break;
 
-        case BB_DO_WHILE_COND: /* Come back to */
-            _bbFindAllLoopNodes(loop_head,bb->next,nodes,loop_cnt);
-            break;
+    case BB_DO_WHILE_COND: /* Come back to */
+        _bbFindAllLoopNodes(loop_head, bb->next, nodes, loop_cnt);
+        break;
 
-        case BB_BRANCH_BLOCK:
-            assert(bb->_if != NULL);
-            assert(bb->_else != NULL);
-            _bbFindAllLoopNodes(loop_head,bb->_if,nodes,loop_cnt);
-            if (is_start_of_new_loop || !(bb->flags & BB_FLAG_LOOP_HEAD)) {
-                _bbFindAllLoopNodes(loop_head,bb->_else,nodes,loop_cnt);
-            }
-            break;
-
-        case BB_SWITCH: {
-            for (int i = 0; i < bb->next_blocks->size; ++i) {
-                BasicBlock *it = vecGet(BasicBlock *,bb->next_blocks,i);
-                _bbFindAllLoopNodes(loop_head,it,nodes,loop_cnt);
-            }
-            _bbFindAllLoopNodes(loop_head,bb->next,nodes,loop_cnt);
-            break;
+    case BB_BRANCH_BLOCK:
+        assert(bb->_if != NULL);
+        assert(bb->_else != NULL);
+        _bbFindAllLoopNodes(loop_head, bb->_if, nodes, loop_cnt);
+        if (is_start_of_new_loop || !(bb->flags & BB_FLAG_LOOP_HEAD)) {
+            _bbFindAllLoopNodes(loop_head, bb->_else, nodes, loop_cnt);
         }
+        break;
 
-        case BB_BREAK_BLOCK: 
-            if (loop_cnt > 1) {
-                _bbFindAllLoopNodes(loop_head,bb->next,nodes,loop_cnt);
-            }
-            break;
- 
-        case BB_GOTO:
-        case BB_CONTROL_BLOCK:
-            _bbFindAllLoopNodes(loop_head,bb->next,nodes,loop_cnt);
-            break;
+    case BB_SWITCH: {
+        for (int i = 0; i < bb->next_blocks->size; ++i) {
+            BasicBlock *it = vecGet(BasicBlock *, bb->next_blocks, i);
+            _bbFindAllLoopNodes(loop_head, it, nodes, loop_cnt);
+        }
+        _bbFindAllLoopNodes(loop_head, bb->next, nodes, loop_cnt);
+        break;
     }
 
-    if (bbIsLoopEnd(bb)) {
-        loop_cnt--;
+    case BB_BREAK_BLOCK:
+        if (loop_cnt > 1) {
+            _bbFindAllLoopNodes(loop_head, bb->next, nodes, loop_cnt);
+        }
+        break;
+
+    case BB_GOTO:
+    case BB_CONTROL_BLOCK:
+        _bbFindAllLoopNodes(loop_head, bb->next, nodes, loop_cnt);
+        break;
+    default:;
     }
 }
 
 IntMap *bbFindAllLoopNodes(BasicBlock *loop_head) {
     int loop_cnt = 0;
     IntMap *map = intMapNew(32);
-    intMapAdd(map,loop_head->block_no,loop_head);
-    _bbFindAllLoopNodes(loop_head,loop_head,map,loop_cnt);
+    intMapAdd(map, loop_head->block_no, loop_head);
+    _bbFindAllLoopNodes(loop_head, loop_head, map, loop_cnt);
 
     IntMapIterator *it = intMapIteratorNew(loop_head->prev_blocks);
     IntMapNode *entry;
     while ((entry = intMapNext(it)) != NULL) {
-        BasicBlock *prev = (BasicBlock *)entry->value;
+        const BasicBlock *prev = (BasicBlock *)entry->value;
         if (bbIsType(prev, BB_LOOP_BLOCK) && prev->prev == loop_head) {
             break;
         }
@@ -1818,19 +1871,21 @@ IntMap *bbFindAllLoopNodes(BasicBlock *loop_head) {
     return map;
 }
 
-/* DFS our way through the graph, as it is created in the correct order above 
+/* DFS our way through the graph, as it is created in the correct order above
  * we get the nodes in the correct order here. */
 void cfgExplore(CFG *cfg, IntSet *seen, int block_no) {
-    if (intSetHas(seen,block_no)) return;
-    intSetAdd(seen,block_no);
-    IntSet *iset = (IntSet *)intMapGet(cfg->graph,block_no);
-    printf("bb%d\n",block_no);
+    if (intSetHas(seen, block_no))
+        return;
+    intSetAdd(seen, block_no);
+    IntSet *iset = (IntSet *)intMapGet(cfg->graph, block_no);
+    printf("bb%d\n", block_no);
 
     IntSetIterator *it = intSetIteratorNew(iset);
     long next_block_no;
     while ((next_block_no = intSetNext(it)) != HT_DELETED) {
-        BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,(int)next_block_no);
-        cfgExplore(cfg,seen,bb->block_no);
+        const BasicBlock *bb = (BasicBlock *)intMapGet(cfg->no_to_block,
+                                                       (int)next_block_no);
+        cfgExplore(cfg, seen, bb->block_no);
     }
     intSetIteratorRelease(it);
 }
@@ -1840,8 +1895,8 @@ void cfgIter(CFG *cfg) {
     IntMapIterator *it = intMapIteratorNew(cfg->no_to_block);
     IntMapNode *entry;
     while ((entry = intMapNext(it)) != NULL) {
-        BasicBlock *bb = (BasicBlock *)entry->value;
-        cfgExplore(cfg,seen,bb->block_no);
+        const BasicBlock *bb = (BasicBlock *)entry->value;
+        cfgExplore(cfg, seen, bb->block_no);
     }
     intMapIteratorRelease(it);
     intSetRelease(seen);
@@ -1853,11 +1908,11 @@ PtrVec *cfgConstruct(Cctrl *cc) {
     int block_no = 0;
     IntMap *leaf_cache = intMapNew(32);
     listForEach(cc->ast_list) {
-        Ast *ast = (Ast *)it->value;
+        const Ast *ast = (Ast *)it->value;
         /* XXX: What do we want to do with global variables? */
         if (ast->kind == AST_FUNC) {
-            CFG *cfg = cfgCreateForFunction(cc,ast,leaf_cache,&block_no);
-            ptrVecPush(cfgs,cfg);
+            CFG *cfg = cfgCreateForFunction(cc, ast, leaf_cache, &block_no);
+            ptrVecPush(cfgs, cfg);
         }
     }
     intMapRelease(leaf_cache);

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -7,19 +7,19 @@
 #include "mempool.h"
 
 enum bbType {
-    BB_GARBAGE       = -1,
-    BB_END_BLOCK     = 0,
-    BB_HEAD_BLOCK    = 1,
+    BB_GARBAGE = -1,
+    BB_END_BLOCK = 0,
+    BB_HEAD_BLOCK = 1,
     BB_CONTROL_BLOCK = 2,
-    BB_BRANCH_BLOCK  = 3,
-    BB_LOOP_BLOCK    = 4,
-    BB_RETURN_BLOCK  = 5,
-    BB_BREAK_BLOCK   = 6,
+    BB_BRANCH_BLOCK = 3,
+    BB_LOOP_BLOCK = 4,
+    BB_RETURN_BLOCK = 5,
+    BB_BREAK_BLOCK = 6,
     BB_DO_WHILE_COND = 7,
-    BB_GOTO          = 8,
-    BB_SWITCH        = 9,
-    BB_CASE          = 10,
-    BB_CONTINUE      = 11,
+    BB_GOTO = 8,
+    BB_SWITCH = 9,
+    BB_CASE = 10,
+    BB_CONTINUE = 11,
 };
 
 #define CFG_MAX_PREV      (32)
@@ -38,23 +38,26 @@ enum bbType {
 #define BB_FLAG_LABEL              (0x10)
 #define BB_FLAG_ELSE_BRANCH        (0x20)
 #define BB_FLAG_IF_BRANCH          (0x40)
-#define BB_FLAG_LOOP_JUMP          (0x80) /* this is for when a goto is jumping
-                                           * out of a loop */
-#define BB_FLAG_GOTO_LOOP          (0x100) /* this is for when a goto forms a 
-                                            * loop */
-#define BB_FLAG_CASE_OWNED         (0x200)
-#define BB_FLAG_WHILE_LOOP         (0x400)
-#define BB_FLAG_CASE_BREAK         (0x800)
-#define BB_FLAG_FOR_LOOP           (0x1000)
-#define BB_FLAG_FOR_LOOP_HAS_STEP  (0x2000)
-#define BB_FLAG_HAD_NO_ELSE        (0x4000) /* Where an if branch had no written
-                                             * else branch */
+#define BB_FLAG_LOOP_JUMP                        \
+    (0x80) /* this is for when a goto is jumping \
+            * out of a loop */
+#define BB_FLAG_GOTO_LOOP                      \
+    (0x100) /* this is for when a goto forms a \
+             * loop */
+#define BB_FLAG_CASE_OWNED        (0x200)
+#define BB_FLAG_WHILE_LOOP        (0x400)
+#define BB_FLAG_CASE_BREAK        (0x800)
+#define BB_FLAG_FOR_LOOP          (0x1000)
+#define BB_FLAG_FOR_LOOP_HAS_STEP (0x2000)
+#define BB_FLAG_HAD_NO_ELSE                       \
+    (0x4000) /* Where an if branch had no written \
+              * else branch */
 
 typedef struct BasicBlock {
     /* @Confirm:
      * Should we stick ssa on this struct? */
     int type;
-    /* For denoting a loop head / end, not a big fan of having flags AND 
+    /* For denoting a loop head / end, not a big fan of having flags AND
      * a type field but I presently can't think of a better way for loops. */
     unsigned int flags;
     int block_no;
@@ -63,8 +66,8 @@ typedef struct BasicBlock {
     struct BasicBlock *_if;
     struct BasicBlock *_else;
     struct BasicBlock *prev;
-    /* For a control block points to the next node, for a branch that is a 
-     * loop head the next pointer is the BB_LOOP_BLOCK, so we can keep track of 
+    /* For a control block points to the next node, for a branch that is a
+     * loop head the next pointer is the BB_LOOP_BLOCK, so we can keep track of
      * it more easily */
     struct BasicBlock *next;
     IntMap *prev_blocks;
@@ -73,8 +76,7 @@ typedef struct BasicBlock {
     PtrVec *ast_array;
 } BasicBlock;
 
-#define bbPrevCnt(bb) \
-  ((bb)->prev_blocks->size)
+#define bbPrevCnt(bb) ((bb)->prev_blocks->size)
 
 /* Head of a CFG is a function */
 typedef struct CFG {
@@ -84,12 +86,12 @@ typedef struct CFG {
     BasicBlock *head;
     /* How many basic blocks are in the graph */
     int bb_count;
-    /* A more compact representation of the graph, a block number to its 
+    /* A more compact representation of the graph, a block number to its
      * connected blocks (not including previous nodes)
      * [block_no] => {block, block...}*/
     IntMap *graph;
     /* Block number to it's block struct
-     * [block_no] => block 
+     * [block_no] => block
      * hashtable */
     IntMap *no_to_block;
     /* This a pointer to the memory pool which holds all of the basic blocks */
@@ -119,7 +121,7 @@ BasicBlock *bbAddNext(BasicBlock *cur, int type, BasicBlock *next);
 char *bbTypeToString(int type);
 char *bbFlagsToString(unsigned int flags);
 char *bbPreviousBlockNumbersToString(BasicBlock *bb);
-int bbPrevHas(BasicBlock *bb, int block_no);
+int bbPrevHas(const BasicBlock *bb, int block_no);
 BasicBlock *cfgGet(CFG *cfg, int block_no);
 PtrVec *cfgConstruct(Cctrl *cc);
 void bbPrint(BasicBlock *bb);

--- a/src/cli.h
+++ b/src/cli.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "config.h"
 #include "list.h"
 
 enum CliType {
@@ -47,7 +48,7 @@ typedef struct CliParser {
     char *optname;
     size_t optlen;
     int arg_count;
-    enum CliArgType arg_type; 
+    enum CliArgType arg_type;
     char *usage;
     char *help;
     int (*parse)(struct CliValue *value, char *rawarg);
@@ -82,6 +83,7 @@ typedef struct CliArgs {
 
 void cliArgsInit(CliArgs *args);
 int cliParseArgs(struct CliArgs *cli_args, int argc, char **argv);
-__noreturn void cliPanicGeneric(const char *const_msg, const char *fmt, va_list ap);
+__noreturn void cliPanicGeneric(const char *const_msg, const char *fmt,
+                                va_list ap);
 
 #endif

--- a/src/compile.h
+++ b/src/compile.h
@@ -2,15 +2,14 @@
 #define COMPILE_H
 
 #include "aostr.h"
-#include "cli.h"
 #include "cctrl.h"
+#include "cli.h"
 
 int compileToAst(Cctrl *cc, CliArgs *args, int lexer_flags);
 void compileToTokens(Cctrl *cc, CliArgs *args, int lexer_flags);
 
 aoStr *compileToAsm(Cctrl *cc);
 void compileAssembleToFile(aoStr *asmbuf, char *filename);
-void compilePrintAst(Cctrl *cc);
-
+void compilePrintAst(const Cctrl *cc);
 
 #endif // !COMPILE_H

--- a/src/config.h
+++ b/src/config.h
@@ -2,31 +2,31 @@
 #define CONFIG_H
 
 #if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6)
-#define OS_STR "apple"
+#define OS_STR   "apple"
 #define IS_MACOS 1
 #endif
 #if defined(__APPLE__) && defined(MAC_OS_X_VERSION_10_6) || \
         defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
-#define IS_BSD 1
+#define IS_BSD   1
 #define IS_LINUX 0
 #elif defined(__linux__)
-#define OS_STR "Linux"
+#define OS_STR   "Linux"
 #define IS_LINUX 1
-#define IS_BSD 0
+#define IS_BSD   0
 #endif
 
 #if defined(__x86_64__)
 #define IS_X86_64 1
 #define IS_ARM_64 0
-#define ARCH_STR "x86_64"
-#elif defined (__aarch64__) || defined(__ARM_ARCH) || defined(__ARM_ARCH_64)
+#define ARCH_STR  "x86_64"
+#elif defined(__aarch64__) || defined(__ARM_ARCH) || defined(__ARM_ARCH_64)
 #define IS_X86_64 0
 #define IS_ARM_64 1
-#define ARCH_STR "aarch64"
+#define ARCH_STR  "aarch64"
 #endif
 
 #ifndef __GNUC__
-    #define __attribute__(x)  // Define as empty if not using GCC/Clang
+#define __attribute__(x) // Define as empty if not using GCC/Clang
 #endif
 
 #define __noreturn __attribute__((noreturn))

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1,26 +1,26 @@
+#include <assert.h>
 #include <ctype.h>
+#include <fcntl.h>
+#include <pwd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <pwd.h>
 #include <unistd.h>
-#include <fcntl.h>
-#include <assert.h>
 
 #include "aostr.h"
-#include "ast.h"
 #include "arena.h"
+#include "ast.h"
 #include "cctrl.h"
-#include "map.h"
 #include "lexer.h"
 #include "list.h"
+#include "map.h"
 #include "memory.h"
 #include "prslib.h"
 #include "prsutil.h"
 #include "util.h"
 
 /* prototypes */
-int lexPreProcIf(StrMap *macro_defs, Lexer *l);
+int lexPreProcIf(const StrMap *macro_defs, Lexer *l);
 
 static Arena lexeme_arena;
 static int lexeme_arena_init = 0;
@@ -52,10 +52,11 @@ char *lexerAllocateBuffer(unsigned int size) {
     return (char *)arenaAlloc(&lexeme_arena, size);
 }
 
-char *lexerReAllocBuffer(char *ptr, unsigned int old_size, unsigned int new_size) {
+char *lexerReAllocBuffer(char *ptr, unsigned int old_size,
+                         unsigned int new_size) {
     (void)ptr;
     char *buffer = lexerAllocateBuffer(new_size);
-    memcpy(buffer,ptr,old_size);
+    memcpy(buffer, ptr, old_size);
     return buffer;
 }
 
@@ -66,74 +67,73 @@ typedef struct {
 
 /* Name, kind, size, issigned */
 static LexerTypes lexer_types[] = {
-    /* Holyc Types, this language is semi interoperable */
-    {"U0", KW_U0},
-    {"Bool", KW_BOOL},
-    {"I8", KW_I8},
-    {"U8", KW_U8},
-    {"I16", KW_I16},
-    {"U16", KW_U16},
-    {"I32", KW_I32},
-    {"U32", KW_U32},
-    {"I64", KW_I64},
-    {"U64", KW_U64},
-    {"F64", KW_F64},
+        /* Holyc Types, this language is semi interoperable */
+        {"U0", KW_U0},
+        {"Bool", KW_BOOL},
+        {"I8", KW_I8},
+        {"U8", KW_U8},
+        {"I16", KW_I16},
+        {"U16", KW_U16},
+        {"I32", KW_I32},
+        {"U32", KW_U32},
+        {"I64", KW_I64},
+        {"U64", KW_U64},
+        {"F64", KW_F64},
 
-    {"auto", KW_AUTO},
+        {"auto", KW_AUTO},
 
-    {"_extern", KW_ASM_EXTERN},
-    {"extern", KW_EXTERN},
-    {"asm", KW_ASM},
+        {"_extern", KW_ASM_EXTERN},
+        {"extern", KW_EXTERN},
+        {"asm", KW_ASM},
 
-    {"switch", KW_SWITCH},
-    {"case", KW_CASE},
-    {"break", KW_BREAK},
-    {"continue", KW_CONTINUE},
-    {"while", KW_WHILE},
-    {"do", KW_DO},
-    {"for", KW_FOR},
-    {"goto", KW_GOTO},
-    {"default", KW_DEFAULT},
-    {"return", KW_RETURN},
+        {"switch", KW_SWITCH},
+        {"case", KW_CASE},
+        {"break", KW_BREAK},
+        {"continue", KW_CONTINUE},
+        {"while", KW_WHILE},
+        {"do", KW_DO},
+        {"for", KW_FOR},
+        {"goto", KW_GOTO},
+        {"default", KW_DEFAULT},
+        {"return", KW_RETURN},
 
-    {"if", KW_IF},
-    {"else", KW_ELSE},
-    {"define", KW_DEFINE},
-    {"ifndef", KW_IF_NDEF},
-    {"ifdef", KW_IF_DEF},
-    {"elifdef", KW_ELIF_DEF},
-    {"endif", KW_ENDIF},
-    {"elif", KW_ELIF},
-    {"defined", KW_DEFINED},
-    {"undef", KW_UNDEF},
+        {"if", KW_IF},
+        {"else", KW_ELSE},
+        {"define", KW_DEFINE},
+        {"ifndef", KW_IF_NDEF},
+        {"ifdef", KW_IF_DEF},
+        {"elifdef", KW_ELIF_DEF},
+        {"endif", KW_ENDIF},
+        {"elif", KW_ELIF},
+        {"defined", KW_DEFINED},
+        {"undef", KW_UNDEF},
 
-    {"#if", KW_PP_IF},
-    {"#else", KW_PP_ELSE},
-    {"#define", KW_PP_DEFINE},
-    {"#ifndef", KW_PP_IF_NDEF},
-    {"#ifdef", KW_PP_IF_DEF},
-    {"#elifdef", KW_PP_ELIF_DEF},
-    {"#endif", KW_PP_ENDIF},
-    {"#elif", KW_PP_ELIF},
-    {"#defined", KW_PP_DEFINED},
-    {"#undef", KW_PP_UNDEF},
-    {"#error", KW_PP_ERROR},
-    {"#include", KW_PP_INCLUDE},
+        {"#if", KW_PP_IF},
+        {"#else", KW_PP_ELSE},
+        {"#define", KW_PP_DEFINE},
+        {"#ifndef", KW_PP_IF_NDEF},
+        {"#ifdef", KW_PP_IF_DEF},
+        {"#elifdef", KW_PP_ELIF_DEF},
+        {"#endif", KW_PP_ENDIF},
+        {"#elif", KW_PP_ELIF},
+        {"#defined", KW_PP_DEFINED},
+        {"#undef", KW_PP_UNDEF},
+        {"#error", KW_PP_ERROR},
+        {"#include", KW_PP_INCLUDE},
 
-    {"cast", KW_CAST},
-    {"sizeof", KW_SIZEOF},
-    {"inline", KW_INLINE},
-    {"atomic", KW_ATOMIC},
-    {"volatile", KW_VOLATILE},
+        {"cast", KW_CAST},
+        {"sizeof", KW_SIZEOF},
+        {"inline", KW_INLINE},
+        {"atomic", KW_ATOMIC},
+        {"volatile", KW_VOLATILE},
 
-    {"public", KW_PUBLIC},
-    {"private", KW_PRIVATE},
-    {"class", KW_CLASS},
-    {"union", KW_UNION},
+        {"public", KW_PUBLIC},
+        {"private", KW_PRIVATE},
+        {"class", KW_CLASS},
+        {"union", KW_UNION},
 
-    {"static", KW_STATIC},
+        {"static", KW_STATIC},
 };
-
 
 #define isNum(ch) ((ch) >= '0' && (ch) <= '9')
 #define isHex(ch) \
@@ -141,8 +141,9 @@ static LexerTypes lexer_types[] = {
 #define toInt(ch)   (ch - '0')
 #define toUpper(ch) ((ch >= 'a' && ch <= 'z') ? (ch - 'a' + 'A') : ch)
 #define toHex(ch)   (toUpper(ch) - 'A' + 10)
-#define isNumTerminator(ch) (!isNum(ch) && !isHex(ch) && ch != '.' && ch != 'x' \
-        && ch != 'X' && ch != '\\')
+#define isNumTerminator(ch)                                             \
+    (!isNum(ch) && !isHex(ch) && ch != '.' && ch != 'x' && ch != 'X' && \
+     ch != '\\')
 
 Lexeme *lexemeNew(char *start, int len) {
     Lexeme *le = lexerAllocLexeme();
@@ -180,15 +181,15 @@ Lexeme *lexemeTokNew(char *start, int len, int line, long ch) {
     return copy;
 }
 
-Lexeme *lexemeCopy(Lexeme *le) {
+Lexeme *lexemeCopy(const Lexeme *le) {
     Lexeme *copy = lexerAllocLexeme();
-    memcpy(copy,le,sizeof(Lexeme));
+    memcpy(copy, le, sizeof(Lexeme));
     return copy;
 }
 
 Lexeme *lexemeNewOp(char *start, int len, long op, int line) {
-    Lexeme *le = lexemeNew(start,len);
-    lexemeAssignOp(le,start,len,op,line);
+    Lexeme *le = lexemeNew(start, len);
+    lexemeAssignOp(le, start, len, op, line);
     return le;
 }
 
@@ -223,7 +224,7 @@ void lexInit(Lexer *l, char *source, int flags) {
     /* XXX: create one symbol table for the whole application ;
      * hoist to 'compile.c'*/
     for (int i = 0; i < (int)static_size(lexer_types); ++i) {
-        LexerTypes *bilt = &lexer_types[i]; 
+        LexerTypes *bilt = &lexer_types[i];
         strMapAdd(l->symbol_table, bilt->name, bilt);
     }
 }
@@ -233,98 +234,166 @@ void lexSetBuiltinRoot(Lexer *l, char *root) {
 }
 
 /* Is the lexeme both of type TK_PUNCT and does 'ch' match */
-int tokenPunctIs(Lexeme *tok, long ch) {
-    return tok && (tok->tk_type == TK_PUNCT || tok->tk_type == TK_EOF) && tok->i64 == ch;
+int tokenPunctIs(const Lexeme *tok, long ch) {
+    return tok && (tok->tk_type == TK_PUNCT || tok->tk_type == TK_EOF) &&
+            tok->i64 == ch;
 }
 
 /* Is the token an identifier and does the string match */
-int tokenIdentIs(Lexeme *tok, char *ident, int len) {
-    return tok && tok->tk_type == TK_IDENT 
-               && tok->len == len 
-               && !memcmp(tok->start,ident,len);
+int tokenIdentIs(const Lexeme *tok, const char *ident, int len) {
+    return tok && tok->tk_type == TK_IDENT && tok->len == len &&
+            !memcmp(tok->start, ident, len);
 }
 
 char *lexemeTypeToString(int tk_type) {
     switch (tk_type) {
-    case TK_IDENT:      return "identifier";
-    case TK_PUNCT:      return "character";
-    case TK_I64:        return "integer";
-    case TK_F64:        return "float";
-    case TK_EOF:        return "end of file";
-    case TK_STR:        return "string";
-    case TK_KEYWORD:    return "keyword";
-    case TK_CHAR_CONST: return "character constant";
+    case TK_IDENT:
+        return "identifier";
+    case TK_PUNCT:
+        return "character";
+    case TK_I64:
+        return "integer";
+    case TK_F64:
+        return "float";
+    case TK_EOF:
+        return "end of file";
+    case TK_STR:
+        return "string";
+    case TK_KEYWORD:
+        return "keyword";
+    case TK_CHAR_CONST:
+        return "character constant";
     }
     return "UNKNOWN";
 }
 
 /* This is for something that will play nicely with HTML or GraphViz*/
 char *lexemePunctToEncodedString(long op) {
-    static char buf[4];
-    switch(op) {
-    case '\\':               return "\\";
-    case '\n':               return "\\n";
-    case '\t':               return "\\t";
-    case '\r':               return "\\r";
-    case '\"':               return "&#34;";
-    case '\'':               return "&#39;";
-    case ' ':                return "&#32;";
-    case '>':                return "&#62;";
-    case '<':                return "&#60;";
-    case '&':                return "&#38;";
-    case '|':                return "&#124;";
-    case ';':                return "&#59;";
-    case '@':                return "&#64;";
-    case '=':                return "&#61;";
-    case '(':                return "&#40;";
-    case ')':                return "&#41;";
-    case '~':                return "&#126;";
-    case '^':                return "&#94;";
-    case '_':                return "&#65;";
-    case '!':                return "&#33;";
-    case '{':                return "&#123;";
-    case '}':                return "&#125;";
-    case '[':                return "&#91;";
-    case ']':                return "&#93;";
-    case '`':                return "&#96;";
-    case '*':                return "&#42;";
-    case '+':                return "&#43;";
-    case '-':                return "&#45;";
-    case '/':                return "&#47;";
-    case '%':                return "&#37;";
-    case '$':                return "&#36;";
-    case '#':                return "&#35;";
-    case ',':                return "&#44;";
-    case '.':                return "&#46;";
-    case '?':                return "&#63;";
-    case ':':                return "&#48;";
+    switch (op) {
+    case '\\':
+        return "\\";
+    case '\n':
+        return "\\n";
+    case '\t':
+        return "\\t";
+    case '\r':
+        return "\\r";
+    case '\"':
+        return "&#34;";
+    case '\'':
+        return "&#39;";
+    case ' ':
+        return "&#32;";
+    case '>':
+        return "&#62;";
+    case '<':
+        return "&#60;";
+    case '&':
+        return "&#38;";
+    case '|':
+        return "&#124;";
+    case ';':
+        return "&#59;";
+    case '@':
+        return "&#64;";
+    case '=':
+        return "&#61;";
+    case '(':
+        return "&#40;";
+    case ')':
+        return "&#41;";
+    case '~':
+        return "&#126;";
+    case '^':
+        return "&#94;";
+    case '_':
+        return "&#65;";
+    case '!':
+        return "&#33;";
+    case '{':
+        return "&#123;";
+    case '}':
+        return "&#125;";
+    case '[':
+        return "&#91;";
+    case ']':
+        return "&#93;";
+    case '`':
+        return "&#96;";
+    case '*':
+        return "&#42;";
+    case '+':
+        return "&#43;";
+    case '-':
+        return "&#45;";
+    case '/':
+        return "&#47;";
+    case '%':
+        return "&#37;";
+    case '$':
+        return "&#36;";
+    case '#':
+        return "&#35;";
+    case ',':
+        return "&#44;";
+    case '.':
+        return "&#46;";
+    case '?':
+        return "&#63;";
+    case ':':
+        return "&#48;";
 
-    case TK_EQU_EQU:         return "&#61;&#61;";
-    case TK_NOT_EQU:         return "&#33;&#61;";
-    case TK_LESS_EQU:        return "&#60;&#61;";
-    case TK_GREATER_EQU:     return "&#62;&#61;";      
-    case TK_AND_AND:         return "&#38;&#38;";
-    case TK_OR_OR:           return "&#124;&#124;";
-    case TK_SHL:             return "&#60;&#60;";
-    case TK_SHL_EQU:         return "&#60;&#60;&#61;";
-    case TK_SHR:             return "&#62;&#62;";
-    case TK_SHR_EQU:         return "&#62;&#62;&#61;";
-    case TK_MUL_EQU:         return "&#42;&#61;";
-    case TK_DIV_EQU:         return "&#47;&#61;";
-    case TK_OR_EQU:          return "&#124;&#61;";
-    case TK_XOR_EQU:         return "&#94;&#61;";
-    case TK_AND_EQU:         return "&#38;&#61;";
-    case TK_SUB_EQU:         return "&#45;&#61;";
-    case TK_ADD_EQU:         return "&#43;&#61;";
-    case TK_MOD_EQU:         return "&#37;&#61;";
-    case TK_ELLIPSIS:        return "&#48;&#48;&#48;";
-    case TK_ARROW:           return "&#45;&#62;";
-    case TK_PRE_PLUS_PLUS:   return "&#43;&#43;";
-    case TK_PLUS_PLUS:       return "&#43;&#43;";
-    case TK_PRE_MINUS_MINUS: return "&#45;&#45;";
-    case TK_MINUS_MINUS:     return "&#45;&#45;";
+    case TK_EQU_EQU:
+        return "&#61;&#61;";
+    case TK_NOT_EQU:
+        return "&#33;&#61;";
+    case TK_LESS_EQU:
+        return "&#60;&#61;";
+    case TK_GREATER_EQU:
+        return "&#62;&#61;";
+    case TK_AND_AND:
+        return "&#38;&#38;";
+    case TK_OR_OR:
+        return "&#124;&#124;";
+    case TK_SHL:
+        return "&#60;&#60;";
+    case TK_SHL_EQU:
+        return "&#60;&#60;&#61;";
+    case TK_SHR:
+        return "&#62;&#62;";
+    case TK_SHR_EQU:
+        return "&#62;&#62;&#61;";
+    case TK_MUL_EQU:
+        return "&#42;&#61;";
+    case TK_DIV_EQU:
+        return "&#47;&#61;";
+    case TK_OR_EQU:
+        return "&#124;&#61;";
+    case TK_XOR_EQU:
+        return "&#94;&#61;";
+    case TK_AND_EQU:
+        return "&#38;&#61;";
+    case TK_SUB_EQU:
+        return "&#45;&#61;";
+    case TK_ADD_EQU:
+        return "&#43;&#61;";
+    case TK_MOD_EQU:
+        return "&#37;&#61;";
+    case TK_ELLIPSIS:
+        return "&#48;&#48;&#48;";
+    case TK_ARROW:
+        return "&#45;&#62;";
+    case TK_PRE_PLUS_PLUS:
+        return "&#43;&#43;";
+    case TK_PLUS_PLUS:
+        return "&#43;&#43;";
+    case TK_PRE_MINUS_MINUS:
+        return "&#45;&#45;";
+    case TK_MINUS_MINUS:
+        return "&#45;&#45;";
     default: {
-        int len = snprintf(buf,sizeof(buf),"%c",(char)op);
+        static char buf[4];
+        int len = snprintf(buf, sizeof(buf), "%c", (char)op);
         buf[len] = '\0';
         return buf;
     }
@@ -333,42 +402,74 @@ char *lexemePunctToEncodedString(long op) {
 
 /* Convert all of this to a massive lookup table */
 char *lexemePunctToString(long op) {
-    static char buf[4];
     switch (op) {
-    case '\\':               return "\\";
-    case '\n':               return "\\n";
-    case '\t':               return "\\t";
-    case '\r':               return "\\r";
-    case '\"':               return "\\\"";
-    case '\'':               return "\\\'";
-    case '\0':               return "\\0'";
-    case TK_AND_AND:         return "&&";
-    case TK_OR_OR:           return "||";
-    case TK_EQU_EQU:         return "==";
-    case TK_NOT_EQU:         return "!=";
-    case TK_LESS_EQU:        return "<=";
-    case TK_GREATER_EQU:     return ">=";
-    case TK_PLUS_PLUS:       return "++";
-    case TK_MINUS_MINUS:     return "--";
-    case TK_SHL:             return "<<";
-    case TK_SHR:             return ">>";
-    case TK_ARROW:           return "->";
-    case TK_DBL_COLON:       return "::";
-    case TK_ELLIPSIS:        return "...";
-    case TK_SHL_EQU:         return "<<=";
-    case TK_SHR_EQU:         return ">>=";
-    case TK_MUL_EQU:         return "*=";
-    case TK_DIV_EQU:         return "/=";
-    case TK_OR_EQU:          return "|=";
-    case TK_XOR_EQU:         return "^=";
-    case TK_AND_EQU:         return "&=";
-    case TK_SUB_EQU:         return "-=";
-    case TK_ADD_EQU:         return "+=";
-    case TK_MOD_EQU:         return "%=";
-    case TK_PRE_PLUS_PLUS:   return "++";
-    case TK_PRE_MINUS_MINUS: return "--";
+    case '\\':
+        return "\\";
+    case '\n':
+        return "\\n";
+    case '\t':
+        return "\\t";
+    case '\r':
+        return "\\r";
+    case '\"':
+        return "\\\"";
+    case '\'':
+        return "\\\'";
+    case '\0':
+        return "\\0'";
+    case TK_AND_AND:
+        return "&&";
+    case TK_OR_OR:
+        return "||";
+    case TK_EQU_EQU:
+        return "==";
+    case TK_NOT_EQU:
+        return "!=";
+    case TK_LESS_EQU:
+        return "<=";
+    case TK_GREATER_EQU:
+        return ">=";
+    case TK_PLUS_PLUS:
+        return "++";
+    case TK_MINUS_MINUS:
+        return "--";
+    case TK_SHL:
+        return "<<";
+    case TK_SHR:
+        return ">>";
+    case TK_ARROW:
+        return "->";
+    case TK_DBL_COLON:
+        return "::";
+    case TK_ELLIPSIS:
+        return "...";
+    case TK_SHL_EQU:
+        return "<<=";
+    case TK_SHR_EQU:
+        return ">>=";
+    case TK_MUL_EQU:
+        return "*=";
+    case TK_DIV_EQU:
+        return "/=";
+    case TK_OR_EQU:
+        return "|=";
+    case TK_XOR_EQU:
+        return "^=";
+    case TK_AND_EQU:
+        return "&=";
+    case TK_SUB_EQU:
+        return "-=";
+    case TK_ADD_EQU:
+        return "+=";
+    case TK_MOD_EQU:
+        return "%=";
+    case TK_PRE_PLUS_PLUS:
+        return "++";
+    case TK_PRE_MINUS_MINUS:
+        return "--";
     default: {
-        int len = snprintf(buf,sizeof(buf),"%c",(char)op);
+        static char buf[4];
+        int len = snprintf(buf, sizeof(buf), "%c", (char)op);
         buf[len] = '\0';
         return buf;
     }
@@ -376,8 +477,10 @@ char *lexemePunctToString(long op) {
 }
 
 char *lexemePunctToStringWithFlags(long op, unsigned long flags) {
-    if (flags & LEXEME_ENCODE_PUNCT) return lexemePunctToEncodedString(op);
-    else                             return lexemePunctToString(op);
+    if (flags & LEXEME_ENCODE_PUNCT)
+        return lexemePunctToEncodedString(op);
+    else
+        return lexemePunctToString(op);
 }
 
 char *lexemeToString(Lexeme *tok) {
@@ -385,106 +488,220 @@ char *lexemeToString(Lexeme *tok) {
         return "(null)";
     }
     aoStr *str = aoStrNew();
-    char *tmp;
     switch (tok->tk_type) {
-        case TK_COMMENT: {
-            aoStrCatPrintf(str,"TK_COMMENT    %.*s",tok->len,tok->start);
-            return aoStrMove(str);
-        }
-        case TK_IDENT:
-            aoStrCatPrintf(str,"TK_IDENT      %.*s",tok->len,tok->start);
-            return aoStrMove(str);
-        case TK_CHAR_CONST:
-            aoStrCatPrintf(str,"TK_CHAR_CONST %x",tok->i64);
-            return aoStrMove(str);
-        case TK_PUNCT: {
-            tmp = lexemePunctToString(tok->i64);
-            aoStrCatPrintf(str,"TK_PUNCT      %s", tmp);
-            return aoStrMove(str);
-        }
-        case TK_I64:
-            aoStrCatPrintf(str,"TK_I64        %lld",tok->i64);
-            return aoStrMove(str);
-        case TK_F64:
-            aoStrCatPrintf(str,"TK_F64        %g",tok->f64);
-            return aoStrMove(str);
-        case TK_STR:
-            aoStrCatPrintf(str,"TK_STR        \"%.*s\"",tok->len,tok->start);
-            return aoStrMove(str);
-        case TK_EOF:
-            aoStrCatPrintf(str,"TK_EOF");
-            return aoStrMove(str);
-        case TK_KEYWORD: {
-            aoStrCatPrintf(str,"TK_KEYWORD    ");
-            switch (tok->i64) {
-                case KW_CLASS:       aoStrCatPrintf(str,"class");   break;
-                case KW_UNION:       aoStrCatPrintf(str,"union");   break;
-                case KW_U0:          aoStrCatPrintf(str,"U0");      break;
-                case KW_BOOL:        aoStrCatPrintf(str,"Bool");    break;
-                case KW_I8:          aoStrCatPrintf(str,"I8");      break;
-                case KW_U8:          aoStrCatPrintf(str,"U8");      break;
-                case KW_I16:         aoStrCatPrintf(str,"I16");     break;
-                case KW_U16:         aoStrCatPrintf(str,"U16");     break;
-                case KW_I32:         aoStrCatPrintf(str,"I32");     break;
-                case KW_U32:         aoStrCatPrintf(str,"U32");     break;
-                case KW_I64:         aoStrCatPrintf(str,"I64");     break;
-                case KW_U64:         aoStrCatPrintf(str,"U64");     break;
-                case KW_F64:         aoStrCatPrintf(str,"F64");     break;
-                case KW_PUBLIC:      aoStrCatPrintf(str,"public");  break;
-                case KW_ATOMIC:      aoStrCatPrintf(str,"atomic");  break;
-                case KW_DEFINE:      aoStrCatPrintf(str,"define");  break;
-                case KW_PP_INCLUDE:     aoStrCatPrintf(str,"include"); break;
-                case KW_CAST:        aoStrCatPrintf(str,"cast"); break;
-                case KW_SIZEOF:      aoStrCatPrintf(str,"sizeof");  break;
-                case KW_RETURN:      aoStrCatPrintf(str,"return");  break;
-                case KW_SWITCH:      aoStrCatPrintf(str,"switch");  break;
-                case KW_CASE:        aoStrCatPrintf(str,"case");    break;
-                case KW_BREAK:       aoStrCatPrintf(str,"break");   break;
-                case KW_CONTINUE:    aoStrCatPrintf(str,"continue"); break;
-                case KW_ASM:         aoStrCatPrintf(str,"asm");     break;
-                case KW_ASM_EXTERN:  aoStrCatPrintf(str,"_extern"); break;
-                case KW_EXTERN:      aoStrCatPrintf(str,"extern");  break;
-                case KW_PRIVATE:     aoStrCatPrintf(str,"private");  break;
-                case KW_INLINE:      aoStrCatPrintf(str,"inline");  break;
-                case KW_FOR:         aoStrCatPrintf(str,"for");     break;
-                case KW_WHILE:       aoStrCatPrintf(str,"while");   break;
-                case KW_VOLATILE:    aoStrCatPrintf(str,"volatile"); break;
-                case KW_GOTO:        aoStrCatPrintf(str,"goto");    break;
-                case KW_IF:          aoStrCatPrintf(str,"if");      break;
-                case KW_ELSE:        aoStrCatPrintf(str,"else");    break;
-                case KW_ELIF:        aoStrCatPrintf(str,"elif");    break;
-                case KW_IF_NDEF:     aoStrCatPrintf(str,"ifndef");  break;
-                case KW_IF_DEF:      aoStrCatPrintf(str,"ifdef");   break;
-                case KW_ELIF_DEF:    aoStrCatPrintf(str,"elifdef");   break;
-                case KW_ENDIF:       aoStrCatPrintf(str,"endif");   break;
-                case KW_UNDEF:       aoStrCatPrintf(str,"undef");   break;
-                case KW_AUTO:        aoStrCatPrintf(str,"auto");    break;
-                case KW_DEFAULT:     aoStrCatPrintf(str,"default"); break;
-                case KW_DO:          aoStrCatPrintf(str,"do");      break;
-                case KW_STATIC:      aoStrCatPrintf(str,"static");  break;
-                case KW_DEFINED:     aoStrCatPrintf(str,"defined"); break;
-
-                case KW_PP_IF: aoStrCatPrintf(str,"#if"); break;   
-                case KW_PP_ELSE: aoStrCatPrintf(str,"#else"); break;   
-                case KW_PP_DEFINE: aoStrCatPrintf(str,"#define"); break;  
-                case KW_PP_IF_NDEF: aoStrCatPrintf(str,"#ifndef"); break; 
-                case KW_PP_IF_DEF: aoStrCatPrintf(str,"#ifdef"); break;
-                case KW_PP_ELIF_DEF:aoStrCatPrintf(str,"#elifdef"); break;
-                case KW_PP_ENDIF: aoStrCatPrintf(str,"#endif"); break;   
-                case KW_PP_ELIF: aoStrCatPrintf(str,"#elif"); break;    
-                case KW_PP_DEFINED: aoStrCatPrintf(str,"#defined"); break; 
-                case KW_PP_UNDEF:  aoStrCatPrintf(str,"#undef"); break;  
-                case KW_PP_ERROR: aoStrCatPrintf(str,"#error"); break;   
-
-                default:
-                    loggerPanic("line %d: Keyword %.*s: is not defined\n",
-                            tok->line,tok->len,tok->start);
-            }
-            return aoStrMove(str);
-        }
+    case TK_COMMENT: {
+        aoStrCatPrintf(str, "TK_COMMENT    %.*s", tok->len, tok->start);
+        return aoStrMove(str);
     }
-    loggerPanic("line %d: Unexpected type %s |%.*s|\n",
-            tok->line,lexemeTypeToString(tok->tk_type),tok->len,tok->start);
+    case TK_IDENT:
+        aoStrCatPrintf(str, "TK_IDENT      %.*s", tok->len, tok->start);
+        return aoStrMove(str);
+    case TK_CHAR_CONST:
+        aoStrCatPrintf(str, "TK_CHAR_CONST %x", tok->i64);
+        return aoStrMove(str);
+    case TK_PUNCT: {
+        char *tmp = lexemePunctToString(tok->i64);
+        aoStrCatPrintf(str, "TK_PUNCT      %s", tmp);
+        return aoStrMove(str);
+    }
+    case TK_I64:
+        aoStrCatPrintf(str, "TK_I64        %lld", tok->i64);
+        return aoStrMove(str);
+    case TK_F64:
+        aoStrCatPrintf(str, "TK_F64        %g", tok->f64);
+        return aoStrMove(str);
+    case TK_STR:
+        aoStrCatPrintf(str, "TK_STR        \"%.*s\"", tok->len, tok->start);
+        return aoStrMove(str);
+    case TK_EOF:
+        aoStrCatPrintf(str, "TK_EOF");
+        return aoStrMove(str);
+    case TK_KEYWORD: {
+        aoStrCatPrintf(str, "TK_KEYWORD    ");
+        switch (tok->i64) {
+        case KW_CLASS:
+            aoStrCatPrintf(str, "class");
+            break;
+        case KW_UNION:
+            aoStrCatPrintf(str, "union");
+            break;
+        case KW_U0:
+            aoStrCatPrintf(str, "U0");
+            break;
+        case KW_BOOL:
+            aoStrCatPrintf(str, "Bool");
+            break;
+        case KW_I8:
+            aoStrCatPrintf(str, "I8");
+            break;
+        case KW_U8:
+            aoStrCatPrintf(str, "U8");
+            break;
+        case KW_I16:
+            aoStrCatPrintf(str, "I16");
+            break;
+        case KW_U16:
+            aoStrCatPrintf(str, "U16");
+            break;
+        case KW_I32:
+            aoStrCatPrintf(str, "I32");
+            break;
+        case KW_U32:
+            aoStrCatPrintf(str, "U32");
+            break;
+        case KW_I64:
+            aoStrCatPrintf(str, "I64");
+            break;
+        case KW_U64:
+            aoStrCatPrintf(str, "U64");
+            break;
+        case KW_F64:
+            aoStrCatPrintf(str, "F64");
+            break;
+        case KW_PUBLIC:
+            aoStrCatPrintf(str, "public");
+            break;
+        case KW_ATOMIC:
+            aoStrCatPrintf(str, "atomic");
+            break;
+        case KW_DEFINE:
+            aoStrCatPrintf(str, "define");
+            break;
+        case KW_PP_INCLUDE:
+            aoStrCatPrintf(str, "include");
+            break;
+        case KW_CAST:
+            aoStrCatPrintf(str, "cast");
+            break;
+        case KW_SIZEOF:
+            aoStrCatPrintf(str, "sizeof");
+            break;
+        case KW_RETURN:
+            aoStrCatPrintf(str, "return");
+            break;
+        case KW_SWITCH:
+            aoStrCatPrintf(str, "switch");
+            break;
+        case KW_CASE:
+            aoStrCatPrintf(str, "case");
+            break;
+        case KW_BREAK:
+            aoStrCatPrintf(str, "break");
+            break;
+        case KW_CONTINUE:
+            aoStrCatPrintf(str, "continue");
+            break;
+        case KW_ASM:
+            aoStrCatPrintf(str, "asm");
+            break;
+        case KW_ASM_EXTERN:
+            aoStrCatPrintf(str, "_extern");
+            break;
+        case KW_EXTERN:
+            aoStrCatPrintf(str, "extern");
+            break;
+        case KW_PRIVATE:
+            aoStrCatPrintf(str, "private");
+            break;
+        case KW_INLINE:
+            aoStrCatPrintf(str, "inline");
+            break;
+        case KW_FOR:
+            aoStrCatPrintf(str, "for");
+            break;
+        case KW_WHILE:
+            aoStrCatPrintf(str, "while");
+            break;
+        case KW_VOLATILE:
+            aoStrCatPrintf(str, "volatile");
+            break;
+        case KW_GOTO:
+            aoStrCatPrintf(str, "goto");
+            break;
+        case KW_IF:
+            aoStrCatPrintf(str, "if");
+            break;
+        case KW_ELSE:
+            aoStrCatPrintf(str, "else");
+            break;
+        case KW_ELIF:
+            aoStrCatPrintf(str, "elif");
+            break;
+        case KW_IF_NDEF:
+            aoStrCatPrintf(str, "ifndef");
+            break;
+        case KW_IF_DEF:
+            aoStrCatPrintf(str, "ifdef");
+            break;
+        case KW_ELIF_DEF:
+            aoStrCatPrintf(str, "elifdef");
+            break;
+        case KW_ENDIF:
+            aoStrCatPrintf(str, "endif");
+            break;
+        case KW_UNDEF:
+            aoStrCatPrintf(str, "undef");
+            break;
+        case KW_AUTO:
+            aoStrCatPrintf(str, "auto");
+            break;
+        case KW_DEFAULT:
+            aoStrCatPrintf(str, "default");
+            break;
+        case KW_DO:
+            aoStrCatPrintf(str, "do");
+            break;
+        case KW_STATIC:
+            aoStrCatPrintf(str, "static");
+            break;
+        case KW_DEFINED:
+            aoStrCatPrintf(str, "defined");
+            break;
+
+        case KW_PP_IF:
+            aoStrCatPrintf(str, "#if");
+            break;
+        case KW_PP_ELSE:
+            aoStrCatPrintf(str, "#else");
+            break;
+        case KW_PP_DEFINE:
+            aoStrCatPrintf(str, "#define");
+            break;
+        case KW_PP_IF_NDEF:
+            aoStrCatPrintf(str, "#ifndef");
+            break;
+        case KW_PP_IF_DEF:
+            aoStrCatPrintf(str, "#ifdef");
+            break;
+        case KW_PP_ELIF_DEF:
+            aoStrCatPrintf(str, "#elifdef");
+            break;
+        case KW_PP_ENDIF:
+            aoStrCatPrintf(str, "#endif");
+            break;
+        case KW_PP_ELIF:
+            aoStrCatPrintf(str, "#elif");
+            break;
+        case KW_PP_DEFINED:
+            aoStrCatPrintf(str, "#defined");
+            break;
+        case KW_PP_UNDEF:
+            aoStrCatPrintf(str, "#undef");
+            break;
+        case KW_PP_ERROR:
+            aoStrCatPrintf(str, "#error");
+            break;
+
+        default:
+            loggerPanic("line %d: Keyword %.*s: is not defined\n", tok->line,
+                        tok->len, tok->start);
+        }
+        return aoStrMove(str);
+    }
+    default:;
+    }
+    loggerPanic("line %d: Unexpected type %s |%.*s|\n", tok->line,
+                lexemeTypeToString(tok->tk_type), tok->len, tok->start);
 }
 
 /* Print one lexeme */
@@ -492,24 +709,25 @@ void lexemePrint(Lexeme *le) {
     if (le) {
         char *str = lexemeToString(le);
         printf("%s\n", str);
-      //  free(str);
+        //  free(str);
     }
 }
 
 static char lexNextChar(Lexer *l) {
     l->start = l->ptr;
-    LexFile *lex_file;
     char ch = '\0';
     if (l->ptr) {
         ch = *l->ptr;
     }
     if (ch == '\0') {
-        if (listEmpty(l->files)) return '\0';
+        LexFile *lex_file;
+        if (listEmpty(l->files))
+            return '\0';
         if ((lex_file = listPop(l->files)) == NULL) {
             return '\0';
         }
         l->cur_file = lex_file;
-        l->ptr = lex_file->ptr; 
+        l->ptr = lex_file->ptr;
         l->lineno = lex_file->lineno;
         ch = *l->ptr;
         l->cur_ch = ch;
@@ -529,11 +747,11 @@ static void lexRewindChar(Lexer *l) {
 }
 
 /* Doese the next character match the expected character */
-static int lexPeekMatch(Lexer *l, char expected) {
+static int lexPeekMatch(const Lexer *l, char expected) {
     return *l->ptr == expected;
 }
 
-static char lexPeek(Lexer *l) {
+static char lexPeek(const Lexer *l) {
     return *l->ptr;
 }
 
@@ -543,15 +761,15 @@ char *lexReadfile(char *path, ssize_t *_len) {
     if ((fd = open(path, O_RDONLY, 0644)) == -1) {
         loggerPanic("Failed to open file: %s\n", path);
     }
- 
+
     int len = lseek(fd, 0, SEEK_END);
     lseek(fd, 0, SEEK_SET);
 
     /* Add a `+1` for `\0` */
-    char *buf = (char *)malloc((sizeof(char) * len)+1);
+    char *buf = (char *)malloc((sizeof(char) * len) + 1);
     int size = 0;
     int rbytes = 0;
-    while ((rbytes = read(fd,buf,len)) != 0) {
+    while ((rbytes = read(fd, buf, len)) != 0) {
         size += rbytes;
     }
 
@@ -566,7 +784,7 @@ char *lexReadfile(char *path, ssize_t *_len) {
 }
 
 void lexPushFile(Lexer *l, aoStr *filename) {
-    /* We need to save what we are currently lexing and 
+    /* We need to save what we are currently lexing and
      * make the file we've just seen the file we want to lex */
     LexFile *f = (LexFile *)malloc(sizeof(LexFile));
     ssize_t file_len = 0;
@@ -580,9 +798,9 @@ void lexPushFile(Lexer *l, aoStr *filename) {
     f->src = src_code;
     f->lineno = 1;
     f->filename = filename;
-    strMapAdd(l->seen_files,filename->data,filename);
+    strMapAdd(l->seen_files, filename->data, filename);
     if (l->cur_file) {
-        listAppend(l->files,l->cur_file);
+        listAppend(l->files, l->cur_file);
     }
     l->cur_file = f;
     l->ptr = f->ptr;
@@ -604,9 +822,9 @@ static void lexSkipCodeComment(Lexer *l) {
                 l->lineno++;
             }
             if (*l->ptr == '*' && *(l->ptr + 1) == '/') {
-                //while (*l->ptr != '\n') {
-                //    l->ptr++;
-                //}
+                // while (*l->ptr != '\n') {
+                //     l->ptr++;
+                // }
                 l->ptr += 2;
                 break;
             }
@@ -615,9 +833,9 @@ static void lexSkipCodeComment(Lexer *l) {
     }
 }
 
-static int countNumberLen(Lexer *l, char *ptr, int *isfloat, int *ishex,
+static int countNumberLen(const Lexer *l, char *ptr, int *isfloat, int *ishex,
                           int *err) {
-    char *start = ptr;
+    const char *start = ptr;
     int seen_e = 0;
 
     while (!isNumTerminator(*ptr)) {
@@ -656,7 +874,8 @@ static int countNumberLen(Lexer *l, char *ptr, int *isfloat, int *ishex,
         /* Anything else is invalid */
         default:
             if (!isHex(*ptr)) {
-                loggerWarning("line %d: Number errored with char: '%c'\n",l->lineno,*ptr);
+                loggerWarning("line %d: Number errored with char: '%c'\n",
+                              l->lineno, *ptr);
                 *err = 1;
                 return -1;
             }
@@ -668,7 +887,7 @@ static int countNumberLen(Lexer *l, char *ptr, int *isfloat, int *ishex,
     /* Floating point hex does not exist */
     if (*isfloat && *ishex) {
         *err = 1;
-        loggerWarning("line %d: LEX error is float and ishex\n",l->lineno);
+        loggerWarning("line %d: LEX error is float and ishex\n", l->lineno);
         return -1;
     }
 
@@ -707,8 +926,8 @@ finish:
     return TK_IDENT;
 }
 
-/* As this function escapes strings we pass in `_real_len` to be able 
- * to capture the length of the string minus escape sequences. 
+/* As this function escapes strings we pass in `_real_len` to be able
+ * to capture the length of the string minus escape sequences.
  * The string is allocated from the lexers arean not the global allocator */
 char *lexString(Lexer *l, char terminator, long *_real_len, int *_buffer_len) {
     unsigned int capacity = 64;
@@ -732,73 +951,95 @@ char *lexString(Lexer *l, char terminator, long *_real_len, int *_buffer_len) {
 
         if (!ch || ch == terminator) {
             goto done;
-        } else if (ch == '\\') {
+        }
+
+        if (ch == '\\') {
             ch = lexNextChar(l);
 
             buffer[len++] = '\\';
             switch (ch) {
-                case '\\': buffer[len++] = '\\'; break;
-                case '\'': buffer[len++] = '\''; break;
-                case '0':  buffer[len++] = '0' ; break;
-                case '`':  buffer[len++] = '`' ; break;
-                case '"':  buffer[len++] = '"' ; break;
-                case 'n':  buffer[len++] = 'n' ; break;
-                case 'r':  buffer[len++] = 'r' ; break;
-                case 't':  buffer[len++] = 't' ; break;
-                case 'b':  buffer[len++] = 'b' ; break;
-                case 'f':  buffer[len++] = 'f' ; break;
-                case 'v':  
-                    buffer[len++] = 'x';
-                    buffer[len++] = '0';
-                    buffer[len++] = 'B';
-                    break;
+            case '\\':
+                buffer[len++] = '\\';
+                break;
+            case '\'':
+                buffer[len++] = '\'';
+                break;
+            case '0':
+                buffer[len++] = '0';
+                break;
+            case '`':
+                buffer[len++] = '`';
+                break;
+            case '"':
+                buffer[len++] = '"';
+                break;
+            case 'n':
+                buffer[len++] = 'n';
+                break;
+            case 'r':
+                buffer[len++] = 'r';
+                break;
+            case 't':
+                buffer[len++] = 't';
+                break;
+            case 'b':
+                buffer[len++] = 'b';
+                break;
+            case 'f':
+                buffer[len++] = 'f';
+                break;
+            case 'v':
+                buffer[len++] = 'x';
+                buffer[len++] = '0';
+                buffer[len++] = 'B';
+                break;
 
-                case 'x':
-                case 'X':
-                    is_bytes = 1;
-                    buffer[len++] = 'x';
-                    buffer[len++] = toupper(lexNextChar(l));
-                    buffer[len++] = toupper(lexNextChar(l));
-                    break;
+            case 'x':
+            case 'X':
+                is_bytes = 1;
+                buffer[len++] = 'x';
+                buffer[len++] = toupper(lexNextChar(l));
+                buffer[len++] = toupper(lexNextChar(l));
+                break;
             default:
                 loggerPanic("Line: %d - Invalid escape character: '%c'\n",
-                        l->lineno, (char)ch);
+                            l->lineno, (char)ch);
             }
         } else {
-            /* Because HC can have multi line strings, tabs or other escaped 
+            /* Because HC can have multi line strings, tabs or other escaped
              * characters which are typeable we need to escape them. */
             switch (ch) {
-                case '\n':
-                    buffer[len++] = '\\';
-                    buffer[len++] = 'n';
-                    break;
-                case '\t':
-                    buffer[len++] = '\\';
-                    buffer[len++] = 't';
-                    break;
-                case '\r':
-                    buffer[len++] = '\\';
-                    buffer[len++] = 'r';
-                    break;
-                case '\f':
-                    buffer[len++] = '\\';
-                    buffer[len++] = 'f';
-                    break;
-                case '\v':
-                    buffer[len++] = '\\';
-                    buffer[len++] = 'x';
-                    buffer[len++] = '0';
-                    buffer[len++] = 'B';
-                    break;
-                default:
-                    buffer[len++] = ch;
-                    break;
+            case '\n':
+                buffer[len++] = '\\';
+                buffer[len++] = 'n';
+                break;
+            case '\t':
+                buffer[len++] = '\\';
+                buffer[len++] = 't';
+                break;
+            case '\r':
+                buffer[len++] = '\\';
+                buffer[len++] = 'r';
+                break;
+            case '\f':
+                buffer[len++] = '\\';
+                buffer[len++] = 'f';
+                break;
+            case '\v':
+                buffer[len++] = '\\';
+                buffer[len++] = 'x';
+                buffer[len++] = '0';
+                buffer[len++] = 'B';
+                break;
+            default:
+                buffer[len++] = ch;
+                break;
             }
         }
     }
 
 done:
-    /* XXX: Should raise exception if we run out of tokens as it is 
+    /* XXX: Should raise exception if we run out of tokens as it is
      * an unterminated string. */
     if (!is_bytes) {
         real_len++;
@@ -809,10 +1050,10 @@ done:
     return buffer;
 }
 
-/* Length of the char const is returned, it OR's in at max 8 characters. 
+/* Length of the char const is returned, it OR's in at max 8 characters.
  * A long being 64 bits and 64/8 = 8. */
 unsigned long lexCharConst(Lexer *l) {
-    unsigned long char_const = 0, idx;
+    unsigned long char_const = 0;
     long hex_num = 0;
     long len;
     char ch;
@@ -822,70 +1063,91 @@ unsigned long lexCharConst(Lexer *l) {
         if (!ch || ch == '\'') {
             break;
         }
-        idx = len * 8;
+        unsigned long idx = len * 8;
         if (ch == '\\') {
             ch = lexNextChar(l);
             switch (ch) {
-                case '0':  char_const |= (unsigned long)'\0' << ((unsigned long)idx); break;
-                case '\'': char_const |= (unsigned long)'\'' << ((unsigned long)idx); break;
-                case '`':  char_const |= (unsigned long)'`'  << ((unsigned long)idx); break;
-                case '\"': char_const |= (unsigned long)'\"' << ((unsigned long)idx); break;
-                case 'd':  char_const |= (unsigned long)'$'  << ((unsigned long)idx); break;
-                case 'n':  {
-                    char_const |= (unsigned long)'\n' << ((unsigned long)idx);
-                    break;
-                }
-                case 'r':  char_const |= (unsigned long)'\r' << ((unsigned long)idx); break;
-                case 't':  char_const |= (unsigned long)'\t' << ((unsigned long)idx); break;
-                case 'v':  char_const |= (unsigned long)'\v' << ((unsigned long)idx); break;
-                case 'f':  char_const |= (unsigned long)'\f' << ((unsigned long)idx); break;
-                case 'x':
-                case 'X':
-                    for (int i = 0; i < 2; ++i) {
-                        ch = toupper(lexNextChar(l));
-                        if (isHex(ch)) {
-                            if (ch <= '9') {
-                                hex_num |= (unsigned long)(hex_num<<4)+ch-'0';
-                            } else {
-                                hex_num |= (unsigned long)(hex_num<<4)+ch-'A'+10;
-                            }
+            case '0':
+                char_const |= (unsigned long)'\0' << ((unsigned long)idx);
+                break;
+            case '\'':
+                char_const |= (unsigned long)'\'' << ((unsigned long)idx);
+                break;
+            case '`':
+                char_const |= (unsigned long)'`' << ((unsigned long)idx);
+                break;
+            case '\"':
+                char_const |= (unsigned long)'\"' << ((unsigned long)idx);
+                break;
+            case 'd':
+                char_const |= (unsigned long)'$' << ((unsigned long)idx);
+                break;
+            case 'n': {
+                char_const |= (unsigned long)'\n' << ((unsigned long)idx);
+                break;
+            }
+            case 'r':
+                char_const |= (unsigned long)'\r' << ((unsigned long)idx);
+                break;
+            case 't':
+                char_const |= (unsigned long)'\t' << ((unsigned long)idx);
+                break;
+            case 'v':
+                char_const |= (unsigned long)'\v' << ((unsigned long)idx);
+                break;
+            case 'f':
+                char_const |= (unsigned long)'\f' << ((unsigned long)idx);
+                break;
+            case 'x':
+            case 'X':
+                for (int i = 0; i < 2; ++i) {
+                    ch = toupper(lexNextChar(l));
+                    if (isHex(ch)) {
+                        if (ch <= '9') {
+                            hex_num |= (unsigned long)(hex_num << 4) + ch - '0';
                         } else {
-                            break;
+                            hex_num |= (unsigned long)(hex_num << 4) + ch -
+                                    'A' + 10;
                         }
+                    } else {
+                        break;
                     }
-                    char_const |= (unsigned long)hex_num << (unsigned long)(idx);
-                    break;
-                default:
-                    char_const |= (unsigned long)'\\' << (unsigned long)(idx);
-                    break;
+                }
+                char_const |= (unsigned long)hex_num << (unsigned long)(idx);
+                break;
+            default:
+                char_const |= (unsigned long)'\\' << (unsigned long)(idx);
+                break;
             }
         } else {
-            char_const |= (unsigned long)(((unsigned long)ch) << ((unsigned long)(idx)));
+            char_const |= (unsigned long)(((unsigned long)ch)
+                                          << ((unsigned long)(idx)));
         }
     }
 
     if (ch != '\'' && lexPeek(l) != '\'') {
-        loggerPanic("line %d: Char const limited to 8 characters!\n",l->lineno);
+        loggerPanic("line %d: Char const limited to 8 characters!\n",
+                    l->lineno);
     }
 
     /* Consume next character if it is the end of the char const */
     if (lexPeek(l) == '\'') {
         lexNextChar(l);
-    } 
+    }
     l->cur_i64 = char_const;
     l->cur_strlen = len;
     return TK_CHAR_CONST;
 }
 
 int lexNumeric(Lexer *l, int _isfloat) {
-    int ishex, isfloat, err, numlen;
+    int ishex, err;
     char *endptr;
 
-    isfloat = _isfloat;
+    int isfloat = _isfloat;
 
     ishex = isfloat = err = 0;
     char *start = l->ptr - 1;
-    numlen = countNumberLen(l, start, &isfloat, &ishex, &err);
+    int numlen = countNumberLen(l, start, &isfloat, &ishex, &err);
     if (err) {
         return -1;
     }
@@ -907,42 +1169,42 @@ int lexNumeric(Lexer *l, int _isfloat) {
 
 LexerTypes *lexPreProcDirective(Lexer *l) {
     Lexeme le;
-    if (!lex(l,&le)) return 0;
+    if (!lex(l, &le))
+        return 0;
     char buffer[32];
-    ssize_t len = snprintf(buffer,sizeof(buffer),"#%.*s",le.len,le.start);
-    LexerTypes *type = strMapGetLen(l->symbol_table,buffer,len);
+    ssize_t len = snprintf(buffer, sizeof(buffer), "#%.*s", le.len, le.start);
+    LexerTypes *type = strMapGetLen(l->symbol_table, buffer, len);
     if (!type) {
-        loggerPanic("line %d: invalid preprocessor directive '%s'\n", le.line, buffer);
+        loggerPanic("line %d: invalid preprocessor directive '%s'\n", le.line,
+                    buffer);
     }
     return type;
 }
 
 int lex(Lexer *l, Lexeme *le) {
-    char ch, *start;
-    int tk_type;
+    int tk_type = 0;
     LexerTypes *type;
 
     while (1) {
-        ch = lexNextChar(l);
-        start = l->start;
+        const char ch = lexNextChar(l);
+        char *start = l->start;
 
         switch (ch) {
         case '\r':
         case '\n':
             l->lineno++;
-            if (l->flags & (CCF_ACCEPT_NEWLINES|CCF_ACCEPT_WHITESPACE)) {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+            if (l->flags & (CCF_ACCEPT_NEWLINES | CCF_ACCEPT_WHITESPACE)) {
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
                 return 1;
             }
             break;
 
         case ' ':
             if (l->flags & (CCF_ACCEPT_WHITESPACE)) {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
                 return 1;
             }
             break;
-
 
         case '\0':
             return 0;
@@ -950,18 +1212,13 @@ int lex(Lexer *l, Lexeme *le) {
         case 'a' ... 'z':
         case 'A' ... 'Z':
         case '_':
-            if ((tk_type = lexIdentifier(l, ch)) == -1) {
-                loggerPanic("line %d: Lex error while lexing lexIdentifier\n",
-                        l->lineno);
-                goto error;
-            }
-
             le->start = start;
             le->len = l->cur_strlen;
             le->tk_type = tk_type;
             le->line = l->lineno;
 
-            if ((type = strMapGetLen(l->symbol_table,le->start,le->len)) != NULL) {
+            if ((type = strMapGetLen(l->symbol_table, le->start, le->len)) !=
+                NULL) {
                 le->tk_type = TK_KEYWORD;
                 le->i64 = type->kind;
                 type = NULL;
@@ -969,9 +1226,9 @@ int lex(Lexer *l, Lexeme *le) {
             return 1;
 
         case '0' ... '9':
-            if ((tk_type = lexNumeric(l,0)) == -1) {
+            if ((tk_type = lexNumeric(l, 0)) == -1) {
                 loggerPanic("line %d: Lex error while lexing lexNumeric\n",
-                        l->lineno);
+                            l->lineno);
                 goto error;
             }
             le->len = l->cur_strlen;
@@ -990,7 +1247,7 @@ int lex(Lexer *l, Lexeme *le) {
         case '\"': {
             le->len = 0;
             le->i64 = 0;
-            le->start = lexString(l,'"',&le->i64,&le->len);
+            le->start = lexString(l, '"', &le->i64, &le->len);
             le->tk_type = TK_STR;
             le->line = l->lineno;
             l->cur_str = NULL;
@@ -1000,7 +1257,7 @@ int lex(Lexer *l, Lexeme *le) {
 
         case '\'':
             lexCharConst(l);
-            le->start = start+1;
+            le->start = start + 1;
             le->len = l->cur_strlen;
             le->i64 = l->cur_i64;
             le->tk_type = TK_CHAR_CONST;
@@ -1011,11 +1268,11 @@ int lex(Lexer *l, Lexeme *le) {
 
         case '/':
             if (*l->ptr == '/' || *l->ptr == '*') {
-                start = l->ptr-1;
+                start = l->ptr - 1;
                 lexSkipCodeComment(l);
                 ssize_t lineno = l->lineno;
                 if (l->flags & CCF_ACCEPT_COMMENTS) {
-                    ssize_t len = l->ptr-start;
+                    ssize_t len = l->ptr - start;
                     le->start = start;
                     le->len = len;
                     le->line = lineno;
@@ -1023,13 +1280,13 @@ int lex(Lexer *l, Lexeme *le) {
                     return 1;
                 }
             } else {
-                if (lexPeekMatch(l,'=')) {
+                if (lexPeekMatch(l, '=')) {
                     lexNextChar(l);
-                    lexemeAssignOp(le,start,2,TK_DIV_EQU,l->lineno);
+                    lexemeAssignOp(le, start, 2, TK_DIV_EQU, l->lineno);
                     return 1;
                 } else {
-                /* Divide */
-                    lexemeAssignOp(le,start,1,ch,l->lineno);
+                    /* Divide */
+                    lexemeAssignOp(le, start, 1, ch, l->lineno);
                     return 1;
                 }
             }
@@ -1037,147 +1294,147 @@ int lex(Lexer *l, Lexeme *le) {
 
         case '=':
             /* Check for equality */
-            if (lexPeekMatch(l,'=')) {
+            if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_EQU_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_EQU_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
-        
+
         case '<':
-            if (lexPeekMatch(l,'=')) {
+            if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_LESS_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_LESS_EQU, l->lineno);
             } else if (lexPeekMatch(l, '<')) {
                 lexNextChar(l);
                 if (lexPeekMatch(l, '=')) {
                     lexNextChar(l);
-                    lexemeAssignOp(le,start,2,TK_SHL_EQU,l->lineno);
+                    lexemeAssignOp(le, start, 2, TK_SHL_EQU, l->lineno);
                 } else {
-                    lexemeAssignOp(le,start,2,TK_SHL,l->lineno);
+                    lexemeAssignOp(le, start, 2, TK_SHL, l->lineno);
                 }
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
-        
+
         case '>':
-            if (lexPeekMatch(l,'=')) {
+            if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_GREATER_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_GREATER_EQU, l->lineno);
             } else if (lexPeekMatch(l, '>')) {
                 lexNextChar(l);
                 if (lexPeekMatch(l, '=')) {
                     lexNextChar(l);
-                    lexemeAssignOp(le,start,2,TK_SHR_EQU,l->lineno);
+                    lexemeAssignOp(le, start, 2, TK_SHR_EQU, l->lineno);
                 } else {
-                    lexemeAssignOp(le,start,2,TK_SHR,l->lineno);
+                    lexemeAssignOp(le, start, 2, TK_SHR, l->lineno);
                 }
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '+':
-            if (lexPeekMatch(l,'+')) {
+            if (lexPeekMatch(l, '+')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_PLUS_PLUS,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_PLUS_PLUS, l->lineno);
             } else if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_ADD_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_ADD_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '-':
-            if (lexPeekMatch(l,'-')) {
+            if (lexPeekMatch(l, '-')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_MINUS_MINUS,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_MINUS_MINUS, l->lineno);
             } else if (lexPeekMatch(l, '>')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_ARROW,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_ARROW, l->lineno);
             } else if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_SUB_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_SUB_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
-        
+
         case '!':
-            if (lexPeekMatch(l,'=')) {
+            if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_NOT_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_NOT_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '&':
-            if (lexPeekMatch(l,'&')) {
+            if (lexPeekMatch(l, '&')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_AND_AND,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_AND_AND, l->lineno);
             } else if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_AND_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_AND_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '|':
-            if (lexPeekMatch(l,'|')) {
+            if (lexPeekMatch(l, '|')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_OR_OR,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_OR_OR, l->lineno);
             } else if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_OR_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_OR_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '*':
             if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_MUL_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_MUL_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '%':
             if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_MOD_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_MOD_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
-        
+
         case '^':
             if (lexPeekMatch(l, '=')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_XOR_EQU,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_XOR_EQU, l->lineno);
             } else {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
             }
             return 1;
 
         case '$':
         case '@':
             if (l->flags & CCF_ASM_BLOCK) {
-                lexemeAssignOp(le,start,1,ch,l->lineno);
+                lexemeAssignOp(le, start, 1, ch, l->lineno);
                 return 1;
             }
             break;
         case '.':
             if (isNum(lexPeek(l))) {
-                if ((tk_type = lexNumeric(l,0)) == -1) {
+                if ((tk_type = lexNumeric(l, 0)) == -1) {
                     loggerPanic("line %d: Lex error while lexing lexNumeric\n",
-                            l->lineno);
+                                l->lineno);
                     goto error;
                 }
                 le->len = l->ptr - start;
@@ -1191,22 +1448,22 @@ int lex(Lexer *l, Lexeme *le) {
                 le->ishex = l->ishex;
                 l->ishex = 0;
                 return 1;
-            } else if (lexPeekMatch(l,'.')) {
+            } else if (lexPeekMatch(l, '.')) {
                 lexNextChar(l);
-                if (lexPeekMatch(l,'.')) {
+                if (lexPeekMatch(l, '.')) {
                     lexNextChar(l);
-                    lexemeAssignOp(le,start,3,TK_ELLIPSIS,l->lineno);
+                    lexemeAssignOp(le, start, 3, TK_ELLIPSIS, l->lineno);
                     return 1;
                 }
                 loggerPanic("line %d: .. is an invalid token sequence\n",
-                        l->lineno);
+                            l->lineno);
             }
-            
-            lexemeAssignOp(le,start,1,ch,l->lineno);
+
+            lexemeAssignOp(le, start, 1, ch, l->lineno);
             return 1;
 
         case '\\':
-            lexemeAssignOp(le,start,1,'\\',l->lineno);
+            lexemeAssignOp(le, start, 1, '\\', l->lineno);
             return 1;
 
         case '#': {
@@ -1222,17 +1479,18 @@ int lex(Lexer *l, Lexeme *le) {
         case ',':
         case ';':
         case ':':
-            if (l->flags & CCF_MULTI_COLON && lexPeekMatch(l,':')) {
+            if (l->flags & CCF_MULTI_COLON && lexPeekMatch(l, ':')) {
                 lexNextChar(l);
-                lexemeAssignOp(le,start,2,TK_DBL_COLON,l->lineno);
+                lexemeAssignOp(le, start, 2, TK_DBL_COLON, l->lineno);
                 return 1;
             }
         case '[':
         case ']':
         case '{':
         case '}':
-            lexemeAssignOp(le,start,1,ch,l->lineno);
+            lexemeAssignOp(le, start, 1, ch, l->lineno);
             return 1;
+        default:;
         }
     }
 error:
@@ -1240,66 +1498,63 @@ error:
     return 0;
 }
 
-int lexHasFile(Lexer *l, aoStr *file) {
-    return strMapGet(l->seen_files,file->data) != NULL;
+int lexHasFile(const Lexer *l, const aoStr *file) {
+    return strMapGet(l->seen_files, file->data) != NULL;
 }
 
 void lexInclude(Lexer *l) {
-    aoStr *ident, *include_path;
+    aoStr *include_path;
     Lexeme next;
 
     lex(l, &next);
     if (tokenPunctIs(&next, '<')) {
         lex(l, &next);
-        ident = aoStrNew();
+        aoStr *ident = aoStrNew();
         do {
-            aoStrCatPrintf(ident, "%.*s", next.len,
-                    next.start);
+            aoStrCatPrintf(ident, "%.*s", next.len, next.start);
             lex(l, &next);
         } while (next.i64 != '>');
         include_path = aoStrNew();
-        aoStrCatPrintf(include_path, "%s/%s",
-                l->builtin_root, ident->data);
+        aoStrCatPrintf(include_path, "%s/%s", l->builtin_root, ident->data);
         aoStrRelease(ident);
     } else if (next.tk_type == TK_STR) {
         include_path = aoStrDupRaw(next.start, next.len);
     } else {
-        loggerPanic(
-                "line %d: Syntax is: #include \"<value>\" got: %s\n",
-                next.line,lexemeToString(&next));
+        loggerPanic("line %d: Syntax is: #include \"<value>\" got: %s\n",
+                    next.line, lexemeToString(&next));
     }
 
-    if (!lexHasFile(l,include_path)) {
-        lexPushFile(l,include_path);
+    if (!lexHasFile(l, include_path)) {
+        lexPushFile(l, include_path);
     } else {
         aoStrRelease(include_path);
     }
 }
 
 Lexeme *lexDefine(StrMap *macro_defs, Lexer *l) {
-    int tk_type,iters;
-    Lexeme next,*start,*end,*expanded,*macro;
-    aoStr *ident;
+    Lexeme next, *expanded, *macro;
     PtrVec *tokens = ptrVecNew();
 
-
-    tk_type = -1;
+    int tk_type = -1;
     /* <ident> <value> */
     lex(l, &next);
     if (next.tk_type != TK_IDENT) {
-        loggerPanic("line %d: Syntax is: #define <TK_IDENT> <value>\n",next.line);
+        loggerPanic("line %d: Syntax is: #define <TK_IDENT> <value>\n",
+                    next.line);
     }
 
-    ident = aoStrDupRaw(next.start, next.len);
+    const aoStr *ident = aoStrDupRaw(next.start, next.len);
     /* A define must be on one line a \n determines the end of a define */
     l->flags |= CCF_ACCEPT_NEWLINES;
-    iters = 0;
+    int iters = 0;
     do {
         iters++;
-        if (!lex(l,&next)) break;
+        if (!lex(l, &next))
+            break;
 
         if (next.tk_type == TK_IDENT) {
-            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
+            if ((macro = strMapGetLen(macro_defs, next.start, next.len)) !=
+                NULL) {
                 ptrVecPush(tokens, lexemeCopy(macro));
                 tk_type = macro->tk_type;
                 continue;
@@ -1308,64 +1563,67 @@ Lexeme *lexDefine(StrMap *macro_defs, Lexer *l) {
 
         if (tk_type == -1) {
             switch (next.tk_type) {
-                case TK_F64:
-                case TK_I64:
-                case TK_STR: 
-                case TK_CHAR_CONST:
-                    tk_type = next.tk_type;
-                    break;
+            case TK_F64:
+            case TK_I64:
+            case TK_STR:
+            case TK_CHAR_CONST:
+                tk_type = next.tk_type;
+                break;
+            default:;
             }
         }
-        if (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')) {
+        if (!tokenPunctIs(&next, '\n') && !tokenPunctIs(&next, '\0')) {
             ptrVecPush(tokens, lexemeCopy(&next));
         }
-    } while (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0'));
+    } while (!tokenPunctIs(&next, '\n') && !tokenPunctIs(&next, '\0'));
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
-    start = tokens->entries[0]; 
-    end = tokens->entries[tokens->size - 1];
+    Lexeme *start = tokens->entries[0];
+    const Lexeme *end = tokens->entries[tokens->size - 1];
 
     if (start == end && iters == 1) {
-        strMapAdd(macro_defs,ident->data,lexemeSentinal());
+        strMapAdd(macro_defs, ident->data, lexemeSentinal());
         ptrVecRelease(tokens);
         return NULL;
     }
 
     if (tk_type == -1) {
-        loggerPanic("line %d: Error while parsing #define %s; #define either be a numerical expression or a string\n",
-                next.line,ident->data);
+        loggerPanic(
+                "line %d: Error while parsing #define %s; #define either be a numerical expression or a string\n",
+                next.line, ident->data);
     }
 
     if (start == end) {
         expanded = lexemeCopy(start);
-        strMapAdd(macro_defs,ident->data,expanded);
+        strMapAdd(macro_defs, ident->data, expanded);
     } else {
-        /* XXX: this is a hack as sometimes the number of tokens in a macro 
-         * will exceed what is allowed in our ring buffer. Conveniently PtrVec 
+        /* XXX: this is a hack as sometimes the number of tokens in a macro
+         * will exceed what is allowed in our ring buffer. Conveniently PtrVec
          * has some fields we can use. */
         cctrlInitMacroProcessor(macro_proccessor);
         macro_proccessor->token_buffer->entries = (Lexeme **)tokens->entries;
         macro_proccessor->token_buffer->size = tokens->size;
-        macro_proccessor->token_buffer->capacity = roundUpToNextPowerOf2(tokens->size);
+        macro_proccessor->token_buffer->capacity = roundUpToNextPowerOf2(
+                tokens->size);
 
-        Ast *ast = parseExpr(macro_proccessor,16);
-        expanded = lexemeNew(start->start,end->len-start->len);
+        Ast *ast = parseExpr(macro_proccessor, 16);
+        expanded = lexemeNew(start->start, end->len - start->len);
         expanded->tk_type = tk_type;
         if (tk_type == TK_STR) {
             if (!ast && start->tk_type == TK_STR) {
-                expanded->start = strndup(start->start,start->len);
+                expanded->start = strndup(start->start, start->len);
                 expanded->len = start->len;
             } else if (ast && ast->kind != TK_STR && ast->kind != AST_STRING) {
                 loggerPanic("line %d: #define %s expected string but got: %s\n",
-                        next.line,ident->data,astKindToString(ast->kind));
+                            next.line, ident->data, astKindToString(ast->kind));
             } else if (ast && ast->kind == AST_STRING) {
                 /* Copy as we will free the AST which will free the string*/
-                expanded->start = strndup(ast->sval->data,ast->sval->len);
+                expanded->start = strndup(ast->sval->data, ast->sval->len);
                 expanded->len = ast->sval->len;
             } else {
-                loggerPanic("line: %d failed to parse #define %s\n",
-                        next.line, ident->data);
+                loggerPanic("line: %d failed to parse #define %s\n", next.line,
+                            ident->data);
             }
         } else if (tk_type == TK_F64) {
             expanded->f64 = (long double)evalFloatExpr(ast);
@@ -1374,12 +1632,12 @@ Lexeme *lexDefine(StrMap *macro_defs, Lexer *l) {
             if (ast) {
                 expanded->i64 = evalIntConstExpr(ast);
             } else {
-                printf("Failed to expand: %s\n",ident->data);
+                printf("Failed to expand: %s\n", ident->data);
                 expanded->i64 = -1;
             }
             expanded->line = start->line;
         }
-        strMapAdd(macro_defs,ident->data,expanded);
+        strMapAdd(macro_defs, ident->data, expanded);
     }
     for (ssize_t i = 0; i < tokens->size; ++i) {
         lexemeFree(tokens->entries[i]);
@@ -1395,82 +1653,87 @@ void lexUndef(StrMap *macro_defs, Lexer *l) {
 
     lex(l, &next);
     if (next.tk_type != TK_IDENT) {
-        loggerPanic("line %d: Syntax is: #undef <TK_IDENT>\n",next.line);
+        loggerPanic("line %d: Syntax is: #undef <TK_IDENT>\n", next.line);
     }
-    tmp_len = snprintf(tmp,sizeof(tmp),"%.*s",
-            next.len,next.start);
+    tmp_len = snprintf(tmp, sizeof(tmp), "%.*s", next.len, next.start);
     tmp[tmp_len] = '\0';
-    strMapRemove(macro_defs,tmp);
+    strMapRemove(macro_defs, tmp);
 }
 
-int lexPreProcIf(StrMap *macro_defs, Lexer *l) {
-    int tk_type,iters,should_collect;
-    PtrVec *macro_tokens;
-    Lexeme next,*start,*end,*expanded,*macro;
+int lexPreProcIf(const StrMap *macro_defs, Lexer *l) {
+    Lexeme next, *macro;
 
-    tk_type = -1;
-    should_collect = 0;
-    macro_tokens = ptrVecNew();
+    int tk_type = -1;
+    int should_collect = 0;
+    PtrVec *macro_tokens = ptrVecNew();
 
     /* An if must be on one line a \n determines the end of a define */
     l->flags |= CCF_ACCEPT_NEWLINES;
-    iters = 0;
+    int iters = 0;
 
-    if (!lex(l,&next)) {
+    if (!lex(l, &next)) {
         loggerPanic("line %d: Run out of tokens\n", l->lineno);
     }
 
-    while (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')){ 
+    while (!tokenPunctIs(&next, '\n') && !tokenPunctIs(&next, '\0')) {
         iters++;
 
-        if (tokenPunctIs(&next,'\\')) {
-            if (!lex(l,&next)) break;
-            if (!tokenPunctIs(&next,'\n')) {
-                loggerPanic("line %d: Invalid use of '\\' should be \\ \\n got %s\n",
+        if (tokenPunctIs(&next, '\\')) {
+            if (!lex(l, &next))
+                break;
+            if (!tokenPunctIs(&next, '\n')) {
+                loggerPanic(
+                        "line %d: Invalid use of '\\' should be \\ \\n got %s\n",
                         next.line, lexemeToString(&next));
             }
-            if (!lex(l,&next)) break;
-        } 
+            if (!lex(l, &next))
+                break;
+        }
 
         if (next.tk_type == TK_IDENT) {
-            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
-                ptrVecPush(macro_tokens,lexemeCopy(macro));
+            if ((macro = strMapGetLen(macro_defs, next.start, next.len)) !=
+                NULL) {
+                ptrVecPush(macro_tokens, lexemeCopy(macro));
                 tk_type = macro->tk_type;
             }
-            if (!lex(l,&next)) break;
+            if (!lex(l, &next))
+                break;
         }
 
         if (tk_type == -1) {
             switch (next.tk_type) {
-                case TK_F64:
-                case TK_I64:
-                case TK_CHAR_CONST:
-                    tk_type = next.tk_type;
-                    break;
+            case TK_F64:
+            case TK_I64:
+            case TK_CHAR_CONST:
+                tk_type = next.tk_type;
+                break;
             }
         }
-        if (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')) {
-            ptrVecPush(macro_tokens,lexemeCopy(&next));
+        if (!tokenPunctIs(&next, '\n') && !tokenPunctIs(&next, '\0')) {
+            ptrVecPush(macro_tokens, lexemeCopy(&next));
         }
-        if (!lex(l,&next)) break;
+        if (!lex(l, &next))
+            break;
     }
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
-    start = macro_tokens->entries[0];
-    end = macro_tokens->entries[macro_tokens->size-1];
+    const Lexeme *start = macro_tokens->entries[0];
+    const Lexeme *end = macro_tokens->entries[macro_tokens->size - 1];
 
     if (start == end && iters == 1) {
-        loggerPanic("line %d: a #if must evaluate some expression\n",next.line);
+        loggerPanic("line %d: a #if must evaluate some expression\n",
+                    next.line);
         return 0;
     }
     cctrlInitMacroProcessor(macro_proccessor);
     macro_proccessor->token_buffer->entries = (Lexeme **)macro_tokens->entries;
     macro_proccessor->token_buffer->size = macro_tokens->size;
-    macro_proccessor->token_buffer->capacity = roundUpToNextPowerOf2(macro_tokens->size);
+    macro_proccessor->token_buffer->capacity = roundUpToNextPowerOf2(
+            macro_tokens->size);
 
-    Ast *ast = parseExpr(macro_proccessor,16);
-    expanded = lexemeNew(start->start,end->len-start->len);
+    Ast *ast = parseExpr(macro_proccessor, 16);
+    Lexeme *expanded = lexemeNew(start->start, end->len - start->len);
     expanded->tk_type = tk_type;
 
     if (tk_type == TK_STR) {
@@ -1497,174 +1760,178 @@ int lexPreProcIf(StrMap *macro_defs, Lexer *l) {
 }
 
 /* Decide if we should collect tokens or not */
-int lexPreProcBoolean(Lexer *l, StrMap *macro_defs, Lexeme *le) {
-    Lexeme next,*macro;
+int lexPreProcBoolean(Lexer *l, const StrMap *macro_defs, const Lexeme *le) {
+    Lexeme next, *macro;
 
     switch (le->i64) {
-        case KW_PP_IF: {
-            int ok = lexPreProcIf(macro_defs,l);
-            if (ok) {
-                l->collecting = 1;
-                l->skip_else = 1;
-            } else {
-                l->collecting = 0;
-                l->skip_else = 0;
-            }
-            return ok;
-        }
-
-        case KW_PP_IF_DEF: {
-            lex(l,&next);
-            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
-                l->collecting = 1;
-                l->skip_else = 1;
-                return 1;
-            } 
-
+    case KW_PP_IF: {
+        int ok = lexPreProcIf(macro_defs, l);
+        if (ok) {
+            l->collecting = 1;
+            l->skip_else = 1;
+        } else {
             l->collecting = 0;
             l->skip_else = 0;
-            return 0;
         }
+        return ok;
+    }
 
-        case KW_PP_IF_NDEF: {
-            lex(l,&next);
-            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) == NULL) {
-                l->collecting = 0;
-                l->skip_else = 1;
-                return 1;
-            }
+    case KW_PP_IF_DEF: {
+        lex(l, &next);
+        if ((macro = strMapGetLen(macro_defs, next.start, next.len)) != NULL) {
             l->collecting = 1;
-            l->skip_else = 0;
-            return 0;
-        }
-
-        case KW_PP_ELIF: {
-            if (l->skip_else) return 0;
-            int ok = lexPreProcIf(macro_defs,l);
-            if (ok) {
-                l->skip_else = 1;
-            } else {
-                l->skip_else = 0;
-            }
-            return ok;
-        }
-
-        case KW_PP_ELIF_DEF: {
-            if (l->skip_else) return 0;
-            lex(l,&next);
-            if ((macro = strMapGetLen(macro_defs,next.start,next.len)) != NULL) {
-                l->collecting = 1;
-                l->skip_else = 1;
-                return 1;
-            }
-            l->collecting = 0;
-            l->skip_else = 0;
-            return 0;
-        }
-
-
-        case KW_PP_ELSE: {
-            if (l->skip_else) return 0;
-            l->collecting = 1;
+            l->skip_else = 1;
             return 1;
         }
 
-        case KW_PP_ENDIF:
-            l->skip_else = 0;
-            l->collecting = 1;
-            return 1;
+        l->collecting = 0;
+        l->skip_else = 0;
+        return 0;
+    }
 
-        default:
+    case KW_PP_IF_NDEF: {
+        lex(l, &next);
+        if ((macro = strMapGetLen(macro_defs, next.start, next.len)) == NULL) {
+            l->collecting = 0;
+            l->skip_else = 1;
+            return 1;
+        }
+        l->collecting = 1;
+        l->skip_else = 0;
+        return 0;
+    }
+
+    case KW_PP_ELIF: {
+        if (l->skip_else)
             return 0;
+        int ok = lexPreProcIf(macro_defs, l);
+        if (ok) {
+            l->skip_else = 1;
+        } else {
+            l->skip_else = 0;
+        }
+        return ok;
+    }
+
+    case KW_PP_ELIF_DEF: {
+        if (l->skip_else)
+            return 0;
+        lex(l, &next);
+        if ((macro = strMapGetLen(macro_defs, next.start, next.len)) != NULL) {
+            l->collecting = 1;
+            l->skip_else = 1;
+            return 1;
+        }
+        l->collecting = 0;
+        l->skip_else = 0;
+        return 0;
+    }
+
+    case KW_PP_ELSE: {
+        if (l->skip_else)
+            return 0;
+        l->collecting = 1;
+        return 1;
+    }
+
+    case KW_PP_ENDIF:
+        l->skip_else = 0;
+        l->collecting = 1;
+        return 1;
+
+    default:
+        return 0;
     }
 }
 
 Lexeme *lexToken(StrMap *macro_defs, Lexer *l) {
-    Lexeme le,next,*copy;
+    Lexeme le, next, *copy;
 
     macro_proccessor->macro_defs = macro_defs;
 
     while (1) {
-        if (!lex(l,&le)) {
+        if (!lex(l, &le)) {
             return NULL;
         }
 
         if (l->flags & (CCF_ASM_BLOCK) && tokenPunctIs(&le, '}')) {
             copy = lexemeCopy(&le);
             /* turn off assembly lexing */
-            l->flags &= ~(CCF_MULTI_COLON|CCF_ACCEPT_NEWLINES|CCF_ASM_BLOCK);
+            l->flags &= ~(CCF_MULTI_COLON | CCF_ACCEPT_NEWLINES |
+                          CCF_ASM_BLOCK);
             return copy;
         }
 
         if (le.tk_type == TK_KEYWORD) {
             switch (le.i64) {
-                case KW_ASM:
-                    l->flags |= (CCF_MULTI_COLON|CCF_ACCEPT_NEWLINES|CCF_ASM_BLOCK);
-                    copy = lexemeCopy(&le);
-                    return copy;
+            case KW_ASM:
+                l->flags |= (CCF_MULTI_COLON | CCF_ACCEPT_NEWLINES |
+                             CCF_ASM_BLOCK);
+                copy = lexemeCopy(&le);
+                return copy;
 
-                case KW_PP_INCLUDE: {
-                    lexInclude(l);
-                    continue;
-                }
-                case KW_PP_DEFINE: {
-                    copy = lexDefine(macro_defs,l);
-                    continue;
-                }
-                case KW_PP_UNDEF: {
-                    lexUndef(macro_defs, l);
-                    continue;
-                }
+            case KW_PP_INCLUDE: {
+                lexInclude(l);
+                continue;
+            }
+            case KW_PP_DEFINE: {
+                copy = lexDefine(macro_defs, l);
+                continue;
+            }
+            case KW_PP_UNDEF: {
+                lexUndef(macro_defs, l);
+                continue;
+            }
 
-                case KW_PP_ELIF_DEF:
-                case KW_PP_ELIF:
-                case KW_PP_ELSE: {
-                    if (l->skip_else) {
-                        while (lex(l,&le)) {
-                            if (le.tk_type == TK_KEYWORD && le.i64 == KW_PP_ENDIF) {
-                                break;
-                            }
-                        }
-                        l->skip_else = 0;
-                    } else {
-                        int line = le.line;
-                        while ((lexPreProcBoolean(l,macro_defs,&le)) != 1) {
-                            int ok = lex(l,&le);
-                            if (!ok) {
-                                loggerPanic("line %d: Unterminated #if\n", line);
-                            }
+            case KW_PP_ELIF_DEF:
+            case KW_PP_ELIF:
+            case KW_PP_ELSE: {
+                if (l->skip_else) {
+                    while (lex(l, &le)) {
+                        if (le.tk_type == TK_KEYWORD && le.i64 == KW_PP_ENDIF) {
+                            break;
                         }
                     }
-                    continue;
-                }
-
-                case KW_PP_IF_DEF:
-                case KW_PP_IF_NDEF:
-                case KW_PP_IF: {
+                    l->skip_else = 0;
+                } else {
                     int line = le.line;
-                    while ((lexPreProcBoolean(l,macro_defs,&le)) != 1) {
-                        int ok = lex(l,&le);
+                    while ((lexPreProcBoolean(l, macro_defs, &le)) != 1) {
+                        int ok = lex(l, &le);
                         if (!ok) {
                             loggerPanic("line %d: Unterminated #if\n", line);
                         }
                     }
-                    continue;
                 }
-                case KW_PP_ENDIF:
-                    l->skip_else = 0;
-                    continue;
+                continue;
+            }
 
-                case KW_PP_ERROR:
-                    lex(l,&next);
-                    loggerPanic("line %d: %.*s",next.line,next.len,next.start);
-                    break;
+            case KW_PP_IF_DEF:
+            case KW_PP_IF_NDEF:
+            case KW_PP_IF: {
+                int line = le.line;
+                while ((lexPreProcBoolean(l, macro_defs, &le)) != 1) {
+                    int ok = lex(l, &le);
+                    if (!ok) {
+                        loggerPanic("line %d: Unterminated #if\n", line);
+                    }
+                }
+                continue;
+            }
+            case KW_PP_ENDIF:
+                l->skip_else = 0;
+                continue;
 
-                default:
-                    copy = lexemeCopy(&le);
-                    return copy;
+            case KW_PP_ERROR:
+                lex(l, &next);
+                loggerPanic("line %d: %.*s", next.line, next.len, next.start);
+                break;
+
+            default:
+                copy = lexemeCopy(&le);
+                return copy;
             }
         }
-        
+
         if (le.tk_type == TK_IDENT) {
             copy = lexemeCopy(&le);
             return copy;
@@ -1688,8 +1955,7 @@ static void lexReleaseLexFile(LexFile *lex_file) {
 }
 
 void lexReleaseAllFiles(Lexer *l) {
-    listRelease(l->all_source,
-            ((void (*)(void *))&lexReleaseLexFile));
+    listRelease(l->all_source, ((void (*)(void *))&lexReleaseLexFile));
 }
 
 char *lexerReportLine(Lexer *l, ssize_t lineno) {
@@ -1699,13 +1965,15 @@ char *lexerReportLine(Lexer *l, ssize_t lineno) {
     ssize_t size = l->cur_file->src->len;
     ssize_t line = 1;
     ssize_t i = 0;
-    
-    for (; i < size-1; ++i) {
+
+    for (; i < size - 1; ++i) {
         if (ptr[i] == '\n') {
             line++;
         }
-        if (ptr[i] == '\0') break;
-        if (line == lineno) break;
+        if (ptr[i] == '\0')
+            break;
+        if (line == lineno)
+            break;
     }
 
     i++;
@@ -1725,23 +1993,25 @@ char *lexerReportLine(Lexer *l, ssize_t lineno) {
 }
 
 int lexemeEq(Lexeme *l1, Lexeme *l2) {
-    if (l1->tk_type  != l2->tk_type) {
+    if (l1->tk_type != l2->tk_type) {
         return 0;
     }
 
     switch (l1->tk_type) {
-        case TK_STR:
-        case TK_IDENT: return l1->len == l2->len && !memcmp(l1->start,l2->start,l1->len);
+    case TK_STR:
+    case TK_IDENT:
+        return l1->len == l2->len && !memcmp(l1->start, l2->start, l1->len);
 
-        case TK_KEYWORD:
-        case TK_I64:
-        case TK_PUNCT:
-        case TK_EOF:
-        case TK_CHAR_CONST: return l1->i64 == l2->i64;
-        case TK_F64: return l1->f64 == l2->f64;
-        default:
-            loggerPanic("Cannot compare %s with %s\n",
-                        lexemeToString(l1),
-                        lexemeToString(l2));
+    case TK_KEYWORD:
+    case TK_I64:
+    case TK_PUNCT:
+    case TK_EOF:
+    case TK_CHAR_CONST:
+        return l1->i64 == l2->i64;
+    case TK_F64:
+        return l1->f64 == l2->f64;
+    default:
+        loggerPanic("Cannot compare %s with %s\n", lexemeToString(l1),
+                    lexemeToString(l2));
     }
 }

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -4,137 +4,137 @@
 #include <sys/types.h>
 
 #include "aostr.h"
-#include "map.h"
 #include "list.h"
+#include "map.h"
 
 #define LEX_MAX_IDENT_LEN  128
 #define LEX_CHAR_CONST_LEN 9
 
 /* TOKENS */
-#define TK_EOF          0
-#define TK_SUPERSCRIPT  0x301
-#define TK_SUBSCRIPT    0x302
-#define TK_NORMALSCRIPT 0x303
-#define TK_IDENT        0x300
-#define TK_STR          0x301
-#define TK_I64          0x302
-#define TK_CHAR_CONST   0x303
-#define TK_F64          0x304
-#define TK_PLUS_PLUS    0x305
-#define TK_MINUS_MINUS  0x306
-#define TK_DEREFERENCE  0x307
-#define TK_DBL_COLON    0x308
-#define TK_SHL          0x309
-#define TK_SHR          0x30A
-#define TK_EQU_EQU      0x30B
-#define TK_NOT_EQU      0x30C
-#define TK_LESS_EQU     0x30D
-#define TK_GREATER_EQU  0x30E
-#define TK_AND_AND      0x30F
-#define TK_OR_OR        0x310
-#define TK_XOR_XOR      0x311
-#define TK_SHL_EQU      0x312
-#define TK_SHR_EQU      0x313
-#define TK_MUL_EQU      0x314
-#define TK_DIV_EQU      0x315
-#define TK_AND_EQU      0x316
-#define TK_OR_EQU       0x317
-#define TK_XOR_EQU      0x318
-#define TK_ADD_EQU      0x319
-#define TK_SUB_EQU      0x31A
-#define TK_IF           0x31B
-#define TK_IFDEF        0x31C
-#define TK_IFNDEF       0x31D
-#define TK_IFAOT        0x31E
-#define TK_IFJIT        0x31F
-#define TK_ENDIF        0x320
-#define TK_ELSE         0x321
-#define TK_MOD_EQU      0x322
-#define TK_DOT_DOT      0x323
-#define TK_ELLIPSIS     0x324
-#define TK_INS_BIN      0x325
-#define TK_INS_BIN_SIZE 0x326
-#define TK_TKS_NUM      0x327
-#define TK_ARROW        0x328
-#define TK_PUNCT        0x329
-#define TK_PRE_PLUS_PLUS 0x330
+#define TK_EOF             0
+#define TK_SUPERSCRIPT     0x301
+#define TK_SUBSCRIPT       0x302
+#define TK_NORMALSCRIPT    0x303
+#define TK_IDENT           0x300
+#define TK_STR             0x301
+#define TK_I64             0x302
+#define TK_CHAR_CONST      0x303
+#define TK_F64             0x304
+#define TK_PLUS_PLUS       0x305
+#define TK_MINUS_MINUS     0x306
+#define TK_DEREFERENCE     0x307
+#define TK_DBL_COLON       0x308
+#define TK_SHL             0x309
+#define TK_SHR             0x30A
+#define TK_EQU_EQU         0x30B
+#define TK_NOT_EQU         0x30C
+#define TK_LESS_EQU        0x30D
+#define TK_GREATER_EQU     0x30E
+#define TK_AND_AND         0x30F
+#define TK_OR_OR           0x310
+#define TK_XOR_XOR         0x311
+#define TK_SHL_EQU         0x312
+#define TK_SHR_EQU         0x313
+#define TK_MUL_EQU         0x314
+#define TK_DIV_EQU         0x315
+#define TK_AND_EQU         0x316
+#define TK_OR_EQU          0x317
+#define TK_XOR_EQU         0x318
+#define TK_ADD_EQU         0x319
+#define TK_SUB_EQU         0x31A
+#define TK_IF              0x31B
+#define TK_IFDEF           0x31C
+#define TK_IFNDEF          0x31D
+#define TK_IFAOT           0x31E
+#define TK_IFJIT           0x31F
+#define TK_ENDIF           0x320
+#define TK_ELSE            0x321
+#define TK_MOD_EQU         0x322
+#define TK_DOT_DOT         0x323
+#define TK_ELLIPSIS        0x324
+#define TK_INS_BIN         0x325
+#define TK_INS_BIN_SIZE    0x326
+#define TK_TKS_NUM         0x327
+#define TK_ARROW           0x328
+#define TK_PUNCT           0x329
+#define TK_PRE_PLUS_PLUS   0x330
 #define TK_PRE_MINUS_MINUS 0x331
-#define TK_KEYWORD      0x332
-#define TK_COMMENT      0x333
+#define TK_KEYWORD         0x332
+#define TK_COMMENT         0x333
 
-#define KW_CLASS       (1<<0) /* Easy to see if struct or union */
-#define KW_UNION       (1<<1)
-#define KW_U0           0
+#define KW_CLASS (1 << 0) /* Easy to see if struct or union */
+#define KW_UNION (1 << 1)
+#define KW_U0    0
 /* Integers are odd numbers */
-#define KW_BOOL         3
-#define KW_I8           5
-#define KW_U8           7
-#define KW_I16          9
-#define KW_U16          11
-#define KW_I32          13
-#define KW_U32          15
-#define KW_I64          17
-#define KW_U64          19
+#define KW_BOOL 3
+#define KW_I8   5
+#define KW_U8   7
+#define KW_I16  9
+#define KW_U16  11
+#define KW_I32  13
+#define KW_U32  15
+#define KW_I64  17
+#define KW_U64  19
 /* back to even */
-#define KW_F64          4
-#define KW_PUBLIC       6
-#define KW_ATOMIC       8
-#define KW_DEFINE       10
-#define KW_PP_INCLUDE   12
-#define KW_CAST  14
-#define KW_SIZEOF       16
-#define KW_RETURN       18
-#define KW_SWITCH       20
-#define KW_CASE         22
-#define KW_BREAK        24
-#define KW_CONTINUE     26
-#define KW_ASM          28
-#define KW_ASM_EXTERN   30
-#define KW_EXTERN       32
-#define KW_PRIVATE      34
-#define KW_INLINE       36
-#define KW_FOR          38
-#define KW_WHILE        40
-#define KW_VOLATILE     42
-#define KW_GOTO         44
-#define KW_IF           46
-#define KW_ELSE         48
-#define KW_ELIF         50
-#define KW_IF_NDEF      52
-#define KW_IF_DEF       54
-#define KW_ENDIF        56
-#define KW_DEFINED      58
-#define KW_UNDEF        60
-#define KW_AUTO         62
-#define KW_DEFAULT      64
-#define KW_DO           66
-#define KW_STATIC       67
-#define KW_ELIF_DEF     68
-#define KW_PP_IF        69
-#define KW_PP_ELSE      70
-#define KW_PP_DEFINE    71
-#define KW_PP_IF_NDEF   72
-#define KW_PP_IF_DEF    73
-#define KW_PP_ELIF_DEF  74
-#define KW_PP_ENDIF     75
-#define KW_PP_ELIF      76
-#define KW_PP_DEFINED   77
-#define KW_PP_UNDEF     78
-#define KW_PP_ERROR     79
+#define KW_F64         4
+#define KW_PUBLIC      6
+#define KW_ATOMIC      8
+#define KW_DEFINE      10
+#define KW_PP_INCLUDE  12
+#define KW_CAST        14
+#define KW_SIZEOF      16
+#define KW_RETURN      18
+#define KW_SWITCH      20
+#define KW_CASE        22
+#define KW_BREAK       24
+#define KW_CONTINUE    26
+#define KW_ASM         28
+#define KW_ASM_EXTERN  30
+#define KW_EXTERN      32
+#define KW_PRIVATE     34
+#define KW_INLINE      36
+#define KW_FOR         38
+#define KW_WHILE       40
+#define KW_VOLATILE    42
+#define KW_GOTO        44
+#define KW_IF          46
+#define KW_ELSE        48
+#define KW_ELIF        50
+#define KW_IF_NDEF     52
+#define KW_IF_DEF      54
+#define KW_ENDIF       56
+#define KW_DEFINED     58
+#define KW_UNDEF       60
+#define KW_AUTO        62
+#define KW_DEFAULT     64
+#define KW_DO          66
+#define KW_STATIC      67
+#define KW_ELIF_DEF    68
+#define KW_PP_IF       69
+#define KW_PP_ELSE     70
+#define KW_PP_DEFINE   71
+#define KW_PP_IF_NDEF  72
+#define KW_PP_IF_DEF   73
+#define KW_PP_ELIF_DEF 74
+#define KW_PP_ENDIF    75
+#define KW_PP_ELIF     76
+#define KW_PP_DEFINED  77
+#define KW_PP_UNDEF    78
+#define KW_PP_ERROR    79
 
 /* Compiler Flags*/
-#define CCF_MULTI_CHAR_OP     (1<<0)
-#define CCF_PRE_PROC          (1<<1)
-#define CCF_ACCEPT_NEWLINES   (1<<2)
-#define CCF_MULTI_COLON       (1<<3)
-#define CCF_ASM_BLOCK         (1<<4)
-#define CCF_BLOCK             (1<<5)
-#define CCF_ACCEPT_WHITESPACE (1<<6)
-#define CCF_ACCEPT_COMMENTS   (1<<7)
+#define CCF_MULTI_CHAR_OP     (1 << 0)
+#define CCF_PRE_PROC          (1 << 1)
+#define CCF_ACCEPT_NEWLINES   (1 << 2)
+#define CCF_MULTI_COLON       (1 << 3)
+#define CCF_ASM_BLOCK         (1 << 4)
+#define CCF_BLOCK             (1 << 5)
+#define CCF_ACCEPT_WHITESPACE (1 << 6)
+#define CCF_ACCEPT_COMMENTS   (1 << 7)
 
-#define LEXEME_RAW_PUNCT              (1<<0)
-#define LEXEME_ENCODE_PUNCT           (1<<1)
-#define LEXEME_GRAPH_VIZ_ENCODE_PUNCT (1<<2)
+#define LEXEME_RAW_PUNCT              (1 << 0)
+#define LEXEME_ENCODE_PUNCT           (1 << 1)
+#define LEXEME_GRAPH_VIZ_ENCODE_PUNCT (1 << 2)
 
 typedef struct Lexeme {
     int tk_type;
@@ -150,9 +150,9 @@ typedef struct Lexeme {
 
 typedef struct LexFile {
     aoStr *filename; /* name of the file */
-    char *ptr; /* Where we are in the file */
-    int lineno; /* line number in the file */
-    aoStr *src; /* source */
+    char *ptr;       /* Where we are in the file */
+    int lineno;      /* line number in the file */
+    aoStr *src;      /* source */
 } LexFile;
 
 typedef struct Lexer {
@@ -171,7 +171,8 @@ typedef struct Lexer {
     int skip_else;
     char *builtin_root;
     List *files;
-    List *all_source;/* This saves all of the files we see so we can free them later */
+    List *all_source; /* This saves all of the files we see so we can free them
+                         later */
     StrMap *seen_files;
     StrMap *symbol_table;
     LexFile *cur_file;
@@ -196,12 +197,11 @@ char *lexemePunctToStringWithFlags(long op, unsigned long flags);
 char *lexemePunctToEncodedString(long op);
 char *lexemeToString(Lexeme *tok);
 void lexReleaseAllFiles(Lexer *l);
-int tokenPunctIs(Lexeme *tok, long ch);
-int tokenIdentIs(Lexeme *tok, char *ident, int len);
+int tokenPunctIs(const Lexeme *tok, long ch);
+int tokenIdentIs(const Lexeme *tok, const char *ident, int len);
 void lexemeFree(void *_le);
 char *lexerReportLine(Lexer *l, ssize_t lineno);
 int lexemeEq(Lexeme *l1, Lexeme *l2);
 char *lexReadfile(char *path, ssize_t *_len);
-
 
 #endif // !LEXER_H

--- a/src/list.c
+++ b/src/list.c
@@ -4,9 +4,9 @@
 
 #include "list.h"
 
-void listInit(List *ll) {
-    ll->next = ll->prev = ll;
-    ll->value = NULL;
+void listInit(List *l) {
+    l->next = l->prev = l;
+    l->value = NULL;
 }
 
 List *listNew(void) {
@@ -16,8 +16,9 @@ List *listNew(void) {
     return ll;
 }
 
-int listEmpty(List *l) {
-    if (l == NULL) return 1;
+int listEmpty(const List *l) {
+    if (l == NULL)
+        return 1;
     return l->next == l;
 }
 
@@ -63,7 +64,7 @@ void listInsertBefore(List *ll, List *new_node) {
 void listInsertValueBefore(List *ll, void *value) {
     List *prev = listNew();
     prev->value = value;
-    listInsertBefore(ll,prev);
+    listInsertBefore(ll, prev);
 }
 
 void *listHead(List *ll) {
@@ -84,7 +85,8 @@ void *listPop(void *l) {
 }
 
 void listClear(List *ll, void (*freeValue)(void *)) {
-    if (!ll) return;
+    if (!ll)
+        return;
     List *node = ll->next;
     List *next;
     while (node != ll) {
@@ -99,13 +101,15 @@ void listClear(List *ll, void (*freeValue)(void *)) {
 }
 
 void listRelease(List *ll, void (*freeValue)(void *)) {
-    if (!ll) return;
-    listClear(ll,freeValue);
+    if (!ll)
+        return;
+    listClear(ll, freeValue);
     free(ll);
 }
 
 int listCount(List *ll) {
-    if (!ll) return 0;
+    if (!ll)
+        return 0;
     int count = 0;
     listForEach(ll) {
         count++;
@@ -162,7 +166,7 @@ void listMergeAppend(List *l1, List *l2) {
 List *listCopy(List *l) {
     List *cpy = listNew();
     listForEach(l) {
-        listAppend(cpy,it->value);
+        listAppend(cpy, it->value);
     }
     return cpy;
 }
@@ -197,17 +201,17 @@ int main(void) {
     List *l1 = listNew();
     List *l2 = listNew();
 
-    listAppend(l1,intNew(1));
-    listAppend(l1,intNew(2));
-    listAppend(l1,intNew(3));
+    listAppend(l1, intNew(1));
+    listAppend(l1, intNew(2));
+    listAppend(l1, intNew(3));
     listTestPrint(l1);
 
-    listAppend(l2,intNew(4));
-    listAppend(l2,intNew(5));
-    listAppend(l2,intNew(6));
+    listAppend(l2, intNew(4));
+    listAppend(l2, intNew(5));
+    listAppend(l2, intNew(6));
     listTestPrint(l2);
 
-    listMergePrepend(l1,l2);
+    listMergePrepend(l1, l2);
     listTestPrint(l1);
     listTestPrintReverse(l1);
 }

--- a/src/list.h
+++ b/src/list.h
@@ -7,12 +7,11 @@ typedef struct List {
     void *value;
 } List;
 
-#define listForEach(l) \
-    for (List *it = l->next; it != l; it = it->next)
+#define listForEach(l) for (List *it = l->next; it != l; it = it->next)
 
 void listInit(List *l);
 List *listNew(void);
-int listEmpty(List *l);
+int listEmpty(const List *l);
 void listAppend(List *head, void *value);
 void listPrepend(List *head, void *value);
 void listInsertBefore(List *ll, List *new_node);

--- a/src/map.c
+++ b/src/map.c
@@ -1,9 +1,9 @@
+#include <assert.h>
 #include <limits.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "aostr.h"
 #include "map.h"
@@ -23,47 +23,47 @@ void setAllLongs(long *array, unsigned long len, long value) {
         vec = (ret_type *)malloc(sizeof(ret_type));                   \
         vec->size = 0;                                                \
         vec->capacity = VECTOR_INITIAL_CAPACITY;                      \
-        vec->entries = (entry_type *)malloc(sizeof(entry_type) * VECTOR_INITIAL_CAPACITY); \
+        vec->entries = (entry_type *)malloc(sizeof(entry_type) *      \
+                                            VECTOR_INITIAL_CAPACITY); \
     } while (0)
 
-#define vectorResize(vec, type)                           \
-    do {                                                  \
-        int new_capacity = vec->capacity * 2;             \
-        type *new_entries = (type *)realloc(vec->entries, \
-                    sizeof(type)*new_capacity);           \
-        vec->entries = new_entries;                       \
-        vec->capacity = new_capacity;                     \
+#define vectorResize(vec, type)                                           \
+    do {                                                                  \
+        int new_capacity = vec->capacity * 2;                             \
+        type *new_entries = (type *)realloc(vec->entries,                 \
+                                            sizeof(type) * new_capacity); \
+        vec->entries = new_entries;                                       \
+        vec->capacity = new_capacity;                                     \
     } while (0)
 
-#define vectorPush(vec, type, value)                      \
-    do {                                                  \
-        if (vec->size + 1 >= vec->capacity) {             \
-            vectorResize(vec,type);                       \
-        }                                                 \
-        vec->entries[vec->size++] = value;                \
+#define vectorPush(vec, type, value)          \
+    do {                                      \
+        if (vec->size + 1 >= vec->capacity) { \
+            vectorResize(vec, type);          \
+        }                                     \
+        vec->entries[vec->size++] = value;    \
     } while (0)
 
-#define vectorBoundsCheck(vec_size, idx)                                   \
-    do {                                                                   \
-        if (idx < 0 || idx >= vec_size) {                                  \
-            loggerPanic("idx '%d' is out of range for vector of size %d\n",\
-                    idx,vec->size);                                        \
-        }                                                                  \
+#define vectorBoundsCheck(vec_size, idx)                                    \
+    do {                                                                    \
+        if (idx < 0 || idx >= vec_size) {                                   \
+            loggerPanic("idx '%d' is out of range for vector of size %d\n", \
+                        idx, vec->size);                                    \
+        }                                                                   \
     } while (0)
 
-#define vectorRelease(vec)                                                 \
-    do {                                                                   \
-        if (vec) {                                                         \
-            free(vec->entries);                                            \
-            free(vec);                                                     \
-        }                                                                  \
+#define vectorRelease(vec)      \
+    do {                        \
+        if (vec) {              \
+            free(vec->entries); \
+            free(vec);          \
+        }                       \
     } while (0)
-    
 
-/* I feel combining all of these data structures into one file will lead 
+/* I feel combining all of these data structures into one file will lead
  * to a more happy prosperous codebase */
 IntVec *intVecNew(void) {
-    vectorNew(IntVec,long);
+    vectorNew(IntVec, long);
 #ifdef DEBUG
     assert(vec != NULL);
     assert(vec->entries != NULL);
@@ -72,7 +72,7 @@ IntVec *intVecNew(void) {
 }
 
 void intVecPush(IntVec *vec, long value) {
-    vectorPush(vec,long,value);
+    vectorPush(vec, long, value);
 }
 
 long intVecPop(IntVec *vec, int *ok) {
@@ -87,7 +87,7 @@ long intVecPop(IntVec *vec, int *ok) {
 
 int intVecGet(IntVec *vec, int idx) {
 #ifdef DEBUG
-    vectorBoundsCheck(vec->size,idx);
+    vectorBoundsCheck(vec->size, idx);
 #endif
     /* No checking */
     return vec->entries[idx];
@@ -105,7 +105,7 @@ void intVecRelease(IntVec *vec) {
 }
 
 /* Make the first instance of key the first element in the vector */
-void intVecMoveFirst(IntVec *vec, int key) {
+void intVecMoveFirst(const IntVec *vec, int key) {
     int idx = -1;
     for (int i = 0; i < vec->size; ++i) {
         if (vec->entries[i] == key) {
@@ -113,14 +113,15 @@ void intVecMoveFirst(IntVec *vec, int key) {
             break;
         }
     }
-    if (idx == -1) return;
+    if (idx == -1)
+        return;
     int tmp = vec->entries[0];
     vec->entries[0] = vec->entries[idx];
     vec->entries[idx] = tmp;
 }
 
 PtrVec *ptrVecNew(void) {
-    vectorNew(PtrVec,void*);
+    vectorNew(PtrVec, void *);
 #ifdef DEBUG
     assert(vec != NULL);
     assert(vec->entries != NULL);
@@ -129,12 +130,12 @@ PtrVec *ptrVecNew(void) {
 }
 
 void ptrVecPush(PtrVec *vec, void *value) {
-    vectorPush(vec,void*,value);
+    vectorPush(vec, void *, value);
 }
 
 void *ptrVecGet(PtrVec *vec, int idx) {
 #ifdef DEBUG
-    vectorBoundsCheck(vec->size,idx);
+    vectorBoundsCheck(vec->size, idx);
 #endif
     /* No checking */
     return vec->entries[idx];
@@ -160,7 +161,6 @@ unsigned long roundUpToNextPowerOf2(unsigned long v) {
     return v;
 }
 
-
 IntMap *intMapNew(unsigned long capacity) {
     IntMap *map = (IntMap *)malloc(sizeof(IntMap));
     capacity = roundUpToNextPowerOf2(capacity);
@@ -185,8 +185,8 @@ IntMapNode *intMapNodeNew(long key, void *value) {
     return n;
 }
 
-static unsigned long intMapGetIdx(IntMap *map, long key) {
-    unsigned long idx = intMapHashFunction(key, map->mask); 
+static unsigned long intMapGetIdx(const IntMap *map, long key) {
+    unsigned long idx = intMapHashFunction(key, map->mask);
     unsigned long mask = map->mask;
     IntMapNode **entries = map->entries;
     IntMapNode *cur;
@@ -215,7 +215,7 @@ void intMapIteratorRelease(IntMapIterator *it) {
 
 IntMapNode *intMapNext(IntMapIterator *it) {
     while (it->idx < (unsigned long)it->map->indexes->size) {
-        long idx = intVecGet(it->map->indexes,it->idx);
+        long idx = intVecGet(it->map->indexes, it->idx);
         IntMapNode *n = it->map->entries[idx];
         if (n->key != HT_DELETED) {
             it->idx++;
@@ -226,8 +226,9 @@ IntMapNode *intMapNext(IntMapIterator *it) {
     return NULL;
 }
 
-/* Finds the next avalible slot */ 
-static unsigned long intMapGetNextIdx(IntMap *map, long key, int *_is_free) { 
+/* Finds the next avalible slot */
+static unsigned long intMapGetNextIdx(const IntMap *map, long key,
+                                      int *_is_free) {
     unsigned long mask = map->mask;
     unsigned long idx = key & mask;
     IntMapNode *cur;
@@ -244,10 +245,10 @@ static unsigned long intMapGetNextIdx(IntMap *map, long key, int *_is_free) {
 }
 
 void intMapClear(IntMap *map) {
-    IntVec *indexes = map->indexes;
+    const IntVec *indexes = map->indexes;
     void (*free_value)(void *value) = map->_free_value;
     for (int i = 0; i < indexes->size; ++i) {
-        long idx = vecGet(long,indexes,i);
+        long idx = vecGet(long, indexes, i);
         IntMapNode *n = map->entries[idx];
         if (n) {
             if (free_value)
@@ -256,7 +257,7 @@ void intMapClear(IntMap *map) {
         }
     }
     map->size = 0;
-    memset(map->entries,0,map->capacity*sizeof(IntMapNode *));
+    memset(map->entries, 0, map->capacity * sizeof(IntMapNode *));
     intVecClear(map->indexes);
 }
 
@@ -279,25 +280,23 @@ void intMapRelease(IntMap *map) { // free the entire hashtable
 
 int intMapResize(IntMap *map) {
     // Resize the hashtable, will return false if OMM
-    unsigned long new_capacity, new_mask;
-    IntMapNode **new_entries, **old_entries;
-    long *new_indexes;
     long *old_index_entries = map->indexes->entries;
     int indexes_capacity = (int)map->indexes->size;
     int is_free;
 
-    old_entries = map->entries;
+    IntMapNode **old_entries = map->entries;
 
-    new_capacity = map->capacity << 1;
-    new_mask = new_capacity - 1;
+    unsigned long new_capacity = map->capacity << 1;
+    unsigned long new_mask = new_capacity - 1;
 
-    new_indexes = (long *)calloc(indexes_capacity, sizeof(long));
+    long *new_indexes = (long *)calloc(indexes_capacity, sizeof(long));
     /* OOM */
     if (new_indexes == NULL) {
         return 0;
     }
 
-    new_entries = (IntMapNode **)calloc(new_capacity, sizeof(IntMapNode *));
+    IntMapNode **new_entries = (IntMapNode **)calloc(new_capacity,
+                                                     sizeof(IntMapNode *));
     /* OOM */
     if (new_entries == NULL) {
         free(new_indexes);
@@ -309,15 +308,15 @@ int intMapResize(IntMap *map) {
     map->capacity = new_capacity;
     long new_size = 0;
 
-    /* Keeps insertion order, and does not have to go over the capacity of 
+    /* Keeps insertion order, and does not have to go over the capacity of
      * the hashtable which 'dict.c' has to do on a resize thus this should in
-     * theory be faster, but there are more array lookups however they should 
+     * theory be faster, but there are more array lookups however they should
      * have good spatial locality */
     for (long i = 0; i < indexes_capacity; ++i) {
         long idx = old_index_entries[i];
         IntMapNode *old = old_entries[idx];
         if (old->key != HT_DELETED) {
-            long new_idx = intMapGetNextIdx(map,old->key,&is_free);
+            long new_idx = intMapGetNextIdx(map, old->key, &is_free);
             new_indexes[new_size] = new_idx;
             new_entries[new_idx] = old;
             /* keep track of the new size of this hashtable */
@@ -351,7 +350,7 @@ int intMapAdd(IntMap *map, long key, void *value) {
     unsigned long idx = intMapGetNextIdx(map, key, &is_free);
     if (is_free) {
         IntMapNode *n = intMapNodeNew(key, value);
-        intVecPush(map->indexes,idx);
+        intVecPush(map->indexes, idx);
         map->entries[idx] = n;
         map->size++;
         return 1;
@@ -364,7 +363,7 @@ int intMapAdd(IntMap *map, long key, void *value) {
 }
 
 int intMapDelete(IntMap *map, long key) {
-    unsigned long idx = intMapGetIdx(map,key);
+    unsigned long idx = intMapGetIdx(map, key);
     if (idx != HT_DELETED) {
         IntMapNode *n = map->entries[idx];
         if (map->_free_value)
@@ -376,25 +375,25 @@ int intMapDelete(IntMap *map, long key) {
     return 0;
 }
 
-void *intMapGet(IntMap *map, long key) {
-    unsigned long idx = intMapGetIdx(map,key);
+void *intMapGet(const IntMap *map, long key) {
+    unsigned long idx = intMapGetIdx(map, key);
     if (idx != HT_DELETED) {
         return map->entries[idx]->value;
     }
     return NULL;
 }
 
-/* @UnSafe 
+/* @UnSafe
  * What if the nth entry is deleted? */
-void *intMapGetAt(IntMap *map, long index) {
-    long idx = intVecGet(map->indexes,index);
+void *intMapGetAt(const IntMap *map, long index) {
+    long idx = intVecGet(map->indexes, index);
     return map->entries[idx]->value;
 }
 
-/* While seemingly an overkill this means that we can use the map as a set 
+/* While seemingly an overkill this means that we can use the map as a set
  * as we can now have the value as NULL */
-int intMapHas(IntMap *map, long key) {
-    unsigned long idx = intMapGetIdx(map,key);
+int intMapHas(const IntMap *map, long key) {
+    unsigned long idx = intMapGetIdx(map, key);
     return idx != HT_DELETED;
 }
 
@@ -403,20 +402,20 @@ char *intMapToString(IntMap *map, char *(*stringify_value)(void *)) {
     unsigned long map_size = map->size;
 
     if (map_size == 0) {
-        aoStrCatLen(str,"{}",2);
+        aoStrCatLen(str, "{}", 2);
         return aoStrMove(str);
     }
 
     unsigned long i = 0;
     IntMapIterator *it = intMapIteratorNew(map);
     IntMapNode *entry;
-    aoStrPutChar(str,'{');
+    aoStrPutChar(str, '{');
     while ((entry = intMapNext(it)) != NULL) {
         char *value_string = stringify_value(entry->value);
         if ((i + 1) == map_size) {
-            aoStrCatPrintf(str,"[%ld] => %s}",entry->key,value_string);
+            aoStrCatPrintf(str, "[%ld] => %s}", entry->key, value_string);
         } else {
-            aoStrCatPrintf(str,"[%ld] => %s, ",entry->key,value_string);
+            aoStrCatPrintf(str, "[%ld] => %s, ", entry->key, value_string);
         }
         free(value_string);
         i++;
@@ -430,19 +429,19 @@ char *intMapKeysToString(IntMap *map) {
     unsigned long map_size = map->size;
 
     if (map_size == 0) {
-        aoStrCatLen(str,"{}",2);
+        aoStrCatLen(str, "{}", 2);
         return aoStrMove(str);
     }
 
     unsigned long i = 0;
     IntMapIterator *it = intMapIteratorNew(map);
     IntMapNode *entry;
-    aoStrPutChar(str,'{');
+    aoStrPutChar(str, '{');
     while ((entry = intMapNext(it)) != NULL) {
         if ((i + 1) == map_size) {
-            aoStrCatPrintf(str,"%ld}",entry->key);
+            aoStrCatPrintf(str, "%ld}", entry->key);
         } else {
-            aoStrCatPrintf(str,"%ld, ",entry->key);
+            aoStrCatPrintf(str, "%ld, ", entry->key);
         }
         i++;
     }
@@ -450,7 +449,8 @@ char *intMapKeysToString(IntMap *map) {
     return aoStrMove(str);
 }
 
-unsigned long strMapHashFunction(char *key, long key_len, unsigned long mask) {
+unsigned long strMapHashFunction(const char *key, long key_len,
+                                 unsigned long mask) {
     unsigned long hash = 0;
     for (long i = 0; i < key_len; ++i) {
         hash = ((hash << 5) - hash) + key[i];
@@ -495,18 +495,19 @@ StrMapNode *strMapNodeNew(char *key, long key_len, void *value) {
     return n;
 }
 
-static int strMapKeyMatch(StrMapNode *n, char *key, ssize_t key_len) {
-    return n->key_len == key_len && !memcmp(n->key,key,key_len);
+static int strMapKeyMatch(const StrMapNode *n, const char *key,
+                          ssize_t key_len) {
+    return n->key_len == key_len && !memcmp(n->key, key, key_len);
 }
 
-static long strMapGetIdx(StrMap *map, char *key, long key_len) {
+static long strMapGetIdx(const StrMap *map, const char *key, long key_len) {
     unsigned long mask = map->mask;
     unsigned long idx = strMapHashFunction(key, key_len, mask);
     StrMapNode **entries = map->entries;
     StrMapNode *cur;
 
     while ((cur = entries[idx]) != NULL) {
-        if (strMapKeyMatch(cur,key,key_len)) {
+        if (strMapKeyMatch(cur, key, key_len)) {
             return idx;
         }
         idx = (idx + 1) & mask;
@@ -514,9 +515,9 @@ static long strMapGetIdx(StrMap *map, char *key, long key_len) {
     return HT_DELETED;
 }
 
-static unsigned long strMapGetNextIdx(StrMap *map, char *key, long key_len,
-        int *_is_free)
-{ // Finds the next avalible slot
+static unsigned long
+strMapGetNextIdx(const StrMap *map, const char *key, long key_len,
+                 int *_is_free) { // Finds the next avalible slot
     unsigned long mask = map->mask;
     unsigned long idx = strMapHashFunction(key, key_len, mask);
     StrMapNode *cur;
@@ -525,7 +526,7 @@ static unsigned long strMapGetNextIdx(StrMap *map, char *key, long key_len,
         if (cur->key == NULL) {
             *_is_free = 0;
             return idx;
-        } else if (strMapKeyMatch(cur,key,key_len)) {
+        } else if (strMapKeyMatch(cur, key, key_len)) {
             *_is_free = 0;
             return idx;
         }
@@ -536,11 +537,11 @@ static unsigned long strMapGetNextIdx(StrMap *map, char *key, long key_len,
 }
 
 void strMapClear(StrMap *map) {
-    IntVec *indexes = map->indexes;
+    const IntVec *indexes = map->indexes;
     void (*free_value)(void *value) = map->_free_value;
     void (*free_key)(void *_key) = map->_free_key;
     for (int i = 0; i < indexes->size; ++i) {
-        long idx = vecGet(long,indexes,i);
+        long idx = vecGet(long, indexes, i);
         StrMapNode *n = map->entries[idx];
         if (n) {
             if (free_value)
@@ -551,7 +552,7 @@ void strMapClear(StrMap *map) {
         }
     }
     map->size = 0;
-    memset(map->entries,0,map->capacity*sizeof(StrMapNode *));
+    memset(map->entries, 0, map->capacity * sizeof(StrMapNode *));
     intVecClear(map->indexes);
 }
 
@@ -595,24 +596,22 @@ void strMapRemoveKeys(StrMap *map1, StrMap *map2) {
 
 // Resize the hashtable, will return false if OMM
 int strMapResize(StrMap *map) {
-    unsigned long new_capacity, new_mask;
-    long *new_indexes;
-    long *old_index_entries = map->indexes->entries;
+    const long *old_index_entries = map->indexes->entries;
     int indexes_capacity = (int)map->indexes->size;
-    StrMapNode **old_entries, **new_entries;
     int is_free;
 
-    new_capacity = map->capacity << 1;
-    new_mask = new_capacity - 1;
-    old_entries = map->entries;
+    unsigned long new_capacity = map->capacity << 1;
+    unsigned long new_mask = new_capacity - 1;
+    StrMapNode **old_entries = map->entries;
 
-    new_indexes = (long *)calloc(new_capacity, sizeof(long));
+    long *new_indexes = (long *)calloc(new_capacity, sizeof(long));
     /* OOM */
     if (new_indexes == NULL) {
         return 0;
     }
 
-    new_entries = (StrMapNode **)calloc(new_capacity, sizeof(StrMapNode *));
+    StrMapNode **new_entries = (StrMapNode **)calloc(new_capacity,
+                                                     sizeof(StrMapNode *));
     /* OOM */
     if (new_entries == NULL) {
         free(new_indexes);
@@ -624,15 +623,16 @@ int strMapResize(StrMap *map) {
     map->capacity = new_capacity;
     long new_size = 0;
 
-    /* Keeps insertion order, and does not have to go over the capacity of 
+    /* Keeps insertion order, and does not have to go over the capacity of
      * the hashtable which 'dict.c' has to do on a resize thus this should in
-     * theory be faster, but there are more array lookups however they should 
+     * theory be faster, but there are more array lookups however they should
      * have good spatial locality */
     for (unsigned long i = 0; i < map->size; ++i) {
         long idx = old_index_entries[i];
         StrMapNode *old = old_entries[idx];
         if (old->key != NULL) {
-            long new_idx = strMapGetNextIdx(map,old->key,old->key_len,&is_free);
+            long new_idx = strMapGetNextIdx(map, old->key, old->key_len,
+                                            &is_free);
             new_indexes[new_size] = new_idx;
             new_entries[new_idx] = old;
             /* keep track of the new size of this hashtable */
@@ -667,7 +667,7 @@ int strMapAddLen(StrMap *map, char *key, long key_len, void *value) {
 
     if (is_free) {
         StrMapNode *n = strMapNodeNew(key, key_len, value);
-        intVecPush(map->indexes,idx);
+        intVecPush(map->indexes, idx);
         map->entries[idx] = n;
         map->size++;
         return 1;
@@ -682,7 +682,7 @@ int strMapAddLen(StrMap *map, char *key, long key_len, void *value) {
 
 int strMapAdd(StrMap *map, char *key, void *value) {
     long key_len = strlen(key);
-    return strMapAddLen(map,key,key_len,value);
+    return strMapAddLen(map, key, key_len, value);
 }
 
 int strMapAddOrErr(StrMap *map, char *key, void *value) {
@@ -700,7 +700,7 @@ int strMapAddOrErr(StrMap *map, char *key, void *value) {
 
     if (is_free) {
         StrMapNode *n = strMapNodeNew(key, key_len, value);
-        intVecPush(map->indexes,idx);
+        intVecPush(map->indexes, idx);
         map->entries[idx] = n;
         map->size++;
         return 1;
@@ -709,7 +709,7 @@ int strMapAddOrErr(StrMap *map, char *key, void *value) {
     }
 }
 
-int strMapRemove(StrMap *map, char *key) {
+int strMapRemove(StrMap *map, const char *key) {
     long len = strlen(key);
     unsigned long mask = map->mask;
     unsigned long idx = strMapHashFunction(key, len, mask);
@@ -718,8 +718,10 @@ int strMapRemove(StrMap *map, char *key) {
 
     while ((cur = entries[idx])) {
         if (cur->key_len == len && !strncmp(cur->key, key, len)) {
-            if (map->_free_key)   map->_free_key(cur->key);
-            if (map->_free_value) map->_free_value(cur->value);
+            if (map->_free_key)
+                map->_free_key(cur->key);
+            if (map->_free_value)
+                map->_free_value(cur->value);
             cur->value = cur->key = NULL;
             map->size--;
             return 1;
@@ -729,10 +731,11 @@ int strMapRemove(StrMap *map, char *key) {
     return 0;
 }
 
-void *strMapGetLen(StrMap *map, char *key, long key_len) {
-    if (!key) return NULL;
+void *strMapGetLen(const StrMap *map, char *key, long key_len) {
+    if (!key)
+        return NULL;
     for (; map != NULL; map = map->parent) {
-        unsigned long idx = strMapGetIdx(map,key,key_len);
+        unsigned long idx = strMapGetIdx(map, key, key_len);
         if (idx != HT_DELETED) {
             StrMapNode *n = map->entries[idx];
             assert(n);
@@ -742,15 +745,15 @@ void *strMapGetLen(StrMap *map, char *key, long key_len) {
     return NULL;
 }
 
-void *strMapGet(StrMap *map, char *key) {
+void *strMapGet(const StrMap *map, char *key) {
     long key_len = strlen(key);
-    return strMapGetLen(map,key,key_len);
+    return strMapGetLen(map, key, key_len);
 }
 
-int strMapHas(StrMap *map, char *key) {
+int strMapHas(const StrMap *map, const char *key) {
     long key_len = strlen(key);
     for (; map; map = map->parent) {
-        unsigned long idx = strMapGetIdx(map,key,key_len);
+        unsigned long idx = strMapGetIdx(map, key, key_len);
         if (idx != HT_DELETED)
             return 1;
     }
@@ -783,22 +786,20 @@ StrMapNode *strMapNext(StrMapIterator *it) {
     return NULL;
 }
 
-
 IntSet *intSetNew(unsigned long capacity) {
     IntSet *iset = (IntSet *)malloc(sizeof(IntSet));
     iset->size = 0;
     iset->capacity = capacity;
-    iset->mask = capacity-1;
+    iset->mask = capacity - 1;
     iset->threashold = (unsigned long)(HT_LOAD * capacity);
-    iset->entries = (long *)malloc(sizeof(long)*capacity);
+    iset->entries = (long *)malloc(sizeof(long) * capacity);
     iset->indexes = intVecNew();
-    setAllLongs(iset->entries,capacity,HT_VACANT);
+    setAllLongs(iset->entries, capacity, HT_VACANT);
     return iset;
 }
 
-static unsigned long intSetGetNextIdx(long *entries, unsigned long mask,
-        long key, int *_is_free)
-{ 
+static unsigned long intSetGetNextIdx(const long *entries, unsigned long mask,
+                                      long key, int *_is_free) {
     unsigned long idx = key & mask;
     long cur;
 
@@ -813,7 +814,7 @@ static unsigned long intSetGetNextIdx(long *entries, unsigned long mask,
     return idx;
 }
 
-static long intSetGetIdx(long *entries, unsigned long mask, long key) {
+static long intSetGetIdx(const long *entries, unsigned long mask, long key) {
     unsigned long idx = intMapHashFunction(key, mask);
     long cur_key;
 
@@ -850,7 +851,7 @@ int intSetResize(IntSet *iset) {
         return 0;
     }
 
-    setAllLongs(new_entries,new_capacity,HT_VACANT);
+    setAllLongs(new_entries, new_capacity, HT_VACANT);
 
     iset->mask = new_mask;
     iset->entries = new_entries;
@@ -862,13 +863,14 @@ int intSetResize(IntSet *iset) {
         long idx = old_index_entries[i];
         long old_key = old_entries[idx];
         if (old_key != HT_DELETED) {
-            long new_idx = intSetGetNextIdx(new_entries,new_mask,old_key,&is_free);
+            long new_idx = intSetGetNextIdx(new_entries, new_mask, old_key,
+                                            &is_free);
             new_entries[new_idx] = old_key;
             new_indexes[new_size] = new_idx;
             /* keep track of the new size of this Set */
             new_size++;
         }
-    } 
+    }
 
     free(old_entries);
     free(iset->indexes->entries);
@@ -890,19 +892,20 @@ int intSetAdd(IntSet *iset, long key) {
     }
 
     int is_free = 0;
-    unsigned long idx = intSetGetNextIdx(iset->entries,iset->mask,key,&is_free);
+    unsigned long idx = intSetGetNextIdx(iset->entries, iset->mask, key,
+                                         &is_free);
     if (is_free) {
         iset->entries[idx] = key;
-        intVecPush(iset->indexes,idx);
+        intVecPush(iset->indexes, idx);
         iset->size++;
     }
     return 1;
 }
 
 void intSetRemove(IntSet *iset, long key) {
-    long idx = intSetGetIdx(iset->entries,iset->mask,key);
+    long idx = intSetGetIdx(iset->entries, iset->mask, key);
     if (idx != HT_DELETED) {
-        /* We do nothing with the indexes, this does mean if there are multiple 
+        /* We do nothing with the indexes, this does mean if there are multiple
          * deletes the indexes vector would grow indefinitely */
         iset->entries[idx] = HT_DELETED;
         iset->size--;
@@ -910,16 +913,16 @@ void intSetRemove(IntSet *iset, long key) {
 }
 
 int intSetHas(IntSet *iset, long key) {
-    return intSetGetIdx(iset->entries,iset->mask,key) != HT_DELETED;
+    return intSetGetIdx(iset->entries, iset->mask, key) != HT_DELETED;
 }
 
 long intSetGetAt(IntSet *iset, long index) {
-    long idx = intVecGet(iset->indexes,index);
+    long idx = intVecGet(iset->indexes, index);
     return iset->entries[idx];
 }
 
 void intSetClear(IntSet *iset) {
-    setAllLongs(iset->entries,iset->capacity,HT_VACANT);
+    setAllLongs(iset->entries, iset->capacity, HT_VACANT);
     intVecClear(iset->indexes);
 }
 
@@ -939,7 +942,7 @@ IntSetIterator *intSetIteratorNew(IntSet *iset) {
 
 long intSetNext(IntSetIterator *it) {
     while ((int)it->idx < it->iset->indexes->size) {
-        long idx = intVecGet(it->iset->indexes,it->idx);
+        long idx = intVecGet(it->iset->indexes, it->idx);
         long key = it->iset->entries[idx];
         if (key != HT_DELETED && key != HT_VACANT) {
             it->idx++;
@@ -951,7 +954,8 @@ long intSetNext(IntSetIterator *it) {
 }
 
 void intSetIteratorRelease(IntSetIterator *it) {
-    if (it) free(it);
+    if (it)
+        free(it);
 }
 
 char *intSetToString(IntSet *iset) {
@@ -959,19 +963,19 @@ char *intSetToString(IntSet *iset) {
     unsigned long set_size = iset->size;
 
     if (set_size == 0) {
-        aoStrCatLen(str,"{}",2);
+        aoStrCatLen(str, "{}", 2);
         return aoStrMove(str);
     }
 
     unsigned long i = 0;
     long key;
     IntSetIterator *it = intSetIteratorNew(iset);
-    aoStrPutChar(str,'{');
+    aoStrPutChar(str, '{');
     while ((key = intSetNext(it)) != HT_DELETED) {
         if ((i + 1) == set_size) {
-            aoStrCatPrintf(str,"%ld}",key);
+            aoStrCatPrintf(str, "%ld}", key);
         } else {
-            aoStrCatPrintf(str,"%ld, ",key);
+            aoStrCatPrintf(str, "%ld, ", key);
         }
         i++;
     }

--- a/src/map.h
+++ b/src/map.h
@@ -1,15 +1,15 @@
 #ifndef MAP_H
-#define MAP_H 
+#define MAP_H
 
 #include <limits.h>
 
 #define HT_LOAD    0.60
 #define HT_DELETED LONG_MAX
-#define HT_VACANT  LONG_MAX-1
+#define HT_VACANT  LONG_MAX - 1
 #define HT_PROBE_1 1
 #define HT_PROBE_3 3
 
-/* This is very similar to the MapIndex struct, maybe we can repurpose it 
+/* This is very similar to the MapIndex struct, maybe we can repurpose it
  * or repurpose this to be the index */
 typedef struct IntVec {
     int size;
@@ -21,7 +21,7 @@ IntVec *intVecNew(void);
 void intVecPush(IntVec *vec, long value);
 void intVecClear(IntVec *vec);
 void intVecRelease(IntVec *vec);
-void intVecMoveFirst(IntVec *vec, int key);
+void intVecMoveFirst(const IntVec *vec, int key);
 long intVecPop(IntVec *vec, int *ok);
 
 /* This could be used to replace the `List` */
@@ -31,10 +31,11 @@ typedef struct PtrVec {
     void **entries;
 } PtrVec;
 #define vecInBounds(vec, idx) ((idx >= 0) && idx < (vec)->size)
-#define vecGetInBounds(vec, idx) (vecInBounds(vec,idx) ? (vec)->entries[idx] : NULL)
-#define vecEmpty(vec) ((vec)->size == 0)
-#define vecGet(type,vec,idx) ((type)((vec)->entries[idx]))
-#define vecTail(type,vec) ((type)((vec)->entries[(vec)->size-1]))
+#define vecGetInBounds(vec, idx) \
+    (vecInBounds(vec, idx) ? (vec)->entries[idx] : NULL)
+#define vecEmpty(vec)          ((vec)->size == 0)
+#define vecGet(type, vec, idx) ((type)((vec)->entries[idx]))
+#define vecTail(type, vec)     ((type)((vec)->entries[(vec)->size - 1]))
 
 PtrVec *ptrVecNew(void);
 void ptrVecPush(PtrVec *vec, void *value);
@@ -46,7 +47,6 @@ typedef struct IntMapNode {
     void *value;
 } IntMapNode;
 
-
 typedef struct IntMap {
     unsigned long size;     /* How many entries are in the hashtable */
     unsigned long capacity; /* How much capacity we have in the entries array */
@@ -57,8 +57,8 @@ typedef struct IntMap {
     void (*_free_value)(
             void *value); /* User defined callback for freeing values */
     IntVec *indexes; /* Where all of the values are in the entries array, in
-                    * insertion order. Means we can iterate over the
-                    * HashTable quickly at the cost of memory */
+                      * insertion order. Means we can iterate over the
+                      * HashTable quickly at the cost of memory */
     IntMapNode **entries; /* All of the entries, XXX: could this be IntMapNode
                            *entries? */
 } IntMap;
@@ -69,10 +69,10 @@ typedef struct IntMapIterator {
 } IntMapIterator;
 
 int intMapAdd(IntMap *map, long key, void *value);
-void *intMapGet(IntMap *map, long key);
-void *intMapGetAt(IntMap *map, long index);
+void *intMapGet(const IntMap *map, long key);
+void *intMapGetAt(const IntMap *map, long index);
 int intMapDelete(IntMap *map, long key);
-int intMapHas(IntMap *map, long key);
+int intMapHas(const IntMap *map, long key);
 IntMap *intMapNew(unsigned long capacity);
 void intMapSetFreeValue(IntMap *map, void (*_free_value)(void *value));
 void intMapClear(IntMap *map);
@@ -103,8 +103,8 @@ typedef struct StrMap {
             void *_value); /* User defined callback for freeing values */
     void (*_free_key)(void *_key); /* User defined callback for freeing keys */
     IntVec *indexes; /* Where all of the values are in the entries array, in
-                    * insertion order. Means we can iterate over the
-                    * HashTable quickly at the cost of memory */
+                      * insertion order. Means we can iterate over the
+                      * HashTable quickly at the cost of memory */
     StrMapNode **entries; /* All of the entries, XXX: could this be IntMapNode
                            *entries? */
 } StrMap;
@@ -118,13 +118,13 @@ unsigned long roundUpToNextPowerOf2(unsigned long v);
 
 StrMap *strMapNew(unsigned long capacity);
 StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
-void *strMapGetLen(StrMap *map, char *key, long key_len);
-void *strMapGet(StrMap *map, char *key);
+void *strMapGetLen(const StrMap *map, char *key, long key_len);
+void *strMapGet(const StrMap *map, char *key);
 int strMapAddLen(StrMap *map, char *key, long key_len, void *value);
 int strMapAdd(StrMap *map, char *key, void *value);
 int strMapAddOrErr(StrMap *map, char *key, void *value);
-int strMapHas(StrMap *map, char *key);
-int strMapRemove(StrMap *map, char *key);
+int strMapHas(const StrMap *map, const char *key);
+int strMapRemove(StrMap *map, const char *key);
 void strMapRelease(StrMap *map);
 int strMapResize(StrMap *map);
 void strMapSetFreeValue(StrMap *map, void (*_free_value)(void *value));
@@ -135,7 +135,6 @@ void strMapRemoveKeys(StrMap *map1, StrMap *map2);
 StrMapIterator *strMapIteratorNew(StrMap *map);
 void strMapIteratorRelease(StrMapIterator *it);
 StrMapNode *strMapNext(StrMapIterator *it);
-
 
 typedef struct IntSet {
     unsigned long size;

--- a/src/memory.c
+++ b/src/memory.c
@@ -2,7 +2,7 @@
  * The implementation of the pool below is very simplistic. It can only allocate
  * one type of object as you give it a fixed size when creating it.
  *
- * Free objects are handled by a unique integer id (that increments) being 
+ * Free objects are handled by a unique integer id (that increments) being
  * pushed to a vector.
  */
 #include <stdlib.h>
@@ -24,7 +24,8 @@ void *xmalloc(size_t size) {
 }
 
 void xfree(void *ptr) {
-    if (ptr) free(ptr);
+    if (ptr)
+        free(ptr);
 }
 
 void globalArenaInit(unsigned int capcity) {

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -4,7 +4,7 @@
 #include <pthread.h>
 
 typedef enum {
-    MEMPOOL_OK = 0,                          
+    MEMPOOL_OK = 0,
     MEMPOOL_ALLOCATION_GREATER_THAN_CAPACITY_ERR,
     MEMPOOL_ALLOCATION_SPLIT_BLOCK_ERR,
     MEMPOOL_ALLOCATION_SEGMENT_ARRAY_ERR,
@@ -22,27 +22,28 @@ typedef struct MemChunk {
 } __attribute__((aligned(8))) MemChunk;
 
 typedef struct MemSegment {
-    unsigned int id;        /* Id of this segment */
-    MemChunk *list;         /* The memory list, which is an offset to the
-                             * buffer */
+    unsigned int id; /* Id of this segment */
+    MemChunk *list;  /* The memory list, which is an offset to the
+                      * buffer */
 
     void *buffer;           /* The memory for this segment */
     unsigned int allocated; /* How much memory has been allocated */
 } MemSegment;
 
 typedef struct MemPool {
-    MemSegment **segments;         /* Segments array */
-    unsigned int segments_array_capacity; /* The capacity of the segments array */
+    MemSegment **segments; /* Segments array */
+    unsigned int
+            segments_array_capacity; /* The capacity of the segments array */
 
-    unsigned int segment_count;    /* How many segments we have */
+    unsigned int segment_count; /* How many segments we have */
 
     unsigned int segment_capacity; /* The size in bytes of a segment. Cannot
                                     * allocate anything bigger than this */
 
-    pthread_mutex_t mutex;         /* Lock for the pool to allow for multi
-                                    * threading */
+    pthread_mutex_t mutex; /* Lock for the pool to allow for multi
+                            * threading */
 
-    MemPoolError error;            /* Error code for what the allocation 
+    MemPoolError error;            /* Error code for what the allocation
                                     * error was */
     memPoolDeallocate *deallocate; /* If not null it will be called on an
                                     * object which is free - this is useful
@@ -51,10 +52,10 @@ typedef struct MemPool {
                                     * another pool? */
 } MemPool;
 
-const char *memPoolErrorToString(MemPool *pool);
+const char *memPoolErrorToString(const MemPool *pool);
 char *memChunkToString(MemChunk *chunk);
 char *memPoolToString(MemPool *pool);
-char *memSegmentToString(MemSegment *segment);
+char *memSegmentToString(const MemSegment *segment);
 
 MemPool *memPoolNew(unsigned int bytes);
 void memPoolInit(MemPool *pool, unsigned int bytes);

--- a/src/parser.c
+++ b/src/parser.c
@@ -10,12 +10,12 @@
 #include "list.h"
 #include "map.h"
 #include "parser.h"
-#include "prslib.h"
 #include "prsasm.h"
+#include "prslib.h"
 #include "prsutil.h"
 #include "util.h"
 
-#define MAX_ALIGN         16
+#define MAX_ALIGN 16
 
 /* PARSER Prototypes */
 Ast *parseStatement(Cctrl *cc);
@@ -34,7 +34,7 @@ static aoStr *getRangeLoopIdx(void) {
 }
 
 /* Kinda cheating converting it to a string and calling printf */
-Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
+Ast *parseFloatingCharConst(Cctrl *cc, const Lexeme *tok) {
     unsigned long ch = (unsigned long)tok->i64;
     char str[9];
     PtrVec *argv = ptrVecNew();
@@ -45,37 +45,41 @@ Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
         ch = ch >> 8;
     }
 
-    Ast *ast = cctrlGetOrSetString(cc,str,len,len);
-    ptrVecPush(argv,ast);
-    cctrlTokenExpect(cc,';');
-    return astFunctionCall(ast_void_type,"printf",6,argv);
+    Ast *ast = cctrlGetOrSetString(cc, str, len, len);
+    ptrVecPush(argv, ast);
+    cctrlTokenExpect(cc, ';');
+    return astFunctionCall(ast_void_type, "printf", 6, argv);
 }
 
-void parseTypeCheckClassFieldInitaliser(Cctrl *cc, AstType *cls_field_type, Ast *init) {
+void parseTypeCheckClassFieldInitaliser(Cctrl *cc, AstType *cls_field_type,
+                                        Ast *init) {
     if (!astTypeCheck(cls_field_type, init, '=')) {
         char *cls_field_str = astTypeToColorString(cls_field_type);
         char *init_field = astTypeToColorString(init->type);
-        char *var_string = astLValueToString(init,0);
-        cctrlWarning(cc,"Incompatible value being assigned to class field expected '%s' got '%s %s'",
-                cls_field_str,init_field,var_string);
+        char *var_string = astLValueToString(init, 0);
+        cctrlWarning(
+                cc,
+                "Incompatible value being assigned to class field expected '%s' got '%s %s'",
+                cls_field_str, init_field, var_string);
     }
 }
 
 Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
     Lexeme *tok = cctrlTokenGet(cc);
-    List *initlist;
     Ast *init;
 
-    if (type->ptr && type->ptr->kind == AST_TYPE_CHAR && tok->tk_type == TK_STR) {
-        return cctrlGetOrSetString(cc,tok->start,tok->len,tok->i64);
+    if (type->ptr && type->ptr->kind == AST_TYPE_CHAR &&
+        tok->tk_type == TK_STR) {
+        return cctrlGetOrSetString(cc, tok->start, tok->len, tok->i64);
     }
 
     if (!tokenPunctIs(tok, '{')) {
-        cctrlRaiseException(cc,"Expected intializer list starting with '{' got: '%c'",
+        cctrlRaiseException(
+                cc, "Expected intializer list starting with '{' got: '%c'",
                 (char)tok->i64);
     }
 
-    initlist = listNew();
+    List *initlist = listNew();
     ssize_t i = 0;
     StrMap *cls_fields = NULL;
     if (type->kind == AST_TYPE_CLASS) {
@@ -88,28 +92,31 @@ Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
             break;
         }
         cctrlTokenRewind(cc);
-        if (tokenPunctIs(tok,'{')) {
-            init = parseDeclArrayInitInt(cc,type->ptr);
+        if (tokenPunctIs(tok, '{')) {
+            init = parseDeclArrayInitInt(cc, type->ptr);
             tok = cctrlTokenGet(cc);
-            listAppend(initlist,init);
-            if (tokenPunctIs(tok,'}')) {
+            listAppend(initlist, init);
+            if (tokenPunctIs(tok, '}')) {
                 init = astArrayInit(initlist);
                 return init;
             }
             continue;
         } else {
-            init = parseExpr(cc,16);
+            init = parseExpr(cc, 16);
             if (init == NULL) {
-                cctrlRaiseExceptionFromTo(cc,NULL,'{','}',"Array initaliser encountered an unexpected token");
+                cctrlRaiseExceptionFromTo(
+                        cc, NULL, '{', '}',
+                        "Array initaliser encountered an unexpected token");
             } else if (type->ptr) {
-              if ((astGetResultType('=', init->type, type->ptr)) == NULL) {
-                  cctrlRaiseException(cc,"Incompatiable types: %s %s",
-                          astTypeToString(init->type),
-                          astTypeToString(type->ptr));
-              }
+                if ((astGetResultType('=', init->type, type->ptr)) == NULL) {
+                    cctrlRaiseException(cc, "Incompatiable types: %s %s",
+                                        astTypeToString(init->type),
+                                        astTypeToString(type->ptr));
+                }
             } else if (type->kind == AST_TYPE_CLASS) {
                 if (i >= cls_fields->indexes->size) {
-                    cctrlRaiseException(cc, 
+                    cctrlRaiseException(
+                            cc,
                             "More initialisers than class fields for class: %s",
                             astTypeToString(type));
                 }
@@ -117,11 +124,11 @@ Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
                 ssize_t cls_field_idx = cls_fields->indexes->entries[i];
                 StrMapNode *entry = cls_fields->entries[cls_field_idx];
                 AstType *cls_field_type = entry->value;
-                parseTypeCheckClassFieldInitaliser(cc,cls_field_type,init);
+                parseTypeCheckClassFieldInitaliser(cc, cls_field_type, init);
                 i++;
             }
         }
-        listAppend(initlist,init);
+        listAppend(initlist, init);
 
         tok = cctrlTokenGet(cc);
         if (!tokenPunctIs(tok, ',')) {
@@ -131,9 +138,8 @@ Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
     return astArrayInit(initlist);
 }
 
-void parseFlattenAnnonymous(AstType *anon, StrMap *fields_dict,
-        int offset, int make_copy)
-{
+void parseFlattenAnnonymous(const AstType *anon, StrMap *fields_dict,
+                            int offset, int make_copy) {
     StrMapIterator *it = strMapIteratorNew(anon->fields);
     StrMapNode *n = NULL;
     while ((n = strMapNext(it)) != NULL) {
@@ -146,7 +152,7 @@ void parseFlattenAnnonymous(AstType *anon, StrMap *fields_dict,
         }
         type->offset += offset;
 
-        strMapAdd(fields_dict,n->key,type);
+        strMapAdd(fields_dict, n->key, type);
     }
     strMapIteratorRelease(it);
 }
@@ -163,114 +169,123 @@ ClsField *clsFieldNew(AstType *type, aoStr *field_name) {
     return f;
 }
 
-List *parseClassOrUnionFields(Cctrl *cc, aoStr *name,
-        unsigned int (*computeSize)(List *), unsigned int *_size)
-{
-    unsigned int size;
+List *parseClassOrUnionFields(Cctrl *cc, const aoStr *name,
+                              unsigned int (*computeSize)(const List *),
+                              unsigned int *_size) {
     char *fnptr_name;
     int fnptr_name_len;
-    Lexeme *tok, *tok_name;
     AstType *next_type = NULL, *base_type = NULL, *field_type = NULL;
-    aoStr  *field_name = NULL;
-    List *fields_list;
+    aoStr *field_name = NULL;
 
-    tok = cctrlTokenGet(cc);
+    Lexeme *tok = cctrlTokenGet(cc);
 
-    if (!tokenPunctIs(tok,'{')) {
+    if (!tokenPunctIs(tok, '{')) {
         cctrlTokenRewind(cc);
         return NULL;
     }
 
-    fields_list = listNew();
+    List *fields_list = listNew();
 
     while (1) {
         /* Peek not a consume */
-        tok_name = cctrlTokenPeek(cc);
-        if (tokenPunctIs(tok_name,'}')) {
+        Lexeme *tok_name = cctrlTokenPeek(cc);
+        if (tokenPunctIs(tok_name, '}')) {
             break;
-        } else if (cctrlIsKeyword(cc,tok_name->start,tok_name->len)) {
+        } else if (cctrlIsKeyword(cc, tok_name->start, tok_name->len)) {
             base_type = parseBaseDeclSpec(cc);
-        } else if (name && !memcmp(name->data,tok_name->start,tok_name->len)) {
+        } else if (name &&
+                   !memcmp(name->data, tok_name->start, tok_name->len)) {
             base_type = parseBaseDeclSpec(cc);
             if (base_type == NULL) {
-                base_type = astClassType(NULL, aoStrDup(name),8,0);
+                base_type = astClassType(NULL, aoStrDup(name), 8, 0);
             }
-        } else if (tok_name->tk_type == TK_KEYWORD) { 
+        } else if (tok_name->tk_type == TK_KEYWORD) {
             switch (tok_name->i64) {
-                case KW_UNION: {
-                    AstType *_union = parseUnionDef(cc);
-                    _union->kind = AST_TYPE_UNION;
-                    listAppend(fields_list, clsFieldNew(_union,_union->clsname));
-                    cctrlTokenExpect(cc,';');
-                    continue;
-                }
-                case KW_CLASS: {
-                    AstType *cls = parseClassDef(cc,0);
-                    listAppend(fields_list, clsFieldNew(cls,cls->clsname));
-                    cctrlTokenExpect(cc,';');
-                    continue;
-                }
-                default:
-                    cctrlRaiseException(cc,"Unexpected keyword: `%.*s` while parsing class %s",
-                            tok_name->len,
-                            tok_name->start,
-                            name->data);
+            case KW_UNION: {
+                AstType *_union = parseUnionDef(cc);
+                _union->kind = AST_TYPE_UNION;
+                listAppend(fields_list, clsFieldNew(_union, _union->clsname));
+                cctrlTokenExpect(cc, ';');
+                continue;
+            }
+            case KW_CLASS: {
+                AstType *cls = parseClassDef(cc, 0);
+                listAppend(fields_list, clsFieldNew(cls, cls->clsname));
+                cctrlTokenExpect(cc, ';');
+                continue;
+            }
+            default:
+                cctrlRaiseException(
+                        cc, "Unexpected keyword: `%.*s` while parsing class %s",
+                        tok_name->len, tok_name->start, name->data);
             }
         } else {
             if (name) {
-                cctrlRaiseException(cc,"Unexpected type `%.*s` while parsing class %s",
+                cctrlRaiseException(
+                        cc, "Unexpected type `%.*s` while parsing class %s",
                         tok_name->len, tok_name->start, name->data);
             } else {
-                cctrlRewindUntilStrMatch(cc,tok_name->start,tok_name->len,NULL);
-                cctrlRaiseException(cc,"Unexpected type `%.*s` while parsing annoymous class",
+                cctrlRewindUntilStrMatch(cc, tok_name->start, tok_name->len,
+                                         NULL);
+                cctrlRaiseException(
+                        cc,
+                        "Unexpected type `%.*s` while parsing annoymous class",
                         tok_name->len, tok_name->start);
             }
         }
 
         while (1) {
-            next_type = parsePointerType(cc,base_type);
+            next_type = parsePointerType(cc, base_type);
             tok_name = cctrlTokenGet(cc);
             if (!tok_name) {
-                cctrlRaiseException(cc, "<type> <variable_name | (> expected got NULL while parsing class %s",
+                cctrlRaiseException(
+                        cc,
+                        "<type> <variable_name | (> expected got NULL while parsing class %s",
                         name->data);
             }
-            if (tok_name->tk_type != TK_IDENT && !tokenPunctIs(tok_name, '(')) {
-                cctrlRewindUntilPunctMatch(cc,tok_name->i64,NULL);
-                cctrlRaiseException(cc, "Unexpected character `%.*s` while parsing class %s",
-                        tok_name->len,tok_name->start,name->data);
+            if (tok_name && tok_name->tk_type != TK_IDENT &&
+                !tokenPunctIs(tok_name, '(')) {
+                cctrlRewindUntilPunctMatch(cc, tok_name->i64, NULL);
+                cctrlRaiseException(
+                        cc,
+                        "Unexpected character `%.*s` while parsing class %s",
+                        tok_name->len, tok_name->start, name->data);
             } else if (tokenPunctIs(tok_name, '(')) {
-                next_type = parseFunctionPointerType(cc,&fnptr_name,&fnptr_name_len,next_type);
-                field_name = aoStrDupRaw(fnptr_name,fnptr_name_len);
-            } else  {
-                /* XXX: this does not work properly for classes which are not 
+                next_type = parseFunctionPointerType(cc, &fnptr_name,
+                                                     &fnptr_name_len,
+                                                     next_type);
+                field_name = aoStrDupRaw(fnptr_name, fnptr_name_len);
+            } else {
+                /* XXX: this does not work properly for classes which are not
                  * pointers as we miss one of the strings */
-                next_type = parseArrayDimensions(cc,next_type);
-                field_name = aoStrDupRaw(tok_name->start,tok_name->len);
+                next_type = parseArrayDimensions(cc, next_type);
+                field_name = aoStrDupRaw(tok_name->start, tok_name->len);
             }
 
             field_type = astMakeClassField(next_type, 0);
             if (next_type && next_type->clsname) {
                 field_type->clsname = next_type->clsname;
             }
-            /* The list is here to ease calculating the offset of the class 
-             * fields as they have been defined by the programmer... Hashing 
+            /* The list is here to ease calculating the offset of the class
+             * fields as they have been defined by the programmer... Hashing
              * loses the ordering.*/
-            listAppend(fields_list,clsFieldNew(field_type,field_name));
+            listAppend(fields_list, clsFieldNew(field_type, field_name));
 
             tok = cctrlTokenGet(cc);
             if (tokenPunctIs(tok, ',')) {
                 continue;
-            } else if (tokenPunctIs(tok,';')) {
+            } else if (tokenPunctIs(tok, ';')) {
                 break;
             } else {
-                cctrlRewindUntilPunctMatch(cc,tok->i64,NULL);
-                cctrlRaiseException(cc, "Unexpected token '%.*s' while parsing class %s",
+                cctrlRewindUntilPunctMatch(cc, tok->i64, NULL);
+                cctrlRaiseException(
+                        cc, "Unexpected token '%.*s' while parsing class %s",
                         tok->len, tok->start, name->data);
-           }
+            }
         }
     }
-    cctrlTokenExpect(cc,'}');
-    size = 0;
+    cctrlTokenExpect(cc, '}');
+    unsigned int size = 0;
     size = computeSize(fields_list);
 
     if (_size) {
@@ -279,12 +294,11 @@ List *parseClassOrUnionFields(Cctrl *cc, aoStr *name,
     return fields_list;
 }
 
-unsigned int CalcUnionSize(List *fields) {
-    int max = 0;
-    AstType *type;
+unsigned int CalcUnionSize(const List *fields) {
+    unsigned int max = 0;
     listForEach(fields) {
-        ClsField *cls_field = (ClsField *)it->value;
-        type = cls_field->type;
+        const ClsField *cls_field = (ClsField *)it->value;
+        const AstType *type = cls_field->type;
         if (max < type->size) {
             max = type->size;
         }
@@ -292,14 +306,16 @@ unsigned int CalcUnionSize(List *fields) {
     return max;
 }
 
-unsigned int CalcClassSize(List *fields) {
+unsigned int CalcClassSize(const List *fields) {
     unsigned int offset = 0;
     unsigned int size = 0;
     listForEach(fields) {
-        ClsField *cls_field = (ClsField *)it->value;
+        const ClsField *cls_field = (ClsField *)it->value;
         AstType *type = cls_field->type;
-        if (type->size < MAX_ALIGN) size = type->size;
-        else                        size = MAX_ALIGN;
+        if (type->size < MAX_ALIGN)
+            size = type->size;
+        else
+            size = MAX_ALIGN;
 
         if (offset % size != 0) {
             offset += size - offset % size;
@@ -315,14 +331,10 @@ int CalcPadding(int offset, int size) {
     return offset % size == 0 ? 0 : size - offset % size;
 }
 
-StrMap *parseClassOffsets(Cctrl *cc,
-                          int *aligned_size, 
-                          List *fields, 
-                          AstType *base_class,
-                          aoStr *clsname,
-                          int is_intrinsic)
-{
-    int offset,size,padding;
+StrMap *parseClassOffsets(const Cctrl *cc, int *aligned_size, List *fields,
+                          AstType *base_class, const aoStr *clsname,
+                          int is_intrinsic) {
+    int offset, size;
     AstType *field;
     StrMap *fields_dict = strMapNew(32);
 
@@ -330,13 +342,13 @@ StrMap *parseClassOffsets(Cctrl *cc,
     if (listEmpty(fields)) {
         return fields_dict;
     }
-    
+
     if (base_class) {
         offset = base_class->size;
         if (cc->flags & CCTRL_SAVE_ANONYMOUS) {
-            strMapAdd(fields_dict,astAnnonymousLabel(),base_class);
+            strMapAdd(fields_dict, astAnnonymousLabel(), base_class);
         }
-        parseFlattenAnnonymous(base_class,fields_dict,0,1);
+        parseFlattenAnnonymous(base_class, fields_dict, 0, 1);
     } else {
         offset = 0;
     }
@@ -344,12 +356,12 @@ StrMap *parseClassOffsets(Cctrl *cc,
     if (is_intrinsic) {
         *aligned_size = 16;
         listForEach(fields) {
-            ClsField *cls_field = (ClsField *)it->value;
+            const ClsField *cls_field = (ClsField *)it->value;
             field = cls_field->type;
             field->offset = offset;
-            offset+=field->size;
+            offset += field->size;
             if (cls_field->field_name) {
-                strMapAdd(fields_dict,cls_field->field_name->data,field);
+                strMapAdd(fields_dict, cls_field->field_name->data, field);
             }
         }
 
@@ -359,19 +371,20 @@ StrMap *parseClassOffsets(Cctrl *cc,
     listForEach(fields) {
         ClsField *cls_field = (ClsField *)it->value;
         field = cls_field->type;
-        aoStr *field_name = cls_field->field_name;
+        const aoStr *field_name = cls_field->field_name;
 
         if (field_name == NULL && parseIsClassOrUnion(field->kind)) {
             if (cc->flags & CCTRL_SAVE_ANONYMOUS) {
-                strMapAdd(fields_dict,astAnnonymousLabel(),field);
+                strMapAdd(fields_dict, astAnnonymousLabel(), field);
             }
-            parseFlattenAnnonymous(field,fields_dict,offset,0);
+            parseFlattenAnnonymous(field, fields_dict, offset, 0);
             offset += field->size;
             free(cls_field);
             continue;
         } else {
-            if (field->kind == AST_TYPE_POINTER && 
-                    (field->ptr->kind == AST_TYPE_CLASS || field->ptr->kind == AST_TYPE_UNION)) {
+            if (field->kind == AST_TYPE_POINTER &&
+                (field->ptr->kind == AST_TYPE_CLASS ||
+                 field->ptr->kind == AST_TYPE_UNION)) {
                 if (clsname && field->ptr->clsname) {
                     if (aoStrCmp(field->ptr->clsname, clsname)) {
                         field->fields = fields_dict;
@@ -386,14 +399,14 @@ StrMap *parseClassOffsets(Cctrl *cc,
                 size = field->size;
             }
 
-            padding = CalcPadding(offset,size);
+            int padding = CalcPadding(offset, size);
             offset += (padding);
             field->offset = offset;
             offset += (field->size);
         }
 
         if (field_name) {
-            strMapAdd(fields_dict,field_name->data,field);
+            strMapAdd(fields_dict, field_name->data, field);
         }
         free(cls_field);
     }
@@ -402,41 +415,37 @@ StrMap *parseClassOffsets(Cctrl *cc,
     return fields_dict;
 }
 
-StrMap *parseUnionOffsets(Cctrl *cc, int *real_size, List *fields) {
-    int max_size;
-    AstType *field;
+StrMap *parseUnionOffsets(const Cctrl *cc, int *real_size, List *fields) {
     StrMap *fields_dict = strMapNew(32);
 
-    max_size = 0;
+    int max_size = 0;
     listForEach(fields) {
-        ClsField *cls_field = (ClsField *)it->value;
-        field = cls_field->type;
-        aoStr *field_name = cls_field->field_name;
+        const ClsField *cls_field = (ClsField *)it->value;
+        AstType *field = cls_field->type;
+        const aoStr *field_name = cls_field->field_name;
         if (max_size < field->size) {
             max_size = field->size;
         }
         if (field->clsname == NULL && parseIsClassOrUnion(field->kind)) {
             if (cc->flags & CCTRL_SAVE_ANONYMOUS) {
-                strMapAdd(fields_dict,astAnnonymousLabel(),field);
+                strMapAdd(fields_dict, astAnnonymousLabel(), field);
             }
-            parseFlattenAnnonymous(field,fields_dict,0,0);
+            parseFlattenAnnonymous(field, fields_dict, 0, 0);
             continue;
         }
 
         field->offset = 0;
         if (field_name) {
-            strMapAdd(fields_dict,field_name->data,field);
+            strMapAdd(fields_dict, field_name->data, field);
         }
     }
     *real_size = max_size;
     return fields_dict;
 }
 
-AstType *parseClassOrUnion(Cctrl *cc, StrMap *env,
-        int is_class,
-        unsigned int (*computeSize)(List *),
-        int is_intrinsic)
-{
+AstType *parseClassOrUnion(Cctrl *cc, StrMap *env, int is_class,
+                           unsigned int (*computeSize)(const List *),
+                           int is_intrinsic) {
     aoStr *tag = NULL;
     int aligned_size = 0;
     unsigned int class_size;
@@ -447,25 +456,27 @@ AstType *parseClassOrUnion(Cctrl *cc, StrMap *env,
     cc->localenv = strMapNewWithParent(32, cc->localenv);
 
     if (tok->tk_type == TK_IDENT) {
-        tag = aoStrDupRaw(tok->start,tok->len);
+        tag = aoStrDupRaw(tok->start, tok->len);
 
         tok = cctrlTokenGet(cc);
         if (tokenPunctIs(tok, ':')) { // Class inheritance
             if (!is_class) {
-                cctrlRaiseException(cc,"Cannot use inheritance with a union");
+                cctrlRaiseException(cc, "Cannot use inheritance with a union");
             }
             tok = cctrlTokenGet(cc);
             if (tok->tk_type != TK_IDENT) {
-                cctrlRaiseException(cc, "Expected Identifier for class inheritance");
+                cctrlRaiseException(
+                        cc, "Expected Identifier for class inheritance");
             }
-            base_class = strMapGetLen(cc->clsdefs,tok->start,tok->len);
+            base_class = strMapGetLen(cc->clsdefs, tok->start, tok->len);
             if (base_class == NULL) {
-                cctrlRaiseException(cc,"class %.*s has not been defined\n",
-                        tok->len,tok->start);
+                cctrlRaiseException(cc, "class %.*s has not been defined\n",
+                                    tok->len, tok->start);
             }
 
-            if (tokenPunctIs(cctrlTokenPeek(cc),',')) {
-                cctrlRaiseException(cc,"Only one base class allowed at this time");
+            if (tokenPunctIs(cctrlTokenPeek(cc), ',')) {
+                cctrlRaiseException(cc,
+                                    "Only one base class allowed at this time");
             }
         } else {
             cctrlTokenRewind(cc);
@@ -476,18 +487,19 @@ AstType *parseClassOrUnion(Cctrl *cc, StrMap *env,
         prev = strMapGetLen(env, tag->data, tag->len);
     }
 
-    fields = parseClassOrUnionFields(cc,tag,computeSize,&class_size);
+    fields = parseClassOrUnionFields(cc, tag, computeSize, &class_size);
 
     if (prev && !fields) {
         return prev;
     }
 
     if (is_class) {
-        fields_dict = parseClassOffsets(cc,&aligned_size,fields,base_class,tag,is_intrinsic);
+        fields_dict = parseClassOffsets(cc, &aligned_size, fields, base_class,
+                                        tag, is_intrinsic);
     } else {
-        fields_dict = parseUnionOffsets(cc,&aligned_size,fields);
+        fields_dict = parseUnionOffsets(cc, &aligned_size, fields);
     }
-    listRelease(fields,NULL);
+    listRelease(fields, NULL);
 
     if (prev && fields_dict) {
         prev->fields = fields_dict;
@@ -496,39 +508,40 @@ AstType *parseClassOrUnion(Cctrl *cc, StrMap *env,
     }
 
     if (fields_dict) {
-        ref = astClassType(fields_dict,tag,aligned_size,is_intrinsic); 
+        ref = astClassType(fields_dict, tag, aligned_size, is_intrinsic);
         if (base_class) {
             ref->size += base_class->size;
         }
     } else {
-        ref = astClassType(NULL,tag,aligned_size,is_intrinsic); 
+        ref = astClassType(NULL, tag, aligned_size, is_intrinsic);
     }
-    if (!is_class) ref->kind = AST_TYPE_UNION;
+    if (!is_class)
+        ref->kind = AST_TYPE_UNION;
     if (tag) {
-        strMapAdd(env,tag->data,ref);
+        strMapAdd(env, tag->data, ref);
     }
     return ref;
 }
 
 AstType *parseClassDef(Cctrl *cc, int is_intrinsic) {
-    return parseClassOrUnion(cc,cc->clsdefs,1,CalcClassSize,is_intrinsic);
+    return parseClassOrUnion(cc, cc->clsdefs, 1, CalcClassSize, is_intrinsic);
 }
 
 AstType *parseUnionDef(Cctrl *cc) {
-    AstType *_union = parseClassOrUnion(cc,cc->uniondefs,0,CalcUnionSize,0);
+    AstType *_union = parseClassOrUnion(cc, cc->uniondefs, 0, CalcUnionSize, 0);
     _union->kind = AST_TYPE_UNION;
     return _union;
 }
 
 Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
     Ast *init;
-    int len;
-    Lexeme *peek = cctrlTokenPeek(cc);
+    const Lexeme *peek = cctrlTokenPeek(cc);
 
     if (var->type->kind == AST_TYPE_ARRAY) {
-        init = parseDeclArrayInitInt(cc,var->type);
+        int len;
+        init = parseDeclArrayInitInt(cc, var->type);
         if (init->kind == AST_STRING) {
-            len = init->sval->len+1;
+            len = init->sval->len + 1;
         } else {
             len = listCount(init->arrayinit);
         }
@@ -536,24 +549,25 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
             var->type->len = len;
             var->type->size = len * var->type->ptr->size;
         } else if (var->type->len != len) {
-            cctrlRaiseExceptionFromTo(cc, NULL, '{', '}',
-                                     "Invalid array initializer: expected %d items but got %d",
-                                      var->type->len, len);
+            cctrlRaiseExceptionFromTo(
+                    cc, NULL, '{', '}',
+                    "Invalid array initializer: expected %d items but got %d",
+                    var->type->len, len);
         }
         Lexeme *tok = cctrlTokenGet(cc);
-        assertTokenIsTerminator(cc,tok,terminator_flags);
-        return astDecl(var,init);
-    } else if (var->type->kind == AST_TYPE_CLASS && 
-               !var->type->is_intrinsic && tokenPunctIs(peek,'{')) {
-        init = parseDeclArrayInitInt(cc,var->type);
+        assertTokenIsTerminator(cc, tok, terminator_flags);
+        return astDecl(var, init);
+    } else if (var->type->kind == AST_TYPE_CLASS && !var->type->is_intrinsic &&
+               tokenPunctIs(peek, '{')) {
+        init = parseDeclArrayInitInt(cc, var->type);
         Lexeme *tok = cctrlTokenGet(cc);
-        assertTokenIsTerminator(cc,tok,terminator_flags);
-        return astDecl(var,init);
+        assertTokenIsTerminator(cc, tok, terminator_flags);
+        return astDecl(var, init);
     }
 
-    init = parseExpr(cc,16);
+    init = parseExpr(cc, 16);
     Lexeme *tok = cctrlTokenGet(cc);
-    assertTokenIsTerminator(cc,tok,terminator_flags);
+    assertTokenIsTerminator(cc, tok, terminator_flags);
     if (var->kind == AST_GVAR && var->type->kind == AST_TYPE_INT) {
         init = astI64Type(evalIntConstExpr(init));
     }
@@ -563,125 +577,133 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
     }
 
     /* Check what we are trying to assign is valid */
-    AstType *ok = astTypeCheck(var->type,init,'=');
+    const AstType *ok = astTypeCheck(var->type, init, '=');
     if (!ok) {
-        typeCheckWarn(cc,'=',var,init);
+        typeCheckWarn(cc, '=', var, init);
     }
 
-    /* This is for when we have parsed a call to an inline function that is 
+    /* This is for when we have parsed a call to an inline function that is
      * being assigned to a variable */
     if (init->kind == AST_COMPOUND_STMT) {
         /* Attach the Ast to the current function that is being called */
         if (cc->tmp_func) {
-            listAppend(cc->tmp_func->body->stms,init);
+            listAppend(cc->tmp_func->body->stms, init);
         }
-        return astDecl(var,init->inline_ret);
+        return astDecl(var, init->inline_ret);
     }
 
-    return astDecl(var,init);
+    return astDecl(var, init);
 }
 
 Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, long terminator_flags) {
     Lexeme *tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(tok,'=')) {
-        return parseVariableAssignment(cc,var,terminator_flags);
+    if (tokenPunctIs(tok, '=')) {
+        return parseVariableAssignment(cc, var, terminator_flags);
     }
     if (var->type->len == -1) {
-        cctrlRaiseException(cc, "Missing array initializer: %s",astToString(var));
+        cctrlRaiseException(cc, "Missing array initializer: %s",
+                            astToString(var));
     }
     cctrlTokenRewind(cc);
     tok = cctrlTokenGet(cc);
 
-    assertTokenIsTerminator(cc,tok,terminator_flags);
-    return astDecl(var,NULL);
+    assertTokenIsTerminator(cc, tok, terminator_flags);
+    return astDecl(var, NULL);
 }
 
 Ast *parseDecl(Cctrl *cc) {
     AstType *type;
     Lexeme *varname;
-    Ast *var, *ast;
 
-    parseDeclInternal(cc,&varname,&type);
+    parseDeclInternal(cc, &varname, &type);
     if (varname == NULL) {
-        cctrlTokenExpect(cc,';');
+        cctrlTokenExpect(cc, ';');
         return NULL;
     }
-    var = astLVar(type,varname->start,varname->len);
-    if (!strMapAddOrErr(cc->localenv,var->lname->data,var)) {
-        cctrlRaiseException(cc,"variable %s already declared",astLValueToString(var,0));
+    Ast *var = astLVar(type, varname->start, varname->len);
+    if (!strMapAddOrErr(cc->localenv, var->lname->data, var)) {
+        cctrlRaiseException(cc, "variable %s already declared",
+                            astLValueToString(var, 0));
     }
     if (cc->tmp_locals) {
         listAppend(cc->tmp_locals, var);
     }
-    ast = parseVariableInitialiser(cc,var,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
+    Ast *ast = parseVariableInitialiser(cc, var,
+                                        PUNCT_TERM_SEMI | PUNCT_TERM_COMMA);
     if (type->kind == AST_TYPE_AUTO) {
-        parseAssignAuto(cc,ast);
+        parseAssignAuto(cc, ast);
     }
     return ast;
 }
 
-int parseValidPostControlFlowToken(Lexeme *tok) {
-    if (tok->tk_type == TK_IDENT) return 1;
-    if (tok->tk_type == TK_STR) return 1;
+int parseValidPostControlFlowToken(const Lexeme *tok) {
+    if (tok->tk_type == TK_IDENT)
+        return 1;
+    if (tok->tk_type == TK_STR)
+        return 1;
     if (tok->tk_type == TK_PUNCT) {
         switch (tok->i64) {
-            case TK_MINUS_MINUS:
-            case TK_PLUS_PLUS:
-            case '{':
-            case ';':
-            case '*':
-                return 1;
+        case TK_MINUS_MINUS:
+        case TK_PLUS_PLUS:
+        case '{':
+        case ';':
+        case '*':
+            return 1;
+        default:;
         }
     }
     if (tok->tk_type == TK_KEYWORD) {
         switch (tok->i64) {
-            case KW_DO:
-            case KW_FOR:
-            case KW_GOTO:
-            case KW_IF:
-            case KW_RETURN:
-            case KW_SWITCH:
-            case KW_WHILE:
-            case KW_BREAK:
-            case KW_CONTINUE:
-                return 1;
+        case KW_DO:
+        case KW_FOR:
+        case KW_GOTO:
+        case KW_IF:
+        case KW_RETURN:
+        case KW_SWITCH:
+        case KW_WHILE:
+        case KW_BREAK:
+        case KW_CONTINUE:
+            return 1;
         }
     }
     return 0;
 }
 
 Ast *parseIfStatement(Cctrl *cc) {
-    cctrlTokenExpect(cc,'(');
-    Ast *cond = parseExpr(cc,16);
-    cctrlTokenExpect(cc,')');
+    cctrlTokenExpect(cc, '(');
+    Ast *cond = parseExpr(cc, 16);
+    cctrlTokenExpect(cc, ')');
 
-    Lexeme *peek = cctrlTokenPeek(cc);
+    const Lexeme *peek = cctrlTokenPeek(cc);
     if (!parseValidPostControlFlowToken(peek)) {
-        cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing if body", 
-                lexemeTypeToString(peek->tk_type), peek->len, peek->start);
+        cctrlRaiseException(cc, "Unexpected %s `%.*s` while parsing if body",
+                            lexemeTypeToString(peek->tk_type), peek->len,
+                            peek->start);
     }
 
     Ast *then = parseStatement(cc);
-    Lexeme *tok = cctrlTokenGet(cc);
+    const Lexeme *tok = cctrlTokenGet(cc);
 
     if (tok && tok->tk_type == TK_KEYWORD && tok->i64 == KW_ELSE) {
-        Lexeme *peek = cctrlTokenPeek(cc);
-        if (!parseValidPostControlFlowToken(peek)) {
+        const Lexeme *lexeme = cctrlTokenPeek(cc);
+        if (!parseValidPostControlFlowToken(lexeme)) {
             cctrlTokenRewind(cc);
             cctrlTokenRewind(cc);
-            cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing else body", 
-                    lexemeTypeToString(peek->tk_type), peek->len, peek->start);
+            cctrlRaiseException(cc,
+                                "Unexpected %s `%.*s` while parsing else body",
+                                lexemeTypeToString(lexeme->tk_type),
+                                lexeme->len, lexeme->start);
         }
         Ast *els = parseStatement(cc);
-        return astIf(cond,then,els);
+        return astIf(cond, then, els);
     }
     cctrlTokenRewind(cc);
-    return astIf(cond,then,NULL);
+    return astIf(cond, then, NULL);
 }
 
 Ast *parseOptDeclOrStmt(Cctrl *cc) {
-    Lexeme *tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(tok,';')) {
+    const Lexeme *tok = cctrlTokenGet(cc);
+    if (tokenPunctIs(tok, ';')) {
         return NULL;
     }
     cctrlTokenRewind(cc);
@@ -690,130 +712,143 @@ Ast *parseOptDeclOrStmt(Cctrl *cc) {
 
 Ast *parseOptExpr(Cctrl *cc) {
     Lexeme *tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(tok,';')) {
+    if (tokenPunctIs(tok, ';')) {
         return NULL;
     }
     cctrlTokenRewind(cc);
-    Ast *ast = parseExpr(cc,16);
+    Ast *ast = parseExpr(cc, 16);
     tok = cctrlTokenGet(cc);
-    assertTokenIsTerminatorWithMsg(cc,tok,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA, "for loop requires either a conditional statement or a semi colon to terminate the initalisation");
+    assertTokenIsTerminatorWithMsg(
+            cc, tok, PUNCT_TERM_SEMI | PUNCT_TERM_COMMA,
+            "for loop requires either a conditional statement or a semi colon to terminate the initalisation");
     return ast;
 }
 
 Ast *parseDesugarArrayLoop(Cctrl *cc, Ast *iteratee, Ast *static_array) {
     /* Create a temporay variable as the counter */
-    aoStr *range_tmp_var = getRangeLoopIdx();
-    Ast *counter_var = astLVar(ast_int_type,range_tmp_var->data,
+    const aoStr *range_tmp_var = getRangeLoopIdx();
+    Ast *counter_var = astLVar(ast_int_type, range_tmp_var->data,
                                range_tmp_var->len);
 
-    Ast *counter = astDecl(counter_var,astI64Type(0));
+    Ast *counter = astDecl(counter_var, astI64Type(0));
 
     /* How much memory it takes up / size of one element */
-    Ast *array_len = astI64Type(static_array->type->size/static_array->type->ptr->size);
+    Ast *array_len = astI64Type(static_array->type->size /
+                                static_array->type->ptr->size);
 
     if (iteratee->type->kind == AST_TYPE_AUTO) {
         AstType *deref_type = static_array->type->ptr;
         iteratee->type = deref_type;
     }
 
-    strMapAddLen(cc->localenv,range_tmp_var->data,
-                 range_tmp_var->len,counter_var);
-    strMapAdd(cc->localenv,iteratee->lname->data,iteratee);
+    strMapAddLen(cc->localenv, range_tmp_var->data, range_tmp_var->len,
+                 counter_var);
+    strMapAdd(cc->localenv, iteratee->lname->data, iteratee);
 
     if (cc->tmp_locals) {
-        listAppend(cc->tmp_locals,counter_var);
-        listAppend(cc->tmp_locals,iteratee);
+        listAppend(cc->tmp_locals, counter_var);
+        listAppend(cc->tmp_locals, iteratee);
     }
 
-    Ast *cond = parseCreateBinaryOp(cc,'<', counter_var, array_len);
-
+    Ast *cond = parseCreateBinaryOp(cc, '<', counter_var, array_len);
 
     Ast *iterator = astDecl(iteratee,
-            astUnaryOperator(static_array->type->ptr,
-                AST_DEREF,
-                parseCreateBinaryOp(cc,'+', static_array, counter_var))
-            );
-    Ast *step = astUnaryOperator(ast_int_type,TK_PLUS_PLUS,counter_var);
+                            astUnaryOperator(static_array->type->ptr, AST_DEREF,
+                                             parseCreateBinaryOp(cc, '+',
+                                                                 static_array,
+                                                                 counter_var)));
+    Ast *step = astUnaryOperator(ast_int_type, TK_PLUS_PLUS, counter_var);
 
-    cctrlTokenExpect(cc,')');
+    cctrlTokenExpect(cc, ')');
     Ast *forbody = parseStatement(cc);
-    listPrepend(forbody->stms,iterator);
-    return astFor(counter,cond,step,forbody,NULL,NULL,NULL);
+    listPrepend(forbody->stms, iterator);
+    return astFor(counter, cond, step, forbody, NULL, NULL, NULL);
 }
 
-void parseAssertContainerHasFields(Cctrl *cc, AstType *size_field, 
-                                   AstType *entries_field)
-{
+void parseAssertContainerHasFields(Cctrl *cc, const AstType *size_field,
+                                   const AstType *entries_field) {
     if (!size_field) {
-        cctrlRaiseException(cc,"Range for loop must be on a struct with both a 'size' and 'entries' property");
+        cctrlRaiseException(
+                cc,
+                "Range for loop must be on a struct with both a 'size' and 'entries' property");
     }
 
     if (!astIsIntType(size_field)) {
-        cctrlRaiseException(cc,"Range for loop struct's size field must be an int got: %s",
+        cctrlRaiseException(
+                cc, "Range for loop struct's size field must be an int got: %s",
                 astTypeToColorString(size_field));
     }
 
     if (!entries_field) {
-        cctrlRaiseException(cc,"Range for loop must be on a struct with both a 'size' and 'entries' property");
+        cctrlRaiseException(
+                cc,
+                "Range for loop must be on a struct with both a 'size' and 'entries' property");
     }
 
-    if (entries_field->kind != AST_TYPE_POINTER && entries_field->kind != AST_TYPE_ARRAY) {
-        cctrlRaiseException(cc,"'entries' field must be a pointer or array got '%s'", astKindToString(entries_field->kind));
+    if (entries_field && entries_field->kind != AST_TYPE_POINTER &&
+        entries_field->kind != AST_TYPE_ARRAY) {
+        cctrlRaiseException(
+                cc, "'entries' field must be a pointer or array got '%s'",
+                astKindToString(entries_field->kind));
     }
 
-    if (entries_field->ptr->kind == AST_TYPE_VOID) {
-        cctrlRaiseException(cc,"cannot dereference void pointer");
+    if (entries_field && entries_field->ptr->kind == AST_TYPE_VOID) {
+        cctrlRaiseException(cc, "cannot dereference void pointer");
     }
 }
 
-Ast *parseCreateForRange(Cctrl *cc, Ast *iteratee,
-                         Ast *size_ref, Ast *entries_ref)
-{
-    aoStr *range_tmp_var = getRangeLoopIdx();
-    Ast *counter_var = astLVar(ast_int_type,range_tmp_var->data,
+Ast *parseCreateForRange(Cctrl *cc, Ast *iteratee, Ast *size_ref,
+                         Ast *entries_ref) {
+    const aoStr *range_tmp_var = getRangeLoopIdx();
+    Ast *counter_var = astLVar(ast_int_type, range_tmp_var->data,
                                range_tmp_var->len);
-    Ast *counter = astDecl(counter_var,astI64Type(0));
+    Ast *counter = astDecl(counter_var, astI64Type(0));
 
-    strMapAddLen(cc->localenv,range_tmp_var->data,
-                 range_tmp_var->len,counter_var);
-    strMapAdd(cc->localenv,iteratee->lname->data,iteratee);
+    strMapAddLen(cc->localenv, range_tmp_var->data, range_tmp_var->len,
+                 counter_var);
+    strMapAdd(cc->localenv, iteratee->lname->data, iteratee);
     if (cc->tmp_locals) {
-        listAppend(cc->tmp_locals,counter_var);
-        listAppend(cc->tmp_locals,iteratee);
+        listAppend(cc->tmp_locals, counter_var);
+        listAppend(cc->tmp_locals, iteratee);
     }
 
-    Ast *cond = parseCreateBinaryOp(cc,'<', counter_var, size_ref);
+    Ast *cond = parseCreateBinaryOp(cc, '<', counter_var, size_ref);
     Ast *iterator = astDecl(iteratee,
-            astUnaryOperator(entries_ref->type->ptr,
-                AST_DEREF,
-                parseCreateBinaryOp(cc,'+', entries_ref, counter_var))
-            );
-    Ast *step = astUnaryOperator(ast_int_type,TK_PLUS_PLUS,counter_var);
-    cctrlTokenExpect(cc,')');
+                            astUnaryOperator(entries_ref->type->ptr, AST_DEREF,
+                                             parseCreateBinaryOp(cc, '+',
+                                                                 entries_ref,
+                                                                 counter_var)));
+    Ast *step = astUnaryOperator(ast_int_type, TK_PLUS_PLUS, counter_var);
+    cctrlTokenExpect(cc, ')');
     Ast *forbody = parseStatement(cc);
-    listPrepend(forbody->stms,iterator);
-    return astFor(counter,cond,step,forbody,NULL,NULL,NULL);
+    listPrepend(forbody->stms, iterator);
+    return astFor(counter, cond, step, forbody, NULL, NULL, NULL);
 }
 
 Ast *parseRangeLoop(Cctrl *cc, Ast *iteratee) {
     cctrlTokenGet(cc);
-    Ast *container = parseExpr(cc,16);
+    Ast *container = parseExpr(cc, 16);
 
     if (container->kind == AST_LVAR) {
         if (container->type->kind == AST_TYPE_POINTER) {
             if (container->type->ptr->kind != AST_TYPE_CLASS) {
-                cctrlRaiseException(cc,"pointer '%s' has no fields; range requires 'I64 size' and '<type> *entries'",
+                cctrlRaiseException(
+                        cc,
+                        "pointer '%s' has no fields; range requires 'I64 size' and '<type> *entries'",
                         astLValueToString(container, 0));
             }
 
-            AstType *size_field = strMapGet(container->type->ptr->fields, "size");
-            AstType *entries_field = strMapGet(container->type->ptr->fields, "entries");
+            AstType *size_field = strMapGet(container->type->ptr->fields,
+                                            "size");
+            AstType *entries_field = strMapGet(container->type->ptr->fields,
+                                               "entries");
 
-            parseAssertContainerHasFields(cc,size_field,entries_field);
+            parseAssertContainerHasFields(cc, size_field, entries_field);
 
-            Ast *deref = astUnaryOperator(container->type->ptr,AST_DEREF,container);
-            Ast *size_ref = astClassRef(size_field,deref,"size");
-            Ast *entries_ref = astClassRef(entries_field,deref,"entries");
+            Ast *deref = astUnaryOperator(container->type->ptr, AST_DEREF,
+                                          container);
+            Ast *size_ref = astClassRef(size_field, deref, "size");
+            Ast *entries_ref = astClassRef(entries_field, deref, "entries");
 
             if (iteratee->type->kind == AST_TYPE_AUTO) {
                 AstType *deref_type = entries_field->ptr;
@@ -822,16 +857,16 @@ Ast *parseRangeLoop(Cctrl *cc, Ast *iteratee) {
 
             return parseCreateForRange(cc, iteratee, size_ref, entries_ref);
         } else if (container->type->kind == AST_TYPE_ARRAY) {
-            return parseDesugarArrayLoop(cc,iteratee,container);
+            return parseDesugarArrayLoop(cc, iteratee, container);
         } else {
-            cctrlRaiseException(cc,"can only range over arrays and pointers");
+            cctrlRaiseException(cc, "can only range over arrays and pointers");
         }
     } else if (container->kind == AST_CLASS_REF) {
         StrMap *fields = NULL;
         if (container->type->kind == AST_TYPE_POINTER) {
             fields = container->type->ptr->fields;
         } else if (container->type->kind == AST_TYPE_ARRAY) {
-            return parseDesugarArrayLoop(cc,iteratee,container);
+            return parseDesugarArrayLoop(cc, iteratee, container);
         } else {
             fields = container->type->fields;
         }
@@ -839,11 +874,12 @@ Ast *parseRangeLoop(Cctrl *cc, Ast *iteratee) {
         AstType *size_field = strMapGet(fields, "size");
         AstType *entries_field = strMapGet(fields, "entries");
 
-        parseAssertContainerHasFields(cc,size_field,entries_field);
+        parseAssertContainerHasFields(cc, size_field, entries_field);
 
-        Ast *deref = astUnaryOperator(container->type->ptr,AST_DEREF,container);
-        Ast *size_ref = astClassRef(size_field,deref,"size");
-        Ast *entries_ref = astClassRef(entries_field,deref,"entries");
+        Ast *deref = astUnaryOperator(container->type->ptr, AST_DEREF,
+                                      container);
+        Ast *size_ref = astClassRef(size_field, deref, "size");
+        Ast *entries_ref = astClassRef(entries_field, deref, "entries");
 
         if (iteratee->type->kind == AST_TYPE_AUTO) {
             AstType *deref_type = entries_ref->type;
@@ -852,53 +888,57 @@ Ast *parseRangeLoop(Cctrl *cc, Ast *iteratee) {
 
         return parseCreateForRange(cc, iteratee, size_ref, entries_ref);
     }
-    cctrlRaiseException(cc,"Can only handle lvars, arrays and class references at this time got: %s %s",
-                astKindToString(container->kind), astToString(container));
+    cctrlRaiseException(
+            cc,
+            "Can only handle lvars, arrays and class references at this time got: %s %s",
+            astKindToString(container->kind), astToString(container));
 }
 
 /* Either parse the initialiser or a range loop. Range loop is experimental */
 Ast *parseForLoopInitialiser(Cctrl *cc) {
     Lexeme *tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(tok,';')) {
+    if (tokenPunctIs(tok, ';')) {
         return NULL;
     }
     cctrlTokenRewind(cc);
-    
+
     tok = cctrlTokenPeek(cc);
     if (!tok) {
         return NULL;
     }
 
-    if (cctrlIsKeyword(cc,tok->start,tok->len)) {
+    if (cctrlIsKeyword(cc, tok->start, tok->len)) {
         AstType *type = parseDeclSpec(cc);
         tok = cctrlTokenGet(cc);
         if (tok->tk_type != TK_IDENT) {
-            cctrlRaiseException(cc,"expected Identifier got: %s",
-                    lexemeToString(tok)); 
+            cctrlRaiseException(cc, "expected Identifier got: %s",
+                                lexemeToString(tok));
         }
 
         /* We have a for loop variable */
-        Ast *init_var = astLVar(type,tok->start,tok->len);
+        Ast *init_var = astLVar(type, tok->start, tok->len);
 
         /* can be : for an auto loop or ';' for a normal loop */
-        tok = cctrlTokenPeek(cc); 
-        if (!strMapAddOrErr(cc->localenv,init_var->lname->data,init_var)) {
-            cctrlRaiseException(cc,"variable `%s` already declared!",
-                    astLValueToString(init_var,0));
+        tok = cctrlTokenPeek(cc);
+        if (!strMapAddOrErr(cc->localenv, init_var->lname->data, init_var)) {
+            cctrlRaiseException(cc, "variable `%s` already declared!",
+                                astLValueToString(init_var, 0));
         }
-        
+
         /* For this to work the type must have:
-         * 1) a pointer called entries 
+         * 1) a pointer called entries
          * 2) a size value that must be an integer */
-        if (tokenPunctIs(tok,':')) {
-            return parseRangeLoop(cc,init_var);
+        if (tokenPunctIs(tok, ':')) {
+            return parseRangeLoop(cc, init_var);
         } else if (tokenPunctIs(tok, '=')) {
             if (cc->tmp_locals) {
                 listAppend(cc->tmp_locals, init_var);
             }
-            Ast *ast = parseVariableInitialiser(cc,init_var,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
+            Ast *ast = parseVariableInitialiser(cc, init_var,
+                                                PUNCT_TERM_SEMI |
+                                                        PUNCT_TERM_COMMA);
             if (type->kind == AST_TYPE_AUTO) {
-                parseAssignAuto(cc,ast);
+                parseAssignAuto(cc, ast);
             }
             return ast;
         }
@@ -907,24 +947,22 @@ Ast *parseForLoopInitialiser(Cctrl *cc) {
 }
 
 Ast *parseForStatement(Cctrl *cc) {
-    Ast *forinit, *forcond, *forstep, *forbody;
-    aoStr *for_begin, *for_end, *for_middle,
-          *prev_begin, *prev_end;
-    cctrlTokenExpect(cc,'(');
+    Ast *forstep;
+    cctrlTokenExpect(cc, '(');
 
-    prev_begin = cc->tmp_loop_begin;
-    prev_end = cc->tmp_loop_end;
+    aoStr *prev_begin = cc->tmp_loop_begin;
+    aoStr *prev_end = cc->tmp_loop_end;
 
-    for_begin = astMakeLabel();
-    for_middle = astMakeLabel();
-    for_end = astMakeLabel();
+    aoStr *for_begin = astMakeLabel();
+    aoStr *for_middle = astMakeLabel();
+    aoStr *for_end = astMakeLabel();
 
     cc->tmp_loop_begin = for_middle;
     cc->tmp_loop_end = for_end;
 
     cc->localenv = strMapNewWithParent(32, cc->localenv);
-    forinit = parseForLoopInitialiser(cc);
-    //parseOptDeclOrStmt(cc);
+    Ast *forinit = parseForLoopInitialiser(cc);
+    // parseOptDeclOrStmt(cc);
 
     if (forinit && forinit->kind == AST_FOR) {
         forinit->for_begin = for_begin;
@@ -936,70 +974,66 @@ Ast *parseForStatement(Cctrl *cc) {
         return forinit;
     }
 
-    forcond = parseOptExpr(cc);
+    Ast *forcond = parseOptExpr(cc);
     if (tokenPunctIs(cctrlTokenPeek(cc), ')')) {
         forstep = NULL;
     } else {
-        forstep = parseExpr(cc,16);
+        forstep = parseExpr(cc, 16);
     }
-    cctrlTokenExpect(cc,')');
+    cctrlTokenExpect(cc, ')');
 
     Lexeme *peek = cctrlTokenPeek(cc);
     if (!parseValidPostControlFlowToken(peek)) {
-        cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing for loop body", 
-                lexemeTypeToString(peek->tk_type), peek->len, peek->start);
+        cctrlRaiseException(cc,
+                            "Unexpected %s `%.*s` while parsing for loop body",
+                            lexemeTypeToString(peek->tk_type), peek->len,
+                            peek->start);
     }
-    forbody = parseStatement(cc);
+    Ast *forbody = parseStatement(cc);
     /* Go back up */
     cc->localenv = cc->localenv->parent;
     cc->tmp_loop_begin = prev_begin;
     cc->tmp_loop_end = prev_end;
-    return astFor(forinit,forcond,forstep,forbody,for_begin,for_middle,for_end);
+    return astFor(forinit, forcond, forstep, forbody, for_begin, for_middle,
+                  for_end);
 }
 
 Ast *parseWhileStatement(Cctrl *cc) {
-    Ast *whilecond, *whilebody;
-    aoStr *while_begin, *while_end,
-          *prev_begin, *prev_end;
-    cctrlTokenExpect(cc,'(');
+    cctrlTokenExpect(cc, '(');
 
-    prev_begin = cc->tmp_loop_begin;
-    prev_end = cc->tmp_loop_end;
+    aoStr *prev_begin = cc->tmp_loop_begin;
+    aoStr *prev_end = cc->tmp_loop_end;
 
-    while_begin = astMakeLabel();
-    while_end = astMakeLabel();
+    aoStr *while_begin = astMakeLabel();
+    aoStr *while_end = astMakeLabel();
     cc->tmp_loop_begin = while_begin;
     cc->tmp_loop_end = while_end;
 
     cc->localenv = strMapNewWithParent(32, cc->localenv);
-    whilecond = parseExpr(cc,16);
-    cctrlTokenExpect(cc,')');
+    Ast *whilecond = parseExpr(cc, 16);
+    cctrlTokenExpect(cc, ')');
 
     Lexeme *peek = cctrlTokenPeek(cc);
     if (!parseValidPostControlFlowToken(peek)) {
-        cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing while loop body", 
+        cctrlRaiseException(
+                cc, "Unexpected %s `%.*s` while parsing while loop body",
                 lexemeTypeToString(peek->tk_type), peek->len, peek->start);
     }
 
-    whilebody = parseStatement(cc);
+    Ast *whilebody = parseStatement(cc);
     cc->localenv = cc->localenv->parent;
     cc->tmp_loop_begin = prev_begin;
     cc->tmp_loop_end = prev_end;
-    return astWhile(whilecond,whilebody,while_begin, while_end);
+    return astWhile(whilecond, whilebody, while_begin, while_end);
 }
 
 Ast *parseDoWhileStatement(Cctrl *cc) {
-    Ast *whilecond, *whilebody;
-    Lexeme *tok;
-    aoStr *while_begin, *while_end,
-          *prev_begin, *prev_end;
-    
 
-    prev_begin = cc->tmp_loop_begin;
-    prev_end = cc->tmp_loop_end;
+    aoStr *prev_begin = cc->tmp_loop_begin;
+    aoStr *prev_end = cc->tmp_loop_end;
 
-    while_begin = astMakeLabel();
-    while_end = astMakeLabel();
+    aoStr *while_begin = astMakeLabel();
+    aoStr *while_end = astMakeLabel();
     cc->tmp_loop_begin = while_begin;
     cc->tmp_loop_end = while_end;
 
@@ -1007,115 +1041,124 @@ Ast *parseDoWhileStatement(Cctrl *cc) {
 
     Lexeme *peek = cctrlTokenPeek(cc);
     if (!parseValidPostControlFlowToken(peek)) {
-        cctrlRewindUntilStrMatch(cc,peek->start,peek->len,NULL);
-        cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing do while loop body", 
+        cctrlRewindUntilStrMatch(cc, peek->start, peek->len, NULL);
+        cctrlRaiseException(
+                cc, "Unexpected %s `%.*s` while parsing do while loop body",
                 lexemeTypeToString(peek->tk_type), peek->len, peek->start);
     }
 
+    Ast *whilebody = parseStatement(cc);
 
-    whilebody = parseStatement(cc);
-    
-    tok = cctrlTokenGet(cc);
+    const Lexeme *tok = cctrlTokenGet(cc);
 
     if (tok->tk_type != TK_KEYWORD && tok->i64 != KW_WHILE) {
-        cctrlRaiseException(cc,"Expected keyword 'while'");
+        cctrlRaiseException(cc, "Expected keyword 'while'");
     }
 
     cctrlTokenExpect(cc, '(');
-    whilecond = parseExpr(cc,16);
-    cctrlTokenExpect(cc,')');
-    cctrlTokenExpect(cc,';');
+    Ast *whilecond = parseExpr(cc, 16);
+    cctrlTokenExpect(cc, ')');
+    cctrlTokenExpect(cc, ';');
     cc->localenv = cc->localenv->parent;
     cc->tmp_loop_begin = prev_begin;
     cc->tmp_loop_end = prev_end;
-    return astDoWhile(whilecond,whilebody,while_begin, while_end);
+    return astDoWhile(whilecond, whilebody, while_begin, while_end);
 }
 
 Ast *parseBreakStatement(Cctrl *cc) {
     if (cc->tmp_loop_end == NULL) {
-        cctrlRaiseException(cc,"Floating break, not inside a breakable statement");
+        cctrlRaiseException(cc,
+                            "Floating break, not inside a breakable statement");
     }
     Ast *ast = astBreak(cc->tmp_loop_end);
-    cctrlTokenExpect(cc,';');
+    cctrlTokenExpect(cc, ';');
     return ast;
 }
 
 Ast *parseContinueStatement(Cctrl *cc) {
     if (cc->tmp_loop_begin == NULL) {
-        cctrlRaiseException(cc,"Floating continue, not inside a loop");
+        cctrlRaiseException(cc, "Floating continue, not inside a loop");
     }
     Ast *ast = astContinue(cc->tmp_loop_begin);
-    cctrlTokenExpect(cc,';');
+    cctrlTokenExpect(cc, ';');
     return ast;
 }
 
 Ast *parseReturnStatement(Cctrl *cc) {
-    Ast *retval = parseExpr(cc,16);
+    Ast *retval = parseExpr(cc, 16);
     AstType *check;
-    cctrlTokenExpect(cc,';');
+    cctrlTokenExpect(cc, ';');
     /* A best attempt at trying to get the return type of a function */
     if (cc->tmp_rettype->kind == AST_TYPE_AUTO) {
-        cc->tmp_rettype = parseReturnAuto(cc,retval);
+        cc->tmp_rettype = parseReturnAuto(cc, retval);
     }
 
-    Ast *maybe_fn = findFunctionDecl(cc,cc->tmp_fname->data,cc->tmp_fname->len);
+    Ast *maybe_fn = findFunctionDecl(cc, cc->tmp_fname->data,
+                                     cc->tmp_fname->len);
 
-    if (retval) check = retval->type;
-    else        check = ast_void_type;
+    if (retval)
+        check = retval->type;
+    else
+        check = ast_void_type;
 
-    if (check->kind == AST_TYPE_VOID && maybe_fn->type->rettype->kind == AST_TYPE_VOID) {
-        if (maybe_fn->flags & AST_FLAG_INLINE && !(cc->flags & CCTRL_TRANSPILING)) {
-            return astDecl(maybe_fn->inline_ret,NULL);
+    if (check->kind == AST_TYPE_VOID &&
+        maybe_fn->type->rettype->kind == AST_TYPE_VOID) {
+        if (maybe_fn->flags & AST_FLAG_INLINE &&
+            !(cc->flags & CCTRL_TRANSPILING)) {
+            return astDecl(maybe_fn->inline_ret, NULL);
         }
-        return astReturn(retval,cc->tmp_rettype);
+        return astReturn(retval, cc->tmp_rettype);
     }
 
-    AstType *ok = astTypeCheck(cc->tmp_rettype,retval,'\0');
+    const AstType *ok = astTypeCheck(cc->tmp_rettype, retval, '\0');
     if (!ok) {
-        Ast *func = strMapGet(cc->global_env,cc->tmp_fname->data);
-        typeCheckReturnTypeWarn(cc,func,check,retval);
+        Ast *func = strMapGet(cc->global_env, cc->tmp_fname->data);
+        typeCheckReturnTypeWarn(cc, func, check, retval);
     }
     if (maybe_fn->flags & AST_FLAG_INLINE && !(cc->flags & CCTRL_TRANSPILING)) {
-        return astDecl(maybe_fn->inline_ret,retval);
+        return astDecl(maybe_fn->inline_ret, retval);
     }
-    return astReturn(retval,cc->tmp_rettype);
+    return astReturn(retval, cc->tmp_rettype);
 }
 
-void parseRaiseCaseException(Cctrl *cc, Ast *case_expr) {
-    cctrlRewindUntilStrMatch(cc,str_lit("case"),NULL);
-    char *exp = astLValueToString(case_expr,0);
+void parseRaiseCaseException(Cctrl *cc, const Ast *case_expr) {
+    cctrlRewindUntilStrMatch(cc, str_lit("case"), NULL);
+    char *exp = astLValueToString(case_expr, 0);
     char *type = astTypeToString(case_expr->type);
     char *suggestion = mprintf("Invalid use of type %s", type);
-    cctrlRaiseExceptionFromTo(cc, suggestion, 'c', ':', "`case` must be followed by an integer constant got - %s", exp);
+    cctrlRaiseExceptionFromTo(
+            cc, suggestion, 'c', ':',
+            "`case` must be followed by an integer constant got - %s", exp);
 }
 
-Ast *parseCaseLabel(Cctrl *cc, Lexeme *tok) {
+Ast *parseCaseLabel(Cctrl *cc, const Lexeme *tok) {
     if (cc->tmp_case_list == NULL) {
-        cctrlRaiseException(cc,"unexpected 'case' found");
+        cctrlRaiseException(cc, "unexpected 'case' found");
     }
-    Ast *case_, *prev, *case_expr = NULL;
-    Lexeme *peek;
+    Ast *case_, *case_expr = NULL;
     aoStr *label;
-    int begining,end;
+    int beginning, end;
     int ok = 1;
 
-    peek = cctrlTokenPeek(cc);
-    if (tokenPunctIs(peek,':')) {
+    const Lexeme *peek = cctrlTokenPeek(cc);
+    if (tokenPunctIs(peek, ':')) {
         if (vecEmpty(cc->tmp_case_list)) {
-            begining = 0;
+            beginning = 0;
         } else {
-            prev = cc->tmp_case_list->entries[cc->tmp_case_list->size - 1];
-            begining = prev->case_end+1;
+            const Ast *prev =
+                    cc->tmp_case_list->entries[cc->tmp_case_list->size - 1];
+            beginning = prev->case_end + 1;
         }
         label = astMakeLabel();
     } else {
-        case_expr = parseExpr(cc,16);
-        begining = evalIntConstExprOrErr(case_expr, &ok);
+        case_expr = parseExpr(cc, 16);
+        beginning = evalIntConstExprOrErr(case_expr, &ok);
         if (!ok) {
-            if (cc->flags & CCTRL_PASTE_DEFINES && case_expr->kind == AST_LVAR) {
+            if (cc->flags & CCTRL_PASTE_DEFINES &&
+                case_expr->kind == AST_LVAR) {
                 label = case_expr->lname;
             } else {
-                parseRaiseCaseException(cc,case_expr);
+                parseRaiseCaseException(cc, case_expr);
             }
         } else {
             label = astMakeLabel();
@@ -1125,94 +1168,101 @@ Ast *parseCaseLabel(Cctrl *cc, Lexeme *tok) {
     tok = cctrlTokenPeek(cc);
 
     /* We're not doing label to label for transpilation */
-    if (tokenPunctIs(tok,TK_ELLIPSIS)) {
+    if (tokenPunctIs(tok, TK_ELLIPSIS)) {
         cctrlTokenGet(cc);
-        case_expr = parseExpr(cc,16);
+        case_expr = parseExpr(cc, 16);
         ok = 1;
         end = evalIntConstExprOrErr(case_expr, &ok);
-        cctrlTokenExpect(cc,':');
-        if (begining > end) {
-            cctrlRewindUntilStrMatch(cc,str_lit("case"),NULL);
-            char *suggestion = mprintf("Swap the conditions around `case %d ... %d: `",end,begining);
-            cctrlRaiseExceptionFromTo(cc, suggestion, 'c', ':', " Condition is in the wrong order '%d' must be lower than '%d'",
-                    begining, end);
+        cctrlTokenExpect(cc, ':');
+        if (beginning > end) {
+            cctrlRewindUntilStrMatch(cc, str_lit("case"), NULL);
+            char *suggestion =
+                    mprintf("Swap the conditions around `case %d ... %d: `",
+                            end, beginning);
+            cctrlRaiseExceptionFromTo(
+                    cc, suggestion, 'c', ':',
+                    " Condition is in the wrong order '%d' must be lower than '%d'",
+                    beginning, end);
         }
     } else {
-        cctrlTokenExpect(cc,':');
-        end = begining;
+        cctrlTokenExpect(cc, ':');
+        end = beginning;
     }
 
     List *stmts = listNew();
-    peek = cctrlTokenPeek(cc);
 
     if (!ok && cc->flags & CCTRL_PASTE_DEFINES) {
-        case_ = astCase(label,begining,end,stmts);
+        case_ = astCase(label, beginning, end, stmts);
         case_->type = ast_void_type;
     } else {
-        case_ = astCase(label,begining,end,stmts);
-        assertUniqueSwitchCaseLabels(cc->tmp_case_list,case_);
+        case_ = astCase(label, beginning, end, stmts);
+        assertUniqueSwitchCaseLabels(cc->tmp_case_list, case_);
     }
 
-    ptrVecPush(cc->tmp_case_list,case_);
+    ptrVecPush(cc->tmp_case_list, case_);
 
     do {
         Ast *stmt = parseStatement(cc);
-        if (stmt && stmt->kind != AST_CASE && stmt->kind != AST_DEFAULT) {
-            listAppend(stmts,stmt);
+        if (!stmt)
+            break;
+        if (stmt->kind != AST_CASE && stmt->kind != AST_DEFAULT) {
+            listAppend(stmts, stmt);
         }
         if (stmt->kind == AST_COMPOUND_STMT || stmt->kind == AST_CASE ||
-                stmt->kind == AST_DEFAULT || stmt->kind == AST_BREAK || stmt->kind == AST_RETURN
-                || stmt->kind == AST_GOTO) break;
+            stmt->kind == AST_DEFAULT || stmt->kind == AST_BREAK ||
+            stmt->kind == AST_RETURN || stmt->kind == AST_GOTO)
+            break;
         peek = cctrlTokenPeek(cc);
-   
+
         /* @Bug - Something is afoot, this ensures we don't go on forever
          * parsing if there isn't a break and the case is a fall through...
          * feels as though we could go on and just ommit the case. Which would
          * avoid the call to `astCasesCompress()`? */
-        if (tokenPunctIs(peek,'}')) break;
+        if (tokenPunctIs(peek, '}'))
+            break;
     } while (1);
 
     return case_;
 }
 
 Ast *parseDefaultStatement(Cctrl *cc) {
-    cctrlTokenExpect(cc,':');
+    cctrlTokenExpect(cc, ':');
     if (cc->tmp_default_case) {
-        cctrlRaiseException(cc,"Duplicate default case");
+        cctrlRaiseException(cc, "Duplicate default case");
     }
-    Lexeme *peek;
     List *stmts = listNew();
     aoStr *default_label = astMakeLabel();
     /* set here so this is non-null for the next call to parseStatement */
-    cc->tmp_default_case = astDefault(default_label,stmts);
+    cc->tmp_default_case = astDefault(default_label, stmts);
 
     do {
         Ast *stmt = parseStatement(cc);
-        if (stmt && stmt->kind != AST_CASE) {
-            listAppend(stmts,stmt);
+        if (!stmt)
+            break;
+        if (stmt->kind != AST_CASE) {
+            listAppend(stmts, stmt);
         }
-        if (stmt->kind == AST_COMPOUND_STMT || stmt->kind == AST_CASE || stmt->kind == AST_BREAK || stmt->kind == AST_RETURN
-                || stmt->kind == AST_GOTO) break;
-        peek = cctrlTokenPeek(cc);
-        if (tokenPunctIs(peek,'}')) break;
+        if (stmt->kind == AST_COMPOUND_STMT || stmt->kind == AST_CASE ||
+            stmt->kind == AST_BREAK || stmt->kind == AST_RETURN ||
+            stmt->kind == AST_GOTO)
+            break;
+        Lexeme *peek = cctrlTokenPeek(cc);
+        if (tokenPunctIs(peek, '}'))
+            break;
     } while (1);
 
     return cc->tmp_default_case;
 }
 
 Ast *parseSwitchStatement(Cctrl *cc) {
-    Ast *cond, *tmp, *original_default_label;
-    Lexeme *peek;
-    PtrVec *original_cases;
-    aoStr *end_label,*tmp_name,*original_break;
     int switch_bounds_checked = 1;
     char terminating_char = ')';
 
-    peek = cctrlTokenPeek(cc);
+    Lexeme *peek = cctrlTokenPeek(cc);
 
-    if (!tokenPunctIs(peek,'[') && !tokenPunctIs(peek, '(')) {
-        cctrlRaiseException(cc,"Switch '(' or '[' expected got: %s",
-                lexemeToString(peek));
+    if (!tokenPunctIs(peek, '[') && !tokenPunctIs(peek, '(')) {
+        cctrlRaiseException(cc, "Switch '(' or '[' expected got: %s",
+                            lexemeToString(peek));
     }
 
     /* Walk past and set the expected terminting character */
@@ -1222,39 +1272,34 @@ Ast *parseSwitchStatement(Cctrl *cc) {
     }
 
     cctrlTokenGet(cc);
-    cond = parseExpr(cc,16);
+    Ast *cond = parseExpr(cc, 16);
     if (!astIsIntType(cond->type)) {
-        cctrlRaiseException(cc,"Switch can only have int's at this time");
+        cctrlRaiseException(cc, "Switch can only have int's at this time");
     }
-    cctrlTokenExpect(cc,terminating_char);
+    cctrlTokenExpect(cc, terminating_char);
 
-    original_break = cc->tmp_loop_end;
-    original_default_label = cc->tmp_default_case;
-    original_cases = cc->tmp_case_list;
+    aoStr *original_break = cc->tmp_loop_end;
+    Ast *original_default_label = cc->tmp_default_case;
+    PtrVec *original_cases = cc->tmp_case_list;
 
     cc->tmp_case_list = ptrVecNew();
     cc->tmp_default_case = NULL;
 
-    end_label = astMakeLabel();
+    aoStr *end_label = astMakeLabel();
 
     /* this is the current label */
     cc->tmp_loop_end = end_label;
 
-    tmp_name = astMakeTmpName();
+    const aoStr *tmp_name = astMakeTmpName();
 
-    tmp = astLVar(cond->type, tmp_name->data, tmp_name->len);
-    listAppend(cc->tmp_locals,tmp);
+    Ast *tmp = astLVar(cond->type, tmp_name->data, tmp_name->len);
+    listAppend(cc->tmp_locals, tmp);
 
     parseStatement(cc);
     aoStrRelease(tmp_name);
 
-    Ast *switch_ast = astSwitch(
-        cond,
-        cc->tmp_case_list,
-        cc->tmp_default_case,
-        end_label,
-        switch_bounds_checked
-    );
+    Ast *switch_ast = astSwitch(cond, cc->tmp_case_list, cc->tmp_default_case,
+                                end_label, switch_bounds_checked);
 
     cc->tmp_loop_end = original_break;
     cc->tmp_case_list = original_cases;
@@ -1262,161 +1307,183 @@ Ast *parseSwitchStatement(Cctrl *cc) {
     return switch_ast;
 }
 
-/* Concatinate the label of the goto with the name of the function 
+/* Concatinate the label of the goto with the name of the function
  * currently being parsed to be able to have uniqe goto labels  */
 aoStr *createFunctionLevelGotoLabel(Cctrl *cc, Lexeme *tok) {
     aoStr *label = aoStrNew();
-    aoStrCatPrintf(label,".%s_%.*s",cc->tmp_fname->data,tok->len,tok->start);
+    aoStrCatPrintf(label, ".%s_%.*s", cc->tmp_fname->data, tok->len,
+                   tok->start);
     return label;
 }
 
 Ast *parseStatement(Cctrl *cc) {
-    Lexeme *tok, *peek;
+    Lexeme *peek;
     aoStr *label;
     Ast *ret, *ast;
-    StrMap *env;
-    tok = cctrlTokenGet(cc);
+    Lexeme *tok = cctrlTokenGet(cc);
 
     if (tok->tk_type == TK_KEYWORD) {
         switch (tok->i64) {
-            case KW_IF:       return parseIfStatement(cc);
-            case KW_FOR:      return parseForStatement(cc);
-            case KW_WHILE:    return parseWhileStatement(cc);
-            case KW_DO:       return parseDoWhileStatement(cc);
-            case KW_RETURN:   return parseReturnStatement(cc);
-            case KW_SWITCH:   return parseSwitchStatement(cc);
-            case KW_CASE:     return parseCaseLabel(cc,tok);
-            case KW_DEFAULT:  return parseDefaultStatement(cc);
-            case KW_BREAK:    return parseBreakStatement(cc);
-            case KW_CONTINUE: return parseContinueStatement(cc);
-            case KW_STATIC: {
-                env = cc->localenv;
-                cc->localenv = NULL;
+        case KW_IF:
+            return parseIfStatement(cc);
+        case KW_FOR:
+            return parseForStatement(cc);
+        case KW_WHILE:
+            return parseWhileStatement(cc);
+        case KW_DO:
+            return parseDoWhileStatement(cc);
+        case KW_RETURN:
+            return parseReturnStatement(cc);
+        case KW_SWITCH:
+            return parseSwitchStatement(cc);
+        case KW_CASE:
+            return parseCaseLabel(cc, tok);
+        case KW_DEFAULT:
+            return parseDefaultStatement(cc);
+        case KW_BREAK:
+            return parseBreakStatement(cc);
+        case KW_CONTINUE:
+            return parseContinueStatement(cc);
+        case KW_STATIC: {
+            StrMap *env = cc->localenv;
+            cc->localenv = NULL;
 
-                AstType *type = parseFullType(cc);
-                tok = cctrlTokenGet(cc);
+            AstType *type = parseFullType(cc);
+            tok = cctrlTokenGet(cc);
 
-                if (tok->tk_type != TK_IDENT) {
-                    cctrlTokenRewind(cc);
-                    cctrlRaiseException(cc,"Expected variable name following type declaration '%s' - '%s' <var_name>",
-                            astTypeToString(type), astTypeToString(type));
-                }
-                type = parseArrayDimensions(cc,type);
+            if (tok->tk_type != TK_IDENT) {
+                cctrlTokenRewind(cc);
+                cctrlRaiseException(
+                        cc,
+                        "Expected variable name following type declaration '%s' - '%s' <var_name>",
+                        astTypeToString(type), astTypeToString(type));
+            }
+            type = parseArrayDimensions(cc, type);
 
-                Ast *gvar_ast = astGVar(type,tok->start,tok->len,1);
+            Ast *gvar_ast = astGVar(type, tok->start, tok->len, 1);
 
+            if (type->kind == AST_TYPE_ARRAY) {
+                ast = parseVariableInitialiser(cc, gvar_ast,
+                                               PUNCT_TERM_SEMI |
+                                                       PUNCT_TERM_COMMA);
 
-                if (type->kind == AST_TYPE_ARRAY) {
-                    ast = parseVariableInitialiser(cc,gvar_ast,
-                            PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
-
-                    cc->localenv = env;
-                    strMapAdd(env,gvar_ast->gname->data,gvar_ast);
-                    listAppend(cc->ast_list,ast);
-                    return ast;
-                }
-
-                peek = cctrlTokenPeek(cc);
-                if (tokenPunctIs(peek,'=')) {
-                    ast = parseVariableInitialiser(cc,gvar_ast,
-                            PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
-
-                    if (type->kind == AST_TYPE_AUTO) {
-                        gvar_ast->type = ast->declinit->type;
-                        if (ast->declinit->kind == AST_STRING) {
-                            /* @Leak: we've just lost the original string array
-                             * that was parsed... or have we? Possibly not as it
-                             * would exist on the declinit->type and we do not 
-                             * change it */
-                            gvar_ast->type = astMakePointerType(ast_u8_type);
-                            gvar_ast->type->len = ast->declinit->type->len;
-                        }
-                    }
-
-                    if (ast->declinit->kind == AST_ASM_FUNCALL ||
-                        parseIsFunctionCall(ast->declinit))
-                    {
-                        cctrlRaiseException(cc,"'%s %s' must be a compile time "
-                                "constant",
-                                astTypeToColorString(gvar_ast->type),
-                                astLValueToString(ast,0));
-                    }
-                } else {
-                    cctrlTokenExpect(cc,';');
-                    ast = astDecl(gvar_ast,NULL);
-                }
                 cc->localenv = env;
-                strMapAdd(env,gvar_ast->gname->data,gvar_ast);
-                listAppend(cc->ast_list,ast);
+                strMapAdd(env, gvar_ast->gname->data, gvar_ast);
+                listAppend(cc->ast_list, ast);
                 return ast;
             }
 
-            case KW_GOTO: {
-                tok = cctrlTokenGet(cc);
-                label = createFunctionLevelGotoLabel(cc,tok);
-                ret = astGoto(label);
-                cctrlTokenExpect(cc,';');
-                return ret;
-            }
+            peek = cctrlTokenPeek(cc);
+            if (tokenPunctIs(peek, '=')) {
+                ast = parseVariableInitialiser(cc, gvar_ast,
+                                               PUNCT_TERM_SEMI |
+                                                       PUNCT_TERM_COMMA);
 
-            /**
-             * XXX: DELETE cast<>
-             * It is possible to do: 
-             * cast<Obj *>(_ptr)->x = 10;
-             * */
-            case KW_CAST: {
-                cctrlTokenRewind(cc);
-                ast = parseExpr(cc,16);
-                tok = cctrlTokenGet(cc);
-                assertTokenIsTerminator(cc,tok,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
-                return ast;
+                if (type->kind == AST_TYPE_AUTO) {
+                    gvar_ast->type = ast->declinit->type;
+                    if (ast->declinit->kind == AST_STRING) {
+                        /* @Leak: we've just lost the original string array
+                         * that was parsed... or have we? Possibly not as it
+                         * would exist on the declinit->type and we do not
+                         * change it */
+                        gvar_ast->type = astMakePointerType(ast_u8_type);
+                        gvar_ast->type->len = ast->declinit->type->len;
+                    }
+                }
+
+                if (ast->declinit->kind == AST_ASM_FUNCALL ||
+                    parseIsFunctionCall(ast->declinit)) {
+                    cctrlRaiseException(cc,
+                                        "'%s %s' must be a compile time "
+                                        "constant",
+                                        astTypeToColorString(gvar_ast->type),
+                                        astLValueToString(ast, 0));
+                }
+            } else {
+                cctrlTokenExpect(cc, ';');
+                ast = astDecl(gvar_ast, NULL);
             }
-            default: {
-                cctrlTokenRewind(cc);
-                cctrlRaiseException(cc,"Keyword '%.*s' cannot be used in this context",
-                        tok->len,tok->start);
-            }
+            cc->localenv = env;
+            strMapAdd(env, gvar_ast->gname->data, gvar_ast);
+            listAppend(cc->ast_list, ast);
+            return ast;
+        }
+
+        case KW_GOTO: {
+            tok = cctrlTokenGet(cc);
+            label = createFunctionLevelGotoLabel(cc, tok);
+            ret = astGoto(label);
+            cctrlTokenExpect(cc, ';');
+            return ret;
+        }
+
+        /**
+         * XXX: DELETE cast<>
+         * It is possible to do:
+         * cast<Obj *>(_ptr)->x = 10;
+         * */
+        case KW_CAST: {
+            cctrlTokenRewind(cc);
+            ast = parseExpr(cc, 16);
+            tok = cctrlTokenGet(cc);
+            assertTokenIsTerminator(cc, tok,
+                                    PUNCT_TERM_SEMI | PUNCT_TERM_COMMA);
+            return ast;
+        }
+        default: {
+            cctrlTokenRewind(cc);
+            cctrlRaiseException(cc,
+                                "Keyword '%.*s' cannot be used in this context",
+                                tok->len, tok->start);
+        }
         }
     }
 
     if (tok->tk_type == TK_CHAR_CONST) {
-        return parseFloatingCharConst(cc,tok);
+        return parseFloatingCharConst(cc, tok);
     }
 
     if (tok->tk_type == TK_STR) {
         cctrlTokenRewind(cc);
         /* HACK in holyc printf */
-        return parseFunctionArguments(cc,"printf",6,';');
+        return parseFunctionArguments(cc, "printf", 6, ';');
     }
 
     /* Hacked in goto label ;) */
     peek = cctrlTokenPeek(cc);
     if (tok->tk_type == TK_IDENT && peek && peek->i64 == ':') {
-        label = createFunctionLevelGotoLabel(cc,tok);
+        label = createFunctionLevelGotoLabel(cc, tok);
         ret = astLabel(label);
         /* consume ':' */
-        cctrlTokenExpect(cc,':');
+        cctrlTokenExpect(cc, ':');
         return ret;
     }
 
-    if (tokenPunctIs(tok,'{')) {
+    if (tokenPunctIs(tok, '{')) {
         return parseCompoundStatement(cc);
     }
 
     if (tok->tk_type == TK_I64) {
-        cctrlRaiseException(cc,"Floating integer constant '%ld' cannot be used in this context", tok->i64);
+        cctrlRaiseException(
+                cc,
+                "Floating integer constant '%ld' cannot be used in this context",
+                tok->i64);
     } else if (tok->tk_type == TK_F64) {
-        cctrlRaiseException(cc,"Floating integer constant '%f' cannot be used in this context", tok->f64);
+        cctrlRaiseException(
+                cc,
+                "Floating integer constant '%f' cannot be used in this context",
+                tok->f64);
     } else if (tok->tk_type == TK_PUNCT && (tok->i64 == ',')) {
         lexemePrint(tok);
         cctrlTokenRewind(cc);
-        cctrlRaiseException(cc, "Floating '%c' cannot be used in this context", tok->i64);
+        cctrlRaiseException(cc, "Floating '%c' cannot be used in this context",
+                            tok->i64);
     }
 
     cctrlTokenRewind(cc);
-    ast = parseExpr(cc,16);
+    ast = parseExpr(cc, 16);
     tok = cctrlTokenGet(cc);
-    assertTokenIsTerminator(cc,tok,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
+    assertTokenIsTerminator(cc, tok, PUNCT_TERM_SEMI | PUNCT_TERM_COMMA);
     return ast;
 }
 
@@ -1425,81 +1492,90 @@ Ast *parseDeclOrStatement(Cctrl *cc) {
     if (!tok) {
         return NULL;
     }
-    if (cctrlIsKeyword(cc,tok->start,tok->len)) {
+    if (cctrlIsKeyword(cc, tok->start, tok->len)) {
         return parseDecl(cc);
     }
     return parseStatement(cc);
 }
 
-void parseCompoundStatementInternal(Cctrl *cc, Ast *body) {
+void parseCompoundStatementInternal(Cctrl *cc, const Ast *body) {
     Ast *stmt, *var;
-    AstType *base_type, *type, *next_type;
-    Lexeme *tok, *varname, *peek;
     cc->localenv = strMapNewWithParent(32, cc->localenv);
-    tok = NULL;
+    Lexeme *tok = NULL;
 
     tok = cctrlTokenPeek(cc);
 
     while (tok && !tokenPunctIs(tok, '}')) {
-        if (cctrlIsKeyword(cc,tok->start,tok->len)) {
-            base_type = parseBaseDeclSpec(cc);
+        if (cctrlIsKeyword(cc, tok->start, tok->len)) {
+            AstType *base_type = parseBaseDeclSpec(cc);
             while (1) {
-                next_type = parsePointerType(cc,base_type);
-                peek = cctrlTokenPeek(cc);
+                AstType *next_type = parsePointerType(cc, base_type);
+                Lexeme *peek = cctrlTokenPeek(cc);
 
-                if (!tokenPunctIs(peek,'(')) {
+                if (!tokenPunctIs(peek, '(')) {
                     /* A normal variable */
-                    varname = cctrlTokenGet(cc);
+                    const Lexeme *varname = cctrlTokenGet(cc);
                     if (varname->tk_type != TK_IDENT) {
                         cctrlTokenRewind(cc);
-                        cctrlRaiseException(cc,"Expected type declaration with identifer got '%.*s' - should be"ESC_BLUE" '%s "ESC_RESET ESC_BOLD"<var_name>'",
-                                peek->len, peek->start, astTypeToString(next_type));
+                        cctrlRaiseException(
+                                cc,
+                                "Expected type declaration with identifer got '%.*s' - should be" ESC_BLUE
+                                " '%s " ESC_RESET ESC_BOLD "<var_name>'",
+                                peek->len, peek->start,
+                                astTypeToString(next_type));
                         break;
                     }
-                    type = parseArrayDimensions(cc,next_type);
-                    var = astLVar(type,varname->start,varname->len);
-                    if (!strMapAddOrErr(cc->localenv,var->lname->data,var)) {
-                        cctrlRewindUntilStrMatch(cc,var->lname->data,var->lname->len,NULL);
-                        cctrlRaiseException(cc,"variable `%s` already declared",
-                                astLValueToString(var,0));
+                    AstType *type = parseArrayDimensions(cc, next_type);
+                    var = astLVar(type, varname->start, varname->len);
+                    if (!strMapAddOrErr(cc->localenv, var->lname->data, var)) {
+                        cctrlRewindUntilStrMatch(cc, var->lname->data,
+                                                 var->lname->len, NULL);
+                        cctrlRaiseException(cc,
+                                            "variable `%s` already declared",
+                                            astLValueToString(var, 0));
                     }
                 } else {
                     cctrlTokenGet(cc);
-                    var = parseFunctionPointer(cc,next_type);
-                    strMapAdd(cc->localenv,var->fname->data,var);
+                    var = parseFunctionPointer(cc, next_type);
+                    strMapAdd(cc->localenv, var->fname->data, var);
                 }
 
                 if (cc->tmp_locals) {
                     listAppend(cc->tmp_locals, var);
                 }
 
-                stmt = parseVariableInitialiser(cc,var,PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
+                stmt = parseVariableInitialiser(cc, var,
+                                                PUNCT_TERM_COMMA |
+                                                        PUNCT_TERM_SEMI);
                 if (next_type->kind == AST_TYPE_AUTO) {
-                    parseAssignAuto(cc,stmt);
+                    parseAssignAuto(cc, stmt);
                 }
 
                 if (stmt) {
-                    listAppend(body->stms,stmt);
+                    listAppend(body->stms, stmt);
                 }
                 cctrlTokenRewind(cc);
                 tok = cctrlTokenGet(cc);
 
                 if (tokenPunctIs(tok, ',')) {
                     continue;
-                } else if (tokenPunctIs(tok,';')) {
+                } else if (tokenPunctIs(tok, ';')) {
                     break;
                 } else {
-                    cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing statement, perhaps you meant to terminate the declaration with `;`?",
-                            lexemeTypeToString(tok->tk_type), tok->len,tok->start);
+                    cctrlRaiseException(
+                            cc,
+                            "Unexpected %s `%.*s` while parsing statement, perhaps you meant to terminate the declaration with `;`?",
+                            lexemeTypeToString(tok->tk_type), tok->len,
+                            tok->start);
                 }
             }
-        } else { 
+        } else {
             if ((stmt = parseStatement(cc)) != NULL) {
                 if (stmt->kind == AST_DECL && stmt->declvar->kind == AST_GVAR) {
                     tok = cctrlTokenPeek(cc);
                     continue;
                 }
-                listAppend(body->stms,stmt);
+                listAppend(body->stms, stmt);
             } else {
                 break;
             }
@@ -1507,7 +1583,7 @@ void parseCompoundStatementInternal(Cctrl *cc, Ast *body) {
         tok = cctrlTokenPeek(cc);
     }
     cc->localenv = cc->localenv->parent;
-    cctrlTokenExpect(cc,'}');
+    cctrlTokenExpect(cc, '}');
     cctrlTokenPeek(cc);
 }
 
@@ -1518,9 +1594,8 @@ Ast *parseCompoundStatement(Cctrl *cc) {
     return ast_compound;
 }
 
-Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
-        char *fname, int len, PtrVec *params, int has_var_args, int is_inline) 
-{
+Ast *parseFunctionDef(Cctrl *cc, AstType *rettype, char *fname, int len,
+                      PtrVec *params, int has_var_args, int is_inline) {
     List *locals = listNew();
     Ast *func = NULL;
     List *body = listNew();
@@ -1531,41 +1606,42 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
     cc->tmp_locals = locals;
 
     /* Upgrade a prototype to an actual function */
-    func = strMapGetLen(cc->global_env,fname,len);
+    func = strMapGetLen(cc->global_env, fname, len);
     if (!func) {
         cc->tmp_params = params;
         cc->tmp_rettype = rettype;
         fn_type = astMakeFunctionType(cc->tmp_rettype, params);
-        func = astFunction(fn_type,fname,len,params,NULL,locals,
-                has_var_args);
-        strMapAdd(cc->global_env,func->fname->data,func);
+        func = astFunction(fn_type, fname, len, params, NULL, locals,
+                           has_var_args);
+        strMapAdd(cc->global_env, func->fname->data, func);
     } else {
         switch (func->kind) {
-            case AST_EXTERN_FUNC:
-                cctrlRaiseException(cc,"Cannot redefine extern function: %.*s",len,fname);
+        case AST_EXTERN_FUNC:
+            cctrlRaiseException(cc, "Cannot redefine extern function: %.*s",
+                                len, fname);
 
-            case AST_FUNC:
-                cctrlRaiseException(cc,"Cannot redefine function: %.*s",len,fname);
+        case AST_FUNC:
+            cctrlRaiseException(cc, "Cannot redefine function: %.*s", len,
+                                fname);
 
-            case AST_ASM_FUNC_BIND:
-                cctrlRaiseException(cc,"Cannot redefine asm function: %.*s",
-                        len,fname);
+        case AST_ASM_FUNC_BIND:
+            cctrlRaiseException(cc, "Cannot redefine asm function: %.*s", len,
+                                fname);
 
-            case AST_FUN_PROTO:
-                /* upgrade prototype to a function */
-                func->locals = cc->tmp_locals;
-                func->params = params;
-                cc->tmp_params = func->params;
-                cc->tmp_rettype = func->type->rettype;
-                fn_type = func->type;
-                func->kind = AST_FUNC;
-                break;
+        case AST_FUN_PROTO:
+            /* upgrade prototype to a function */
+            func->locals = cc->tmp_locals;
+            func->params = params;
+            cc->tmp_params = func->params;
+            cc->tmp_rettype = func->type->rettype;
+            fn_type = func->type;
+            func->kind = AST_FUNC;
+            break;
 
-            default:
-                cctrlRaiseException(cc,"Unexpected function: %.*s -> %s",
-                        cc->lineno,
-                        len,fname, astToString(func));
-                break;
+        default:
+            cctrlRaiseException(cc, "Unexpected function: %.*s -> %s",
+                                cc->lineno, len, fname, astToString(func));
+            break;
         }
     }
 
@@ -1582,7 +1658,7 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
     parseCompoundStatementInternal(cc, func_body);
     fn_type->rettype = cc->tmp_rettype;
     if (is_inline) {
-        listAppend(func->locals,func->inline_ret);
+        listAppend(func->locals, func->inline_ret);
     }
 
     cc->localenv = NULL;
@@ -1594,7 +1670,8 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
     return func;
 }
 
-Ast *parseExternFunctionProto(Cctrl *cc, AstType *rettype, char *fname, int len) {
+Ast *parseExternFunctionProto(Cctrl *cc, AstType *rettype, char *fname,
+                              int len) {
     Ast *func;
     int has_var_args = 0;
     PtrVec *params;
@@ -1602,79 +1679,85 @@ Ast *parseExternFunctionProto(Cctrl *cc, AstType *rettype, char *fname, int len)
     cc->localenv = strMapNewWithParent(32, cc->localenv);
     cc->tmp_locals = NULL;
 
-    params = parseParams(cc,')', &has_var_args,1);
+    params = parseParams(cc, ')', &has_var_args, 1);
     tok = cctrlTokenGet(cc);
     if (!tokenPunctIs(tok, ';')) {
-        cctrlRaiseException(cc,"extern %.*s() cannot have a function body "
-                "this will be defined elsewhere",
-                len,fname);
+        cctrlRaiseException(cc,
+                            "extern %.*s() cannot have a function body "
+                            "this will be defined elsewhere",
+                            len, fname);
     }
     AstType *type = astMakeFunctionType(rettype, params);
-    func = astFunction(type,fname,len,params,NULL,NULL,0);
+    func = astFunction(type, fname, len, params, NULL, NULL, 0);
     func->kind = AST_EXTERN_FUNC;
-    strMapAdd(cc->global_env,func->fname->data,func);
+    strMapAdd(cc->global_env, func->fname->data, func);
     return func;
 }
 
-Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int is_inline) {
+Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len,
+                        int is_inline) {
     int has_var_args = 0;
-    cctrlTokenExpect(cc,'(');
+    cctrlTokenExpect(cc, '(');
     cc->localenv = strMapNewWithParent(32, cc->localenv);
     cc->tmp_locals = listNew();
 
-    PtrVec *params = parseParams(cc,')',&has_var_args,1);
-    Lexeme *tok = cctrlTokenGet(cc);
+    PtrVec *params = parseParams(cc, ')', &has_var_args, 1);
+    const Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {
-        return parseFunctionDef(cc,rettype,fname,len,params,has_var_args,is_inline);
+        return parseFunctionDef(cc, rettype, fname, len, params, has_var_args,
+                                is_inline);
     } else {
         if (rettype->kind == AST_TYPE_AUTO) {
-            cctrlRaiseException(cc,"auto cannot be used with a function prototype %.*s() at this time",
-                    len,fname);
+            cctrlRaiseException(
+                    cc,
+                    "auto cannot be used with a function prototype %.*s() at this time",
+                    len, fname);
         }
         AstType *type = astMakeFunctionType(rettype, params);
-        Ast *fn = astFunction(type,fname,len,params,NULL,NULL,has_var_args);
+        Ast *fn = astFunction(type, fname, len, params, NULL, NULL,
+                              has_var_args);
         fn->kind = AST_FUN_PROTO;
-        strMapAdd(cc->global_env,fn->fname->data,fn);
+        strMapAdd(cc->global_env, fn->fname->data, fn);
         return fn;
     }
 }
 
 Ast *parseAsmFunctionBinding(Cctrl *cc) {
-    Lexeme *tok;
-    aoStr *asm_fname, *c_fname;
-    AstType *rettype;
-    Ast *asm_func;
-    int has_var_args = 0, is_inline = 0;
+    int has_var_args = 0;
 
-    tok = cctrlTokenGet(cc);
+    const Lexeme *tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT && tok->start[0] != '_') {
-        cctrlRaiseException(cc,"ASM function binds must begin with '_' got: %.*s",
-                tok->len,tok->start);
+        cctrlRaiseException(cc,
+                            "ASM function binds must begin with '_' got: %.*s",
+                            tok->len, tok->start);
     }
 
-    asm_fname = aoStrDupRaw(tok->start,tok->len);
-    Ast *asm_blk = strMapGetLen(cc->asm_functions, asm_fname->data, asm_fname->len);
+    aoStr *asm_fname = aoStrDupRaw(tok->start, tok->len);
+    Ast *asm_blk = strMapGetLen(cc->asm_functions, asm_fname->data,
+                                asm_fname->len);
 
-    rettype = parseDeclSpec(cc);
+    AstType *rettype = parseDeclSpec(cc);
 
     if (rettype->kind == AST_TYPE_AUTO) {
-        cctrlRaiseException(cc,"auto cannot be used with an assembly binding for function %s(), type cannot be automatically deduced",
+        cctrlRaiseException(
+                cc,
+                "auto cannot be used with an assembly binding for function %s(), type cannot be automatically deduced",
                 asm_fname->data);
     }
 
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        cctrlRaiseException(cc,"line %d: ASM function requires c function name");
+        cctrlRaiseException(cc,
+                            "line %d: ASM function requires c function name");
     }
-    c_fname = aoStrDupRaw(tok->start,tok->len);
+    aoStr *c_fname = aoStrDupRaw(tok->start, tok->len);
     cc->localenv = strMapNewWithParent(32, cc->localenv);
-    cctrlTokenExpect(cc,'(');
+    cctrlTokenExpect(cc, '(');
 
-    PtrVec *params = parseParams(cc,')',&has_var_args,0);
+    PtrVec *params = parseParams(cc, ')', &has_var_args, 0);
 
-    asm_func = astAsmFunctionBind(
-            astMakeFunctionType(rettype, params),
-            asm_fname,c_fname,params);
+    Ast *asm_func = astAsmFunctionBind(astMakeFunctionType(rettype, params),
+                                       asm_fname, c_fname, params);
 
     /* update the assembly block so it knows the HC function name */
     if (asm_blk && asm_blk->fname == NULL) {
@@ -1683,16 +1766,14 @@ Ast *parseAsmFunctionBinding(Cctrl *cc) {
 
     cc->localenv = NULL;
     /* Map a c function to an ASM function */
-    strMapAdd(cc->asm_funcs,c_fname->data,asm_func);
-    cctrlTokenExpect(cc,';');
-    if (is_inline) {
-        asm_func->flags |= AST_FLAG_INLINE;
-    }
+    strMapAdd(cc->asm_funcs, c_fname->data, asm_func);
+    cctrlTokenExpect(cc, ';');
+
     return asm_func;
 }
 
 Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
-    Ast *variable, *asm_block, *asm_func, *extern_func, *ast;
+    Ast *variable, *asm_func, *ast;
     AstType *type = NULL;
     Lexeme *tok, *name, *peek;
     int is_static = 0;
@@ -1704,229 +1785,251 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
 
         if (tok->tk_type == TK_KEYWORD) {
             switch (tok->i64) {
-                case KW_ASM_EXTERN: {
-                    if ((asm_func = parseAsmFunctionBinding(cc)) != NULL) {
-                        return asm_func;
-                    }
-                    cctrlRaiseException(cc,"Floating \"_extern\" keyword, expected \"_extern '_ASM_FUNC'\""); 
+            case KW_ASM_EXTERN: {
+                if ((asm_func = parseAsmFunctionBinding(cc)) != NULL) {
+                    return asm_func;
                 }
+                cctrlRaiseException(
+                        cc,
+                        "Floating \"_extern\" keyword, expected \"_extern '_ASM_FUNC'\"");
+            }
 
-                case KW_ASM: {
-                    peek = cctrlTokenPeek(cc);
-                    if (tokenPunctIs(peek,'{')) {
-                        asm_block = prsAsm(cc);
-                        listAppend(cc->asm_blocks,asm_block);
-                        return asm_block;
-                    }
-                    cctrlRaiseException(cc,"Floating \"asm\" keyword, expected \"asm {\"");
+            case KW_ASM: {
+                peek = cctrlTokenPeek(cc);
+                if (tokenPunctIs(peek, '{')) {
+                    Ast *asm_block = prsAsm(cc);
+                    listAppend(cc->asm_blocks, asm_block);
+                    return asm_block;
                 }
+                cctrlRaiseException(
+                        cc, "Floating \"asm\" keyword, expected \"asm {\"");
+            }
 
-                case KW_EXTERN: {
-                    tok = cctrlTokenGet(cc);
-                    if (tok->tk_type == TK_STR && !strncmp(tok->start,"c",1)) {
-                        type = parseDeclSpec(cc);
-                        name = cctrlTokenGet(cc);
-                        cctrlTokenExpect(cc,'(');
-                        extern_func = parseExternFunctionProto(cc,type,
-                                name->start,name->len);
-                        return extern_func;
-                    }
-                    cctrlRaiseException(cc,"Can only call external c functions for the "
-                            "time being");
-                }
-                case KW_INLINE: {
-                    peek = cctrlTokenPeek(cc);
-                    if (!cctrlGetKeyWord(cc, peek->start, peek->len)) {
-                        cctrlRaiseException(cc,"Expected return type declaration got: '%.*s'",
-                                peek->len,peek->start);
-                    }
-                    type = parseFullType(cc);
+            case KW_EXTERN: {
+                tok = cctrlTokenGet(cc);
+                if (tok->tk_type == TK_STR && !strncmp(tok->start, "c", 1)) {
+                    type = parseDeclSpec(cc);
                     name = cctrlTokenGet(cc);
-                    
-                    ast = parseFunctionOrDef(cc,type,name->start,name->len,1); 
-                    ast->flags |= AST_FLAG_INLINE;
-                    return ast;
+                    cctrlTokenExpect(cc, '(');
+                    Ast *extern_func = parseExternFunctionProto(cc, type,
+                                                                name->start,
+                                                                name->len);
+                    return extern_func;
                 }
-                case KW_PUBLIC:
-                case KW_PRIVATE:
-                case KW_ATOMIC:
-                    continue;
+                cctrlRaiseException(
+                        cc,
+                        "Can only call external c functions for the "
+                        "time being");
+            }
+            case KW_INLINE: {
+                peek = cctrlTokenPeek(cc);
+                if (!cctrlGetKeyWord(cc, peek->start, peek->len)) {
+                    cctrlRaiseException(
+                            cc, "Expected return type declaration got: '%.*s'",
+                            peek->len, peek->start);
+                }
+                type = parseFullType(cc);
+                name = cctrlTokenGet(cc);
 
-                case KW_STATIC:
-                    type = parseDeclSpec(cc);
-                    if (type == NULL) {
-                        cctrlRaiseException(cc,"Expected type declaration");
-                    }
-                    /* static at the global scope does not yet do anything */
-                    is_static = 1;
-                    (void)is_static;
-                    break;
-                
-                case KW_CLASS:
-                    parseClassDef(cc,0);
-                    cctrlTokenExpect(cc,';');
-                    continue;
+                ast = parseFunctionOrDef(cc, type, name->start, name->len, 1);
+                ast->flags |= AST_FLAG_INLINE;
+                return ast;
+            }
+            case KW_PUBLIC:
+            case KW_PRIVATE:
+            case KW_ATOMIC:
+                continue;
 
-                case KW_UNION:
-                    parseUnionDef(cc);
-                    cctrlTokenExpect(cc,';');
-                    continue;
+            case KW_STATIC:
+                type = parseDeclSpec(cc);
+                if (type == NULL) {
+                    cctrlRaiseException(cc, "Expected type declaration");
+                }
+                /* static at the global scope does not yet do anything */
+                is_static = 1;
+                (void)is_static;
+                break;
 
-                case KW_U0: 
-                case KW_BOOL:
-                case KW_I8:
-                case KW_U8:
-                case KW_I16:
-                case KW_U16:
-                case KW_I32:
-                case KW_U32:
-                case KW_I64:
-                case KW_U64:
-                case KW_F64:
-                case KW_AUTO:
-                    cctrlTokenRewind(cc);
-                    type = parseDeclSpec(cc);
-                    break;
+            case KW_CLASS:
+                parseClassDef(cc, 0);
+                cctrlTokenExpect(cc, ';');
+                continue;
 
-                case KW_IF:
-                    cc->tmp_locals = listNew();
-                    *is_global = 1;
-                    return parseIfStatement(cc);
+            case KW_UNION:
+                parseUnionDef(cc);
+                cctrlTokenExpect(cc, ';');
+                continue;
 
-                case KW_WHILE:
-                    cc->tmp_locals = listNew();
-                    *is_global = 1;
-                    return parseWhileStatement(cc);
+            case KW_U0:
+            case KW_BOOL:
+            case KW_I8:
+            case KW_U8:
+            case KW_I16:
+            case KW_U16:
+            case KW_I32:
+            case KW_U32:
+            case KW_I64:
+            case KW_U64:
+            case KW_F64:
+            case KW_AUTO:
+                cctrlTokenRewind(cc);
+                type = parseDeclSpec(cc);
+                break;
 
-                case KW_DO:
-                    cc->tmp_locals = listNew();
-                    *is_global = 1;
-                    return parseDoWhileStatement(cc);
+            case KW_IF:
+                cc->tmp_locals = listNew();
+                *is_global = 1;
+                return parseIfStatement(cc);
 
-                case KW_FOR:
-                    cc->tmp_locals = listNew();
-                    *is_global = 1;
-                    return parseForStatement(cc);
+            case KW_WHILE:
+                cc->tmp_locals = listNew();
+                *is_global = 1;
+                return parseWhileStatement(cc);
 
-                default:
-                    cctrlRaiseException(cc,"Unexpected floating keyword: %.*s",
-                            tok->len,tok->start);
+            case KW_DO:
+                cc->tmp_locals = listNew();
+                *is_global = 1;
+                return parseDoWhileStatement(cc);
+
+            case KW_FOR:
+                cc->tmp_locals = listNew();
+                *is_global = 1;
+                return parseForStatement(cc);
+
+            default:
+                cctrlRaiseException(cc, "Unexpected floating keyword: %.*s",
+                                    tok->len, tok->start);
             }
         } else if (tok->tk_type == TK_IDENT) {
             /* top level function call */
             peek = cctrlTokenPeek(cc);
-            if (tokenPunctIs(peek,'(')) {
+            if (tokenPunctIs(peek, '(')) {
                 cctrlTokenGet(cc);
-                ast = parseFunctionArguments(cc,tok->start,tok->len,')');
-                cctrlTokenExpect(cc,';');
+                ast = parseFunctionArguments(cc, tok->start, tok->len, ')');
+                cctrlTokenExpect(cc, ';');
                 *is_global = 1;
                 return ast;
-            } else if ((variable = strMapGetLen(cc->global_env,tok->start, tok->len))) {
+            } else if ((variable = strMapGetLen(cc->global_env, tok->start,
+                                                tok->len))) {
                 cctrlTokenRewind(cc);
-                ast = parseExpr(cc,16);
-                cctrlTokenExpect(cc,';');
+                ast = parseExpr(cc, 16);
+                cctrlTokenExpect(cc, ';');
                 *is_global = 1;
                 return ast;
             } else {
                 cctrlTokenRewind(cc);
                 type = parseDeclSpec(cc);
                 if (type == NULL) {
-                    cctrlRaiseException(cc,"Undefined type: %.*s",tok->len,tok->start);
+                    cctrlRaiseException(cc, "Undefined type: %.*s", tok->len,
+                                        tok->start);
                 }
             }
         } else if (tok->tk_type == TK_CHAR_CONST) {
-            ast = parseFloatingCharConst(cc,tok);
+            ast = parseFloatingCharConst(cc, tok);
             *is_global = 1;
             return ast;
         } else if (tok->tk_type == TK_STR) {
             cctrlTokenRewind(cc);
-            ast = parseFunctionArguments(cc,"printf",6,';');
+            ast = parseFunctionArguments(cc, "printf", 6, ';');
             *is_global = 1;
             return ast;
         } else if (tok->tk_type == TK_I64) {
-            cctrlRaiseException(cc,"Floating integer constant '%ld' cannot be used in this context", tok->i64);
+            cctrlRaiseException(
+                    cc,
+                    "Floating integer constant '%ld' cannot be used in this context",
+                    tok->i64);
         } else if (tok->tk_type == TK_F64) {
-            cctrlRaiseException(cc,"Floating float constant '%f' cannot be used in this context", tok->f64);
+            cctrlRaiseException(
+                    cc,
+                    "Floating float constant '%f' cannot be used in this context",
+                    tok->f64);
         }
 
         name = cctrlTokenGet(cc);
 
         if (name->tk_type == TK_KEYWORD) {
             switch (name->i64) {
-                case KW_CLASS:
-                    if (!astIsIntType(type)) {
-                        cctrlRaiseException(cc,"Can only make intrinsic types from integer types, got %s",
-                                astTypeToString(type));
-                    }
-                    parseClassDef(cc,1);
-                    cctrlTokenExpect(cc,';');
-                    continue;
-                default: {
-                    cctrlRaiseException(cc,"%s can only prefix a class",lexemeToString(name));
+            case KW_CLASS:
+                if (!astIsIntType(type)) {
+                    cctrlRaiseException(
+                            cc,
+                            "Can only make intrinsic types from integer types, got %s",
+                            astTypeToString(type));
                 }
+                parseClassDef(cc, 1);
+                cctrlTokenExpect(cc, ';');
+                continue;
+            default: {
+                cctrlRaiseException(cc, "%s can only prefix a class",
+                                    lexemeToString(name));
+            }
             }
         }
 
         if (name->tk_type != TK_IDENT) {
-            cctrlRaiseException(cc,"Identifier expected: got %s",lexemeToString(name));
+            cctrlRaiseException(cc, "Identifier expected: got %s",
+                                lexemeToString(name));
         }
 
-        type = parseArrayDimensions(cc,type);
+        type = parseArrayDimensions(cc, type);
         tok = cctrlTokenPeek(cc);
 
-        if (tokenPunctIs(tok,'=') && type->kind != AST_TYPE_ARRAY) {
-            variable = astGVar(type,name->start,name->len,0);
+        if (tokenPunctIs(tok, '=') && type->kind != AST_TYPE_ARRAY) {
+            variable = astGVar(type, name->start, name->len, 0);
             if (type->kind == AST_TYPE_AUTO) {
-                cctrlRaiseException(cc,"line auto cannot be used without an initialiser");
+                cctrlRaiseException(
+                        cc, "line auto cannot be used without an initialiser");
             }
-            ast = astDecl(variable,NULL);
-            listAppend(cc->ast_list,ast);
-            strMapAdd(cc->global_env,variable->gname->data,variable);
+            ast = astDecl(variable, NULL);
+            listAppend(cc->ast_list, ast);
+            strMapAdd(cc->global_env, variable->gname->data, variable);
             cctrlTokenRewind(cc);
             *is_global = 1;
-            
-            ast = parseExpr(cc,16); // parseVariableInitialiser(cc,variable,PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
-            cctrlTokenExpect(cc,';');
+
+            ast = parseExpr(
+                    cc,
+                    16); // parseVariableInitialiser(cc,variable,PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
+            cctrlTokenExpect(cc, ';');
             return ast;
         } else if (type->kind == AST_TYPE_ARRAY) {
-            variable = astGVar(type,name->start,name->len,0);
-            strMapAdd(cc->global_env,variable->gname->data,variable);
-            ast = parseVariableInitialiser(cc,variable,PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
+            variable = astGVar(type, name->start, name->len, 0);
+            strMapAdd(cc->global_env, variable->gname->data, variable);
+            ast = parseVariableInitialiser(cc, variable,
+                                           PUNCT_TERM_COMMA | PUNCT_TERM_SEMI);
             if (type->kind == AST_TYPE_AUTO) {
-                parseAssignAuto(cc,ast);
+                parseAssignAuto(cc, ast);
             }
             return ast;
         }
 
         if (tokenPunctIs(tok, '(')) {
-            return parseFunctionOrDef(cc,type,name->start,name->len,0); 
+            return parseFunctionOrDef(cc, type, name->start, name->len, 0);
         }
 
-        if (tokenPunctIs(tok,';') || tokenPunctIs(tok, ',')) {
+        if (tokenPunctIs(tok, ';') || tokenPunctIs(tok, ',')) {
             cctrlTokenGet(cc);
-            variable = astGVar(type,name->start,name->len,0);
-            strMapAdd(cc->global_env,variable->gname->data,variable);
-            return astDecl(variable,NULL);
+            variable = astGVar(type, name->start, name->len, 0);
+            strMapAdd(cc->global_env, variable->gname->data, variable);
+            return astDecl(variable, NULL);
         }
-        cctrlRaiseException(cc,"Cannot handle '%s'",lexemeToString(tok));
+        cctrlRaiseException(cc, "Cannot handle '%s'", lexemeToString(tok));
     }
 }
 
 void parseToAst(Cctrl *cc) {
     Ast *ast;
-    Lexeme *tok;
     int is_global = 0;
-    while ((ast = parseToplevelDef(cc,&is_global)) != NULL) {
+    while ((ast = parseToplevelDef(cc, &is_global)) != NULL) {
         if (is_global) {
-            listAppend(cc->initalisers,ast);
+            listAppend(cc->initalisers, ast);
             if (!listEmpty(cc->tmp_locals)) {
-                listMergeAppend(cc->initaliser_locals,cc->tmp_locals);
+                listMergeAppend(cc->initaliser_locals, cc->tmp_locals);
             }
         } else if (ast->kind != AST_FUN_PROTO) {
-            listAppend(cc->ast_list,ast);
+            listAppend(cc->ast_list, ast);
         }
         is_global = 0;
-        tok = cctrlTokenPeek(cc);
+        const Lexeme *tok = cctrlTokenPeek(cc);
         if (!tok) {
             break;
         }

--- a/src/parser.h
+++ b/src/parser.h
@@ -1,18 +1,18 @@
 #ifndef PARSER_H
 #define PARSER_H
 
-#include "list.h"
 #include "ast.h"
 #include "cctrl.h"
+#include "list.h"
 
-#define PUNCT_TERM_COMMA  (1<<0) // ';'
-#define PUNCT_TERM_SEMI   (1<<1) // ','
-#define PUNCT_TERM_RPAREN (1<<2) // ')'
-#define PUNCT_TERM_LPAREN (1<<3) // '('
-#define PUNCT_TERM_ARROW  (1<<4) // '->'
-#define PUNCT_TERM_DOT    (1<<5) // '.'
-#define PUNCT_TERM_LSQR   (1<<6) // '['
-#define PUNCT_TERM_RSQR   (1<<7) // ']'
+#define PUNCT_TERM_COMMA  (1 << 0) // ';'
+#define PUNCT_TERM_SEMI   (1 << 1) // ','
+#define PUNCT_TERM_RPAREN (1 << 2) // ')'
+#define PUNCT_TERM_LPAREN (1 << 3) // '('
+#define PUNCT_TERM_ARROW  (1 << 4) // '->'
+#define PUNCT_TERM_DOT    (1 << 5) // '.'
+#define PUNCT_TERM_LSQR   (1 << 6) // '['
+#define PUNCT_TERM_RSQR   (1 << 7) // ']'
 
 void parseToAst(Cctrl *cc);
 Ast *parseStatement(Cctrl *cc);

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -1,5 +1,5 @@
-#include <string.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "aostr.h"
 #include "ast.h"
@@ -9,345 +9,352 @@
 #include "map.h"
 #include "prsasm.h"
 
-
-/* format the assembly based on how many characters there are for the 
+/* format the assembly based on how many characters there are for the
  * mneumonic */
-static inline char *getTabs(aoStr *str) {
+static inline char *getTabs(const aoStr *str) {
     switch (str->len) {
-        case 2: return "\t\t";
-        case 3: return "\t\t";
-        case 4: return "\t";
-        default: return "\t";
+    case 2:
+    case 3:
+        return "\t\t";
+    case 4:
+    default:
+        return "\t";
     }
 }
 
 void prsAsmMem(Cctrl *cc, aoStr *buf) {
-    Lexeme *tok;
-    tok = cctrlTokenGet(cc);
+    Lexeme *tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        cctrlRaiseException(cc,"[<register>] expected got: %s",lexemeToString(tok));
+        cctrlRaiseException(cc, "[<register>] expected got: %s",
+                            lexemeToString(tok));
     }
-    cctrlTokenExpect(cc,']');
-    aoStrCatPrintf(buf,"(%%%.*s)",tok->len,tok->start);
+    cctrlTokenExpect(cc, ']');
+    aoStrCatPrintf(buf, "(%%%.*s)", tok->len, tok->start);
 }
 
 void prsAsmOffset(Cctrl *cc, aoStr *buf, Lexeme *tok) {
     if (tok->tk_type != TK_I64) {
-        cctrlRaiseException(cc,"Expected TK_I64 type got: %s",lexemeToString(tok));
+        cctrlRaiseException(cc, "Expected TK_I64 type got: %s",
+                            lexemeToString(tok));
     }
 
-    cctrlTokenExpect(cc,'[');
+    cctrlTokenExpect(cc, '[');
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        cctrlRaiseException(cc,"Expected <number>[<register>] Got: %s",
-                lexemeToString(tok));
+        cctrlRaiseException(cc, "Expected <number>[<register>] Got: %s",
+                            lexemeToString(tok));
     }
-    cctrlTokenExpect(cc,']');
-    aoStrCatPrintf(buf, "(%%%.*s)",tok->len,tok->start);
+    cctrlTokenExpect(cc, ']');
+    aoStrCatPrintf(buf, "(%%%.*s)", tok->len, tok->start);
 }
 
 void prsAsmImm(Cctrl *cc, aoStr *buf, Lexeme *tok) {
     Lexeme *next;
     switch (tok->tk_type) {
-        case TK_PUNCT:
-            if (tok->i64 != '-') {
-                cctrlRaiseException(cc,"Expected '-'<numerical>");
-            }
+    case TK_PUNCT:
+        if (tok->i64 != '-') {
+            cctrlRaiseException(cc, "Expected '-'<numerical>");
+        }
 
-            tok = cctrlTokenGet(cc);
-            if (tok->tk_type != TK_I64 && tok->tk_type != TK_F64) {
-                cctrlRaiseException(cc,"Expected -<numerical> got: %s\n",
-                        lexemeToString(tok));
-            }
-            next = cctrlTokenPeek(cc);
-            if (!tokenPunctIs(next,'[')) {
-                aoStrPutChar(buf,'$');
-                aoStrCatPrintf(buf, "-%zu",(unsigned long)tok->i64);
+        tok = cctrlTokenGet(cc);
+        if (tok->tk_type != TK_I64 && tok->tk_type != TK_F64) {
+            cctrlRaiseException(cc, "Expected -<numerical> got: %s\n",
+                                lexemeToString(tok));
+        }
+        next = cctrlTokenPeek(cc);
+        if (!tokenPunctIs(next, '[')) {
+            aoStrPutChar(buf, '$');
+            aoStrCatPrintf(buf, "-%zu", (unsigned long)tok->i64);
+        } else {
+            aoStrCatPrintf(buf, "-%zu", (unsigned long)tok->i64);
+            cctrlTokenGet(cc);
+            prsAsmMem(cc, buf);
+        }
+        break;
+
+    case TK_CHAR_CONST:
+    case TK_I64:
+        next = cctrlTokenPeek(cc);
+        if (!tokenPunctIs(next, '[')) {
+            aoStrPutChar(buf, '$');
+            if (tok->ishex) {
+                aoStrCatPrintf(buf, "%#llX", (size_t)tok->i64);
             } else {
-                aoStrCatPrintf(buf, "-%zu",(unsigned long)tok->i64);
+                aoStrCatPrintf(buf, "%zu", (size_t)tok->i64);
+            }
+        } else {
+            if (tok->ishex) {
+                aoStrCatPrintf(buf, "%#llX", (size_t)tok->i64);
+            } else {
+                aoStrCatPrintf(buf, "%zu", (size_t)tok->i64);
+            }
+            if (tokenPunctIs(next, '[')) {
                 cctrlTokenGet(cc);
-                prsAsmMem(cc,buf);
+                prsAsmMem(cc, buf);
             }
-            break;
+        }
 
-        case TK_CHAR_CONST:
-        case TK_I64:
-            next = cctrlTokenPeek(cc);
-            if (!tokenPunctIs(next,'[')) {
-                aoStrPutChar(buf,'$');
-                if (tok->ishex) {
-                    aoStrCatPrintf(buf, "%#llX",(size_t)tok->i64);
-                } else { 
-                    aoStrCatPrintf(buf, "%zu",(size_t)tok->i64);
-                }
-            } else {
-                if (tok->ishex) {
-                    aoStrCatPrintf(buf, "%#llX",(size_t)tok->i64);
-                } else { 
-                    aoStrCatPrintf(buf, "%zu",(size_t)tok->i64);
-                }
-                if (tokenPunctIs(next,'[')) {
-                    cctrlTokenGet(cc);
-                    prsAsmMem(cc,buf);
-                }
-            }
-
-            break;
+        break;
+    default:;
     }
 }
 
 void prsAsmLabel(Cctrl *cc, aoStr *buf) {
-    Lexeme *tok, *next;
-    long label_num;
 
-    tok = cctrlTokenGet(cc);
-    if (!tokenPunctIs(tok,'@')) {
-        cctrlRaiseException(cc,": Labels must be: '@@<int>'");
+    const Lexeme *tok = cctrlTokenGet(cc);
+    if (!tokenPunctIs(tok, '@')) {
+        cctrlRaiseException(cc, ": Labels must be: '@@<int>'");
     }
 
     tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_I64) {
-        cctrlRaiseException(cc,": Labels must be: '@@<int>'");
+        cctrlRaiseException(cc, ": Labels must be: '@@<int>'");
     }
-    
-    label_num = tok->i64;
-    next = cctrlTokenPeek(cc);
-    if (tokenPunctIs(next,':')) {
-        aoStrCatPrintf(buf, ".%s_%zu:",cc->tmp_asm_fname->data,label_num);
+
+    long label_num = tok->i64;
+    const Lexeme *next = cctrlTokenPeek(cc);
+    if (tokenPunctIs(next, ':')) {
+        aoStrCatPrintf(buf, ".%s_%zu:", cc->tmp_asm_fname->data, label_num);
         cctrlTokenGet(cc);
     } else {
-        aoStrCatPrintf(buf, ".%s_%zu",cc->tmp_asm_fname->data, label_num);
+        aoStrCatPrintf(buf, ".%s_%zu", cc->tmp_asm_fname->data, label_num);
     }
 }
 
 void prsAsmPunct(Cctrl *cc, Lexeme *tok, aoStr *buf) {
-    Lexeme *next;
     switch (tok->i64) {
-        case '[':
-            prsAsmMem(cc,buf);
-            break;
-        case '-':
-            prsAsmImm(cc,buf,tok);
-            break;
-        case '@':
-            prsAsmLabel(cc,buf);
-            break;
-        default:
-            lexemePrint(tok);
-            cctrlRaiseException(cc,": Unexpected character");
+    case '[':
+        prsAsmMem(cc, buf);
+        break;
+    case '-':
+        prsAsmImm(cc, buf, tok);
+        break;
+    case '@':
+        prsAsmLabel(cc, buf);
+        break;
+    default:
+        lexemePrint(tok);
+        cctrlRaiseException(cc, ": Unexpected character");
     }
 
-    next = cctrlTokenPeek(cc);
-    if (tokenPunctIs(next,'[')) {
+    const Lexeme *next = cctrlTokenPeek(cc);
+    if (tokenPunctIs(next, '[')) {
         cctrlTokenRewind(cc);
         tok = cctrlTokenGet(cc);
-        prsAsmOffset(cc,buf,tok);
+        prsAsmOffset(cc, buf, tok);
     }
 }
 
-static void maybePutRegister(Cctrl *cc, aoStr *buf, aoStr *maybe_register) {
-    if (strMapGetLen(cc->x86_registers,
-                maybe_register->data,maybe_register->len) != NULL) {
-        aoStrCatPrintf(buf,"%%%s",maybe_register->data);
+static void maybePutRegister(const Cctrl *cc, aoStr *buf,
+                             const aoStr *maybe_register) {
+    if (strMapGetLen(cc->x86_registers, maybe_register->data,
+                     maybe_register->len) != NULL) {
+        aoStrCatPrintf(buf, "%%%s", maybe_register->data);
     } else {
-        aoStrCatLen(buf,maybe_register->data,maybe_register->len);
+        aoStrCatLen(buf, maybe_register->data, maybe_register->len);
     }
 }
 
 /* Custom assembly to AT&T */
 Ast *prsAsmToATT(Cctrl *cc) {
-    aoStr *op1 = NULL, *op2 = NULL, *op3 = NULL, *asm_code = NULL, *curblock = NULL, *stdfunc = NULL, *curfunc = NULL;
-    List *asm_functions;
-    Ast *asm_function, *asm_block;
-    Lexeme *tok, *next;
+    aoStr *op1 = NULL, *op2 = NULL, *op3 = NULL, *asm_code = NULL,
+          *curblock = NULL, *stdfunc = NULL, *curfunc = NULL;
+    Ast *asm_function;
     int isbol = 0, count = 0;
 
-    asm_functions = listNew();
+    List *asm_functions = listNew();
     curblock = NULL;
     asm_code = aoStrNew();
-    memset(asm_code->data,'\0',asm_code->capacity-1);
+    memset(asm_code->data, '\0', asm_code->capacity - 1);
 
     cctrlTokenExpect(cc, '{');
-    tok = cctrlTokenGet(cc);
+    Lexeme *tok = cctrlTokenGet(cc);
 
     while (!tokenPunctIs(tok, '}')) {
         switch (tok->tk_type) {
-            case TK_CHAR_CONST:
-            case TK_I64: {
-                switch (count) {
-                    case 1:
-                        count++;
-                        op2 = aoStrNew();
-                        prsAsmImm(cc,op2,tok);
-                        break;
-                    case 2:
-                        count++;
-                        op3 = aoStrNew();
-                        prsAsmImm(cc,op3,tok);
-                        break;
-                }
+        case TK_CHAR_CONST:
+        case TK_I64: {
+            switch (count) {
+            case 1:
+                count++;
+                op2 = aoStrNew();
+                prsAsmImm(cc, op2, tok);
                 break;
+            case 2:
+                count++;
+                op3 = aoStrNew();
+                prsAsmImm(cc, op3, tok);
+                break;
+            default:;
             }
+            break;
+        }
 
-            case TK_IDENT: {
-                next = cctrlTokenPeek(cc);
-                if (tokenPunctIs(next, TK_DBL_COLON) || tokenPunctIs(next,':')) {
-                    cctrlTokenGet(cc);
-                    cctrlTokenExpect(cc, '\n');
+        case TK_IDENT: {
+            const Lexeme *next = cctrlTokenPeek(cc);
+            if (tokenPunctIs(next, TK_DBL_COLON) || tokenPunctIs(next, ':')) {
+                cctrlTokenGet(cc);
+                cctrlTokenExpect(cc, '\n');
 
-                    if (curblock == NULL) {
-                        curblock = aoStrNew();
-                    } else {
-                        /* Save the current function */
-                        aoStrCatLen(asm_code,curfunc->data,curfunc->len);
-                        aoStrCatLen(asm_code,":\n",2);
-                        aoStrCatLen(asm_code,curblock->data,curblock->len);
-                        aoStrPutChar(asm_code,'\n');
-                        /* Create an ast */
-                        asm_function = astAsmFunctionDef(curfunc,curblock);
-                        listAppend(asm_functions,asm_function);
-                        if (!strMapAddOrErr(cc->asm_functions, curfunc->data, asm_function)) {
-                            cctrlIce(cc, "Already defined assembly function: %s", curfunc->data);
-                        }
-                        curblock = aoStrNew();
-                    }
-
-                    /* Just the function name in op1, this is so it can be 
-                     * called in the c code. */
-                    curfunc = aoStrDupRaw(tok->start,tok->len);
-                    /* Save the name for pasting labels */
-                    cc->tmp_asm_fname = curfunc;
-                    tok = cctrlTokenGet(cc);
-                    isbol = 1;
-                    continue;
-                }
-                if (isbol) {
-                    op1 = aoStrDupRaw(tok->start,tok->len);
-                    isbol = 0;
+                if (curblock == NULL) {
+                    curblock = aoStrNew();
                 } else {
-                    if (count == 1) {
-                        op2 = aoStrDupRaw(tok->start,tok->len);
-                    } else {
-                        op3 = aoStrDupRaw(tok->start,tok->len);
+                    /* Save the current function */
+                    aoStrCatLen(asm_code, curfunc->data, curfunc->len);
+                    aoStrCatLen(asm_code, ":\n", 2);
+                    aoStrCatLen(asm_code, curblock->data, curblock->len);
+                    aoStrPutChar(asm_code, '\n');
+                    /* Create an ast */
+                    asm_function = astAsmFunctionDef(curfunc, curblock);
+                    listAppend(asm_functions, asm_function);
+                    if (!strMapAddOrErr(cc->asm_functions, curfunc->data,
+                                        asm_function)) {
+                        cctrlIce(cc, "Already defined assembly function: %s",
+                                 curfunc->data);
                     }
+                    curblock = aoStrNew();
+                }
+
+                /* Just the function name in op1, this is so it can be
+                 * called in the c code. */
+                curfunc = aoStrDupRaw(tok->start, tok->len);
+                /* Save the name for pasting labels */
+                cc->tmp_asm_fname = curfunc;
+                tok = cctrlTokenGet(cc);
+                isbol = 1;
+                continue;
+            }
+            if (isbol) {
+                op1 = aoStrDupRaw(tok->start, tok->len);
+                isbol = 0;
+            } else {
+                if (count == 1) {
+                    op2 = aoStrDupRaw(tok->start, tok->len);
+                } else {
+                    op3 = aoStrDupRaw(tok->start, tok->len);
+                }
+            }
+            count++;
+            break;
+        }
+
+        case TK_PUNCT: {
+            switch (tok->i64) {
+            case '\n':
+                switch (count) {
+                case 0:
+                    break;
+
+                case 1:
+                    /* Not A jump */
+                    if (op1->data[0] != '.') {
+                        aoStrPutChar(curblock, '\t');
+                    }
+                    /* Only a few functions get called as one
+                     * operation */
+                    aoStrToLowerCase(op1);
+                    if (strMapGetLen(cc->libc_functions, op1->data, op1->len) !=
+                        NULL) {
+                        stdfunc = astNormaliseFunctionName(op1->data);
+                        aoStrCatPrintf(curblock, "%s\n", stdfunc->data);
+                        aoStrRelease(stdfunc);
+                    } else {
+                        aoStrCatPrintf(curblock, "%s\n", op1->data);
+                    }
+                    aoStrRelease(op1);
+                    break;
+
+                case 2: {
+                    aoStrToLowerCase(op1);
+                    aoStrCatPrintf(curblock, "\t%s%s", op1->data, getTabs(op1));
+
+                    if (op1->len == 4 && !memcmp(op1->data, "call", 4)) {
+                        if (strMapGetLen(cc->libc_functions, op2->data,
+                                         op2->len) != NULL) {
+                            stdfunc = astNormaliseFunctionName(op2->data);
+                            aoStrCatPrintf(curblock, "%s\n", stdfunc->data);
+                            aoStrRelease(stdfunc);
+                        } else {
+                            aoStrCatPrintf(curblock, "%s\n", op2->data);
+                        }
+                    } else {
+                        aoStrToLowerCase(op2);
+                        maybePutRegister(cc, curblock, op2);
+                        aoStrPutChar(curblock, '\n');
+                    }
+                    aoStrRelease(op1);
+                    aoStrRelease(op2);
+                    break;
+                }
+
+                case 3:
+                    aoStrToLowerCase(op1);
+                    aoStrToLowerCase(op2);
+                    aoStrToLowerCase(op3);
+
+                    aoStrCatPrintf(curblock, "\t%s%s", op1->data, getTabs(op1));
+
+                    maybePutRegister(cc, curblock, op3);
+                    aoStrCatLen(curblock, ", ", 2);
+
+                    maybePutRegister(cc, curblock, op2);
+                    aoStrPutChar(curblock, '\n');
+
+                    aoStrRelease(op1);
+                    aoStrRelease(op2);
+                    aoStrRelease(op3);
+                    break;
+                default:
+                    cctrlRaiseException(cc,
+                                        "Unexpected number of arguments for"
+                                        " x86 transpilation: %d"
+                                        " Expression",
+                                        count);
+                }
+                isbol = 1;
+                count = 0;
+                break;
+
+            case ',':
+                break;
+            default:
+                switch (count) {
+                case 0:
+                    op1 = aoStrNew();
+                    prsAsmPunct(cc, tok, op1);
+                    break;
+                case 1:
+                    op2 = aoStrNew();
+                    prsAsmPunct(cc, tok, op2);
+                    break;
+                case 2:
+                    op3 = aoStrNew();
+                    prsAsmPunct(cc, tok, op3);
+                    break;
+                default:;
                 }
                 count++;
                 break;
             }
-
-            case TK_PUNCT: {
-                switch (tok->i64) {
-                    case '\n':
-                        switch (count) {
-                            case 0:
-                                break;
-
-                            case 1:
-                                /* Not A jump */
-                                if (op1->data[0] != '.') { 
-                                    aoStrPutChar(curblock,'\t');
-                                }
-                                /* Only a few functions get called as one 
-                                 * operation */
-                                aoStrToLowerCase(op1);
-                                if (strMapGetLen(cc->libc_functions,
-                                            op1->data,op1->len) != NULL) {
-                                    stdfunc = astNormaliseFunctionName(op1->data);
-                                    aoStrCatPrintf(curblock,"%s\n",stdfunc->data);
-                                    aoStrRelease(stdfunc);
-                                } else {
-                                    aoStrCatPrintf(curblock,"%s\n",op1->data);
-                                }
-                                aoStrRelease(op1);
-                                break;
-
-                            case 2: {
-                                aoStrToLowerCase(op1);
-                                aoStrCatPrintf(curblock,"\t%s%s",op1->data,getTabs(op1));
-
-                                if (op1->len == 4 && !memcmp(op1->data,"call",4)) {
-                                    if (strMapGetLen(cc->libc_functions,
-                                                op2->data,op2->len) != NULL) { 
-                                        stdfunc = astNormaliseFunctionName(op2->data);
-                                        aoStrCatPrintf(curblock,"%s\n",stdfunc->data);
-                                        aoStrRelease(stdfunc);
-                                    } else {
-                                        aoStrCatPrintf(curblock,"%s\n",op2->data);
-                                    }
-                                } else {
-                                    aoStrToLowerCase(op2);
-                                    maybePutRegister(cc,curblock,op2);
-                                    aoStrPutChar(curblock,'\n');
-                                }
-                                aoStrRelease(op1);
-                                aoStrRelease(op2);
-                                break;
-                            }
-
-                            case 3:
-                                aoStrToLowerCase(op1);
-                                aoStrToLowerCase(op2);
-                                aoStrToLowerCase(op3);
-
-                                aoStrCatPrintf(curblock,"\t%s%s", op1->data,getTabs(op1));
-
-                                maybePutRegister(cc,curblock,op3);
-                                aoStrCatLen(curblock, ", ", 2);
-
-                                maybePutRegister(cc,curblock,op2);
-                                aoStrPutChar(curblock,'\n');
-
-                                aoStrRelease(op1);
-                                aoStrRelease(op2);
-                                aoStrRelease(op3);
-                                break;
-                            default:
-                                cctrlRaiseException(cc,"Unexpected number of arguments for"
-                                        " x86 transpilation: %d"" Expression",
-                                        count);
-                        }
-                        isbol = 1;
-                        count = 0;
-                        break;
-
-                    case ',':
-                        break;
-                    default:
-                        switch (count) {
-                            case 0:
-                                op1 = aoStrNew();
-                                prsAsmPunct(cc,tok,op1);
-                                break;
-                            case 1:
-                                op2 = aoStrNew();
-                                prsAsmPunct(cc,tok,op2);
-                                break;
-                            case 2:
-                                op3 = aoStrNew();
-                                prsAsmPunct(cc,tok,op3);
-                                break;
-                        }
-                        count++;
-                        break;
-                }
-                break;
-            }
-
+            break;
+        }
+        default:;
         }
         tok = cctrlTokenGet(cc);
     }
 
     if (curfunc) {
-        aoStrCatLen(asm_code,curfunc->data,curfunc->len);
-        aoStrCatLen(asm_code,":\n",2);
-        aoStrCatLen(asm_code,curblock->data,curblock->len);
-        asm_function = astAsmFunctionDef(curfunc,curblock);
-        listAppend(asm_functions,asm_function);
+        aoStrCatLen(asm_code, curfunc->data, curfunc->len);
+        aoStrCatLen(asm_code, ":\n", 2);
+        aoStrCatLen(asm_code, curblock->data, curblock->len);
+        asm_function = astAsmFunctionDef(curfunc, curblock);
+        listAppend(asm_functions, asm_function);
         if (!strMapAddOrErr(cc->asm_functions, curfunc->data, asm_function)) {
-            cctrlIce(cc, "Already defined assembly function: %s", curfunc->data);
+            cctrlIce(cc, "Already defined assembly function: %s",
+                     curfunc->data);
         }
     }
-    asm_block = astAsmBlock(asm_code,asm_functions);
+    Ast *asm_block = astAsmBlock(asm_code, asm_functions);
     return asm_block;
 }
 
@@ -399,9 +406,9 @@ int main(int argc, char **argv) {
     cctrlInitTokenIter(cc, tokens);
 
     while ((tok = cctrlTokenGet(cc)) != NULL) {
-        if (tokenIdentIs(tok,"asm",3)) {
+        if (tokenIdentIs(tok, "asm", 3)) {
             peek = cctrlTokenPeek(cc);
-            if (tokenPunctIs(peek,'{')) {
+            if (tokenPunctIs(peek, '{')) {
                 asm_block = prsAsm(cc);
                 printf("%s\n", asm_block->asm_stmt->data);
             }

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -11,81 +11,79 @@
 #include "lexer.h"
 #include "list.h"
 #include "map.h"
-#include "prsutil.h"
 #include "prslib.h"
+#include "prsutil.h"
 #include "util.h"
 
 static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type);
 Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast);
 
-void parseAssignAuto(Cctrl *cc, Ast *ast) {
+void parseAssignAuto(Cctrl *cc, const Ast *ast) {
     if (ast->declinit == NULL) {
-        cctrlRaiseException(cc,"auto must have an initaliser");
+        cctrlRaiseException(cc, "auto must have an initaliser");
     }
 
     if (ast->declinit->kind == AST_FUNC) {
-        ast->declvar->type = astMakeFunctionType(
-                ast->declinit->type->rettype,
-                ast->declinit->params);
+        ast->declvar->type = astMakeFunctionType(ast->declinit->type->rettype,
+                                                 ast->declinit->params);
         ast->declvar->type->has_var_args = ast->declinit->type->has_var_args;
-        ast->declvar->type->rettype->has_var_args = ast->declinit->type->has_var_args;
-    //return astMakeFunctionType(rettype,params);
+        ast->declvar->type->rettype->has_var_args =
+                ast->declinit->type->has_var_args;
+        // return astMakeFunctionType(rettype,params);
+        // cctrlRaiseException(cc,"auto with functions is not yet supported");
         return;
-        cctrlRaiseException(cc,"auto with functions is not yet supported");
     }
     ast->declvar->type = ast->declinit->type;
 }
 
 AstType *parseReturnAuto(Cctrl *cc, Ast *retval) {
     switch (retval->kind) {
-        case AST_LVAR:
-        case AST_STRING:
-        case AST_ASM_FUNCALL:
-        case AST_FUNPTR_CALL:
-        case AST_FUNCALL:
-        case AST_FUNPTR:
-        case AST_TYPE_ARRAY:
-        case AST_TYPE_INT:
-        case AST_TYPE_CHAR:
-        case AST_TYPE_FLOAT:
-        case AST_TYPE_POINTER:
-        case AST_TYPE_VOID:
-        case AST_LITERAL:
-        case '+':
-        case '-':
-        case '*':
-        case '/':
-        case '<':
-        case '>':
-        case '!':
-        case '&':
-        case '|':
-        case '%':
-        case '$':
-        case '~':
-        case TK_AND_AND:
-        case TK_OR_OR:
-        case TK_EQU_EQU:
-        case TK_NOT_EQU:
-        case TK_LESS_EQU:
-        case TK_GREATER_EQU:
-        case TK_PLUS_PLUS:
-        case TK_MINUS_MINUS:
-        case TK_SHL:
-        case TK_SHR: {
-            return astTypeCopy(retval->type);
-        }
-        default:
-            cctrlRaiseException(cc,"Could not determine return type for %s()",
-                    cc->tmp_fname->data);
-
+    case AST_LVAR:
+    case AST_STRING:
+    case AST_ASM_FUNCALL:
+    case AST_FUNPTR_CALL:
+    case AST_FUNCALL:
+    case AST_FUNPTR:
+    case AST_TYPE_ARRAY:
+    case AST_TYPE_INT:
+    case AST_TYPE_CHAR:
+    case AST_TYPE_FLOAT:
+    case AST_TYPE_POINTER:
+    case AST_TYPE_VOID:
+    case AST_LITERAL:
+    case '+':
+    case '-':
+    case '*':
+    case '/':
+    case '<':
+    case '>':
+    case '!':
+    case '&':
+    case '|':
+    case '%':
+    case '$':
+    case '~':
+    case TK_AND_AND:
+    case TK_OR_OR:
+    case TK_EQU_EQU:
+    case TK_NOT_EQU:
+    case TK_LESS_EQU:
+    case TK_GREATER_EQU:
+    case TK_PLUS_PLUS:
+    case TK_MINUS_MINUS:
+    case TK_SHL:
+    case TK_SHR: {
+        return astTypeCopy(retval->type);
+    }
+    default:
+        cctrlRaiseException(cc, "Could not determine return type for %s()",
+                            cc->tmp_fname->data);
     }
 }
 
 AstType *parsePointerType(Cctrl *cc, AstType *type) {
-    Lexeme *tok;
     while (1) {
-        tok = cctrlTokenGet(cc);
+        const Lexeme *tok = cctrlTokenGet(cc);
         if (!tokenPunctIs(tok, '*')) {
             cctrlTokenRewind(cc);
             return type;
@@ -95,76 +93,65 @@ AstType *parsePointerType(Cctrl *cc, AstType *type) {
     return type;
 }
 
-AstType *parseFunctionPointerType(Cctrl *cc,
-        char **fnptr_name, int *fnptr_name_len, AstType *rettype)
-{
+AstType *parseFunctionPointerType(Cctrl *cc, char **fnptr_name,
+                                  int *fnptr_name_len, AstType *rettype) {
     int has_var_args;
-    Lexeme *fname;
-    cctrlTokenExpect(cc,'*');
-    fname = cctrlTokenGet(cc);
+    cctrlTokenExpect(cc, '*');
+    Lexeme *fname = cctrlTokenGet(cc);
     if (fname->tk_type != TK_IDENT) {
-        cctrlRaiseException(cc,"Expected function pointer name got: %s",
-                lexemeToString(fname));
+        cctrlRaiseException(cc, "Expected function pointer name got: %s",
+                            lexemeToString(fname));
     }
     *fnptr_name = fname->start;
     *fnptr_name_len = fname->len;
-    cctrlTokenExpect(cc,')');
-    cctrlTokenExpect(cc,'(');
-    PtrVec *params = parseParams(cc,')',&has_var_args,0);
-    return astMakeFunctionType(rettype,params);
+    cctrlTokenExpect(cc, ')');
+    cctrlTokenExpect(cc, '(');
+    PtrVec *params = parseParams(cc, ')', &has_var_args, 0);
+    return astMakeFunctionType(rettype, params);
 }
 
 Ast *parseFunctionPointer(Cctrl *cc, AstType *rettype) {
-    Ast *ast;
     char *fnptr_name;
     int fnptr_name_len;
-    AstType *fnptr_type;
 
-    fnptr_type = parseFunctionPointerType(cc,
-            &fnptr_name,
-            &fnptr_name_len,
-            rettype);
+    AstType *fnptr_type = parseFunctionPointerType(cc, &fnptr_name,
+                                                   &fnptr_name_len, rettype);
 
-    ast = astFunctionPtr(
-            fnptr_type,
-            fnptr_name,
-            fnptr_name_len,
-            fnptr_type->params);
+    Ast *ast = astFunctionPtr(fnptr_type, fnptr_name, fnptr_name_len,
+                              fnptr_type->params);
     return ast;
 }
 
 Ast *parseDefaultFunctionParam(Cctrl *cc, Ast *var) {
     if (var->type->kind == AST_TYPE_ARRAY) {
-        cctrlRaiseException(cc,"Cannot have a default value of type array");
+        cctrlRaiseException(cc, "Cannot have a default value of type array");
     }
-    Ast *init = parseExpr(cc,16);
-    return astFunctionDefaultParam(var,init);
+    Ast *init = parseExpr(cc, 16);
+    return astFunctionDefaultParam(var, init);
 }
 
 PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
     PtrVec *params = ptrVecNew();
 
-    Lexeme *tok, *pname;
-    AstType *type;
     Ast *var;
     int arg_count = 0;
 
-    tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(tok,terminator)) {
+    Lexeme *tok = cctrlTokenGet(cc);
+    if (tokenPunctIs(tok, terminator)) {
         return params;
     }
     cctrlTokenRewind(cc);
-    
+
     while (1) {
-        pname = cctrlTokenPeek(cc);
+        Lexeme *pname = cctrlTokenPeek(cc);
 
         /* VarArgs */
         if (tokenPunctIs(pname, TK_ELLIPSIS)) {
             cctrlTokenGet(cc);
             var = astVarArgs();
-            strMapAdd(cc->localenv,var->argc->lname->data,var->argc);
-            strMapAdd(cc->localenv,var->argv->lname->data,var->argv);
-            
+            strMapAdd(cc->localenv, var->argc->lname->data, var->argc);
+            strMapAdd(cc->localenv, var->argv->lname->data, var->argv);
+
             ptrVecPush(params, var);
 
             if (cc->tmp_locals) {
@@ -173,11 +160,11 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
             }
             *has_var_args = 1;
             /* Var args _has_ to be last */
-            cctrlTokenExpect(cc,terminator);
+            cctrlTokenExpect(cc, terminator);
             return params;
         }
 
-        type = parseDeclSpec(cc);
+        AstType *type = parseDeclSpec(cc);
         pname = cctrlTokenGet(cc);
 
         if (tokenPunctIs(pname, ')') && arg_count == 0) {
@@ -190,14 +177,14 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
         if (pname->tk_type != TK_IDENT) {
             /* Function pointer */
             if (tokenPunctIs(pname, '(')) {
-                type = parseArrayDimensions(cc,type);
+                type = parseArrayDimensions(cc, type);
                 if (type->kind == AST_TYPE_ARRAY) {
                     type = astMakePointerType(type->ptr);
                 }
-                var = parseFunctionPointer(cc,type);
-                if (!strMapAddOrErr(cc->localenv,var->fname->data,var)) {
-                    cctrlRaiseException(cc,"variable %s already declared",
-                            astLValueToString(var,0));
+                var = parseFunctionPointer(cc, type);
+                if (!strMapAddOrErr(cc->localenv, var->fname->data, var)) {
+                    cctrlRaiseException(cc, "variable %s already declared",
+                                        astLValueToString(var, 0));
                 }
                 if (cc->tmp_locals) {
                     listAppend(cc->tmp_locals, var);
@@ -206,7 +193,7 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
 
                 tok = cctrlTokenGet(cc);
                 if (tokenPunctIs(tok, '=')) {
-                    Ast *default_fnptr = parseDefaultFunctionParam(cc,var);
+                    Ast *default_fnptr = parseDefaultFunctionParam(cc, var);
                     var->default_fn = default_fnptr;
                     tok = cctrlTokenGet(cc);
                 }
@@ -214,12 +201,12 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
                     return params;
                 }
                 continue;
-            } else if (tokenPunctIs(pname,',') || tokenPunctIs(pname,')')) {
-                type = parseArrayDimensions(cc,type);
+            } else if (tokenPunctIs(pname, ',') || tokenPunctIs(pname, ')')) {
+                type = parseArrayDimensions(cc, type);
                 if (type->kind == AST_TYPE_ARRAY) {
                     type = astMakePointerType(type->ptr);
                 }
-                var = astLVar(type,"_unknown",7);
+                var = astLVar(type, "_unknown", 7);
                 if (cc->tmp_locals) {
                     listAppend(cc->tmp_locals, var);
                 }
@@ -230,35 +217,36 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
                 }
                 continue;
             } else {
-                cctrlRaiseException(cc,"Identifier expected, got: %s",
-                        lexemeToString(pname));
+                cctrlRaiseException(cc, "Identifier expected, got: %s",
+                                    lexemeToString(pname));
             }
         }
 
-        type = parseArrayDimensions(cc,type);
+        type = parseArrayDimensions(cc, type);
         if (type->kind == AST_TYPE_ARRAY) {
             type = astMakePointerType(type->ptr);
         }
-        var = astLVar(type,pname->start,pname->len);
+        var = astLVar(type, pname->start, pname->len);
 
         tok = cctrlTokenGet(cc);
         if (tokenPunctIs(tok, '=')) {
-            var = parseDefaultFunctionParam(cc,var);
+            var = parseDefaultFunctionParam(cc, var);
             if (store) {
-                if (!strMapAddOrErr(cc->localenv,var->declvar->lname->data,var)) {
-                    cctrlRaiseException(cc,"variable %s already declared",
-                            astLValueToString(var,0));
+                if (!strMapAddOrErr(cc->localenv, var->declvar->lname->data,
+                                    var)) {
+                    cctrlRaiseException(cc, "variable %s already declared",
+                                        astLValueToString(var, 0));
                 }
             }
             tok = cctrlTokenGet(cc);
         } else {
             if (store) {
-                if (!strMapAddOrErr(cc->localenv,var->lname->data,var)) {
-                        cctrlRaiseException(cc,"variable %s already declared",
-                            astLValueToString(var,0));
+                if (!strMapAddOrErr(cc->localenv, var->lname->data, var)) {
+                    cctrlRaiseException(cc, "variable %s already declared",
+                                        astLValueToString(var, 0));
                 }
             }
-       }
+        }
 
         if (cc->tmp_locals) {
             listAppend(cc->tmp_locals, var);
@@ -266,13 +254,13 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
 
         ptrVecPush(params, var);
 
-        if (tokenPunctIs(tok,terminator)) {
+        if (tokenPunctIs(tok, terminator)) {
             return params;
         }
 
-        if (!tokenPunctIs(tok,',')) {
-            cctrlRaiseException(cc,"Comma expected, got %s",
-                    lexemeToString(tok));
+        if (!tokenPunctIs(tok, ',')) {
+            cctrlRaiseException(cc, "Comma expected, got %s",
+                                lexemeToString(tok));
         }
     }
 }
@@ -280,49 +268,49 @@ PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
 /* Does not parse pointer types, only the base type */
 AstType *parseBaseDeclSpec(Cctrl *cc) {
     Lexeme *tok = cctrlTokenGet(cc);
-    AstType *type;
 
     if (!tok) {
         return NULL;
     }
 
     if (tok->tk_type == TK_KEYWORD || tok->tk_type == TK_IDENT) {
+        AstType *type;
         if ((type = parseGetType(cc, tok)) == NULL) {
-            cctrlRewindUntilStrMatch(cc,tok->start,tok->len,NULL);
-            cctrlRaiseException(cc,"Type `%.*s` has not been declared, expected type declaration",tok->len,tok->start);
+            cctrlRewindUntilStrMatch(cc, tok->start, tok->len, NULL);
+            cctrlRaiseException(
+                    cc,
+                    "Type `%.*s` has not been declared, expected type declaration",
+                    tok->len, tok->start);
         }
         return type;
     }
-    cctrlRewindUntilStrMatch(cc,tok->start,tok->len,NULL);
-    cctrlRaiseException(cc,"Declaration or specfier must be an identifier got %s `%.*s`",
-            lexemeTypeToString(tok->tk_type),
-            tok->len, tok->start);
+    cctrlRewindUntilStrMatch(cc, tok->start, tok->len, NULL);
+    cctrlRaiseException(
+            cc, "Declaration or specfier must be an identifier got %s `%.*s`",
+            lexemeTypeToString(tok->tk_type), tok->len, tok->start);
 }
 
 AstType *parseDeclSpec(Cctrl *cc) {
     AstType *type = parseBaseDeclSpec(cc);
-    type = parsePointerType(cc,type);
+    type = parsePointerType(cc, type);
     return type;
 }
 
 static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type) {
-    Ast *size;
     AstType *type = base_type;
-    Lexeme *tok, *next_tok;
-    int dimension;
 
-    tok = cctrlTokenGet(cc);
-    dimension = -1;
+    const Lexeme *tok = cctrlTokenGet(cc);
+    int dimension = -1;
 
     if (!tokenPunctIs(tok, '[')) {
         cctrlTokenRewind(cc);
         return NULL;
     }
 
-    next_tok = cctrlTokenPeek(cc);
+    const Lexeme *next_tok = cctrlTokenPeek(cc);
 
     if (!tokenPunctIs(next_tok, ']')) {
-        size = parseExpr(cc,16);
+        Ast *size = parseExpr(cc, 16);
         int ok = 1;
         dimension = evalIntConstExprOrErr(size, &ok);
 
@@ -330,25 +318,26 @@ static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type) {
             if (size->kind == AST_LVAR) {
                 dimension = -3;
                 type->clsname = size->lname;
-            } else if (astIsArithmetic(size->kind,0)) {
+            } else if (astIsArithmetic(size->kind, 0)) {
                 /* Relent... otherwise this will get far too complicated for a
                  * feature that likely will never be used */
-                Ast *left = size->left;
-                Ast *right = size->right;
+                const Ast *left = size->left;
+                const Ast *right = size->right;
                 aoStr *lname = NULL;
                 int literal;
 
                 if (left->kind == AST_LVAR && right->kind == AST_LITERAL) {
                     literal = right->i64;
                     lname = left->lname;
-                } else if (right->kind == AST_LVAR && left->kind == AST_LITERAL) {
+                } else if (right->kind == AST_LVAR &&
+                           left->kind == AST_LITERAL) {
                     literal = left->i64;
                     lname = right->lname;
                 } else {
                     goto invalid_subscript;
                 }
-                
-                Lexeme *le = strMapGet(cc->macro_defs,lname->data);
+
+                Lexeme *le = strMapGet(cc->macro_defs, lname->data);
                 if (le->tk_type != TK_I64) {
                     goto invalid_subscript;
                 }
@@ -362,42 +351,42 @@ static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type) {
         }
     }
 
-    cctrlTokenExpect(cc,']');
-    AstType *sub_type = parseArrayDimensionsInternal(cc,type);
+    cctrlTokenExpect(cc, ']');
+    AstType *sub_type = parseArrayDimensionsInternal(cc, type);
     if (sub_type) {
         if (sub_type->len == -1 && dimension == -1) {
-            cctrlRaiseException(cc,"Array size not specified");
+            cctrlRaiseException(cc, "Array size not specified");
         }
         type = sub_type;
     }
 
-    return astMakeArrayType(type,dimension);
+    return astMakeArrayType(type, dimension);
 
 invalid_subscript:
-    cctrlRewindUntilPunctMatch(cc, '[',NULL);
-    cctrlRaiseExceptionFromTo(cc,"Expected constant integer expression",
-            '[',']',"Invalid array subscript");
+    cctrlRewindUntilPunctMatch(cc, '[', NULL);
+    cctrlRaiseExceptionFromTo(cc, "Expected constant integer expression", '[',
+                              ']', "Invalid array subscript");
     return NULL;
 }
 
 AstType *parseArrayDimensions(Cctrl *cc, AstType *base_type) {
-    AstType *type = parseArrayDimensionsInternal(cc,base_type);
+    AstType *type = parseArrayDimensionsInternal(cc, base_type);
     if (type) {
         return type;
     }
     return base_type;
-} 
+}
 
 /* Calls TokenGet internally so ensure you are 1 token behind the type */
 AstType *parseFullType(Cctrl *cc) {
     AstType *type = parseDeclSpec(cc);
-    return parseArrayDimensions(cc,type);
+    return parseArrayDimensions(cc, type);
 }
 
 void parseDeclInternal(Cctrl *cc, Lexeme **tok, AstType **type) {
     AstType *_type = parseDeclSpec(cc);
     Lexeme *_tok = cctrlTokenGet(cc);
-    if (tokenPunctIs(_tok,';')) {
+    if (tokenPunctIs(_tok, ';')) {
         cctrlTokenRewind(cc);
         *tok = NULL;
         return;
@@ -409,34 +398,32 @@ void parseDeclInternal(Cctrl *cc, Lexeme **tok, AstType **type) {
     } else {
         *tok = _tok;
     }
-    *type = parseArrayDimensions(cc,_type);
+    *type = parseArrayDimensions(cc, _type);
 }
-
 
 Ast *findFunctionDecl(Cctrl *cc, char *fname, int len) {
     Ast *decl;
-    if ((decl = strMapGetLen(cc->global_env,fname,len)) != NULL) {
-        if (decl->kind == AST_FUNC ||
-            decl->kind == AST_EXTERN_FUNC ||
+    if ((decl = strMapGetLen(cc->global_env, fname, len)) != NULL) {
+        if (decl->kind == AST_FUNC || decl->kind == AST_EXTERN_FUNC ||
             decl->kind == AST_FUN_PROTO) {
             return decl;
         }
-    } else if (cc->localenv && (decl = strMapGetLen(cc->localenv,fname,len)) != NULL) {
+    } else if (cc->localenv &&
+               (decl = strMapGetLen(cc->localenv, fname, len)) != NULL) {
         if (decl->kind == AST_FUNPTR || decl->kind == AST_LVAR) {
             return decl;
         }
-    } else if ((decl = strMapGetLen(cc->asm_funcs,fname,len)) != NULL) {
+    } else if ((decl = strMapGetLen(cc->asm_funcs, fname, len)) != NULL) {
         /* Assembly function */
         return decl;
     }
     return NULL;
 }
 
-PtrVec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
+PtrVec *parseArgv(Cctrl *cc, const Ast *decl, long terminator, char *fname,
+                  int len) {
     List *var_args = NULL, *parameter = NULL;
-    Ast *ast, *param = NULL;
-    AstType *check;
-    Lexeme *tok;
+    Ast *param = NULL;
     PtrVec *params = NULL;
     int param_idx = 0;
 
@@ -446,13 +433,13 @@ PtrVec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
 
     PtrVec *argv_vec = ptrVecNew();
 
-    tok = cctrlTokenPeek(cc);
+    Lexeme *tok = cctrlTokenPeek(cc);
 
     while (tok && !tokenPunctIs(tok, terminator)) {
         if (params && vecInBounds(params, param_idx)) {
             param = params->entries[param_idx++];
         }
-        ast = parseExpr(cc,16);
+        Ast *ast = parseExpr(cc, 16);
         if (ast == NULL) {
             if (param && param->kind == AST_DEFAULT_PARAM) {
                 ast = param->declinit;
@@ -461,25 +448,30 @@ PtrVec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
 
         if (param != NULL && param->kind == AST_VAR_ARGS) {
             if (decl && decl->kind == AST_EXTERN_FUNC) {
-                ptrVecPush(argv_vec,ast);
+                ptrVecPush(argv_vec, ast);
             } else {
                 /* Will merge this to the end of the arguments list */
                 if (var_args == NULL) {
                     var_args = listNew();
                 }
-                listAppend(var_args,ast);
+                listAppend(var_args, ast);
             }
         } else {
-            /* Does a distinctly adequate job of type checking function parameters */
+            /* Does a distinctly adequate job of type checking function
+             * parameters */
             if (param && param->kind != AST_DEFAULT_PARAM) {
-                if ((check = astTypeCheck(param->type,ast,'=')) == NULL) {
-                    char *expected = astTypeToColorString(param->type);
-                    char *got = astTypeToColorString(ast->type);
-                    cctrlWarning(cc,"Incompatible function argument, expected '%s' got '%s' function '%.*s'",
-                            expected,got,len,fname);
+                if (astTypeCheck(param->type, ast, '=') == NULL) {
+                    if (ast) {
+                        char *expected = astTypeToColorString(param->type);
+                        char *got = astTypeToColorString(ast->type);
+                        cctrlWarning(
+                                cc,
+                                "Incompatible function argument, expected '%s' got '%s' function '%.*s'",
+                                expected, got, len, fname);
+                    }
                 }
             }
-            ptrVecPush(argv_vec,ast);
+            ptrVecPush(argv_vec, ast);
         }
 
         tok = cctrlTokenGet(cc);
@@ -488,13 +480,14 @@ PtrVec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
             break;
         }
 
-        if (!tokenPunctIs(tok,',')) {
+        if (!tokenPunctIs(tok, ',')) {
             cctrlRewindUntilPunctMatch(cc, tok->i64, NULL);
-            cctrlInfo(cc, "Function call `%.*s` not terminated correctly", len,fname);
-            cctrlRaiseSuggestion(cc,"terminate with `)`",
+            cctrlInfo(cc, "Function call `%.*s` not terminated correctly", len,
+                      fname);
+            cctrlRaiseSuggestion(
+                    cc, "terminate with `)`",
                     "Invalid %s `%.*s` while parsing function call, perhaps you meant to terminate the arguments with `)` or keep going with `,`?",
-                    lexemeTypeToString(tok->tk_type),
-                   tok->len, tok->start);
+                    lexemeTypeToString(tok->tk_type), tok->len, tok->start);
         }
 
         if (parameter && parameter->next != parameter) {
@@ -508,10 +501,10 @@ PtrVec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
 
     if (var_args) {
         /* set the argument count and merge lists */
-        ptrVecPush(argv_vec,astI64Type(listCount(var_args)));
+        ptrVecPush(argv_vec, astI64Type(listCount(var_args)));
         listForEach(var_args) {
 
-            ptrVecPush(argv_vec,(Ast*)it->value);
+            ptrVecPush(argv_vec, (Ast *)it->value);
         }
     }
 
@@ -530,12 +523,14 @@ Ast *parseInlineFunctionCall(Cctrl *cc, Ast *fn, PtrVec *argv) {
         for (int i = 0; i < size; ++i) {
             Ast *param = fn->params->entries[i];
             Ast *arg = argv->entries[i];
-            Ast *var_decl = astDecl(param,arg);
+            Ast *var_decl = astDecl(param, arg);
             listAppend(cc->tmp_func->locals, param);
             listAppend(stmts, var_decl);
         }
     } else {
-        cctrlRaiseException(cc,"Cannot presently inline a function with default arguments or where the number of parameters does not match the number of arguments");
+        cctrlRaiseException(
+                cc,
+                "Cannot presently inline a function with default arguments or where the number of parameters does not match the number of arguments");
     }
     listMergeAppend(stmts, fn_body);
     if (!listEmpty(fn->locals)) {
@@ -551,81 +546,90 @@ Ast *parseInlineFunctionCall(Cctrl *cc, Ast *fn, PtrVec *argv) {
 /* Read function arguments for a function being called */
 Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, long terminator) {
     AstType *rettype = NULL;
-    Ast *maybe_fn = findFunctionDecl(cc,fname,len);
-    PtrVec *argv = parseArgv(cc,maybe_fn,terminator,fname,len);
+    Ast *maybe_fn = findFunctionDecl(cc, fname, len);
+    PtrVec *argv = parseArgv(cc, maybe_fn, terminator, fname, len);
 
     if (maybe_fn) {
         rettype = maybe_fn->type->rettype;
-        if (maybe_fn->flags & AST_FLAG_INLINE && !(cc->flags & CCTRL_TRANSPILING)) {
+        if (maybe_fn->flags & AST_FLAG_INLINE &&
+            !(cc->flags & CCTRL_TRANSPILING)) {
             return parseInlineFunctionCall(cc, maybe_fn, argv);
         }
     }
 
     if (!maybe_fn) {
-        if ((len == 6 && !strncmp(fname,"printf",6))) {
+        if ((len == 6 && !strncmp(fname, "printf", 6))) {
             rettype = ast_int_type;
-            return astFunctionCall(rettype,fname,len,argv);
+            return astFunctionCall(rettype, fname, len, argv);
         }
         /* Walk back untill we fin the missing function */
         Lexeme *peek = cctrlTokenPeek(cc);
-        while (peek->len != len && memcmp(fname,peek->start,len) != 0) {
+        while (peek->len != len && memcmp(fname, peek->start, len) != 0) {
             cctrlTokenRewind(cc);
             peek = cctrlTokenPeek(cc);
         }
-        
-        cctrlRaiseException(cc,"Function: %.*s() not defined",len,fname);
+
+        cctrlRaiseException(cc, "Function: %.*s() not defined", len, fname);
     }
 
+    assert(maybe_fn);
     switch (maybe_fn->kind) {
-        case AST_LVAR:
-        case AST_FUNPTR:
-            return astFunctionPtrCall(rettype,fname,len,argv,maybe_fn);
+    case AST_LVAR:
+    case AST_FUNPTR:
+        return astFunctionPtrCall(rettype, fname, len, argv, maybe_fn);
 
-        case AST_ASM_FUNCDEF:
-        case AST_ASM_FUNC_BIND:
-            return astAsmFunctionCall(rettype,
-                    aoStrDup(maybe_fn->asmfname),argv);
+    case AST_ASM_FUNCDEF:
+    case AST_ASM_FUNC_BIND:
+        return astAsmFunctionCall(rettype, aoStrDup(maybe_fn->asmfname), argv);
 
-        case AST_EXTERN_FUNC:
-        case AST_FUNC:
-        case AST_FUN_PROTO:
-            return astFunctionCall(rettype,fname,len,argv);
-        default: {
-            cctrlRaiseException(cc,"Unknown function: %.*s", len, fname);
-        }
+    case AST_EXTERN_FUNC:
+    case AST_FUNC:
+    case AST_FUN_PROTO:
+        return astFunctionCall(rettype, fname, len, argv);
+    default: {
+        cctrlRaiseException(cc, "Unknown function: %.*s", len, fname);
+    }
     }
 }
 
 /* parse either a function call or a variable being used */
-static Ast *parseIdentifierOrFunction(Cctrl *cc, 
-                                      char *name, 
-                                      int len,
-                                      int can_call_function)
-{
+static Ast *parseIdentifierOrFunction(Cctrl *cc, char *name, int len,
+                                      int can_call_function) {
     Ast *ast = NULL;
 
     Lexeme *tok = cctrlTokenGet(cc);
     Lexeme *peek = cctrlTokenPeek(cc);
-    int is_lparen = tokenPunctIs(tok,'(');
+    int is_lparen = tokenPunctIs(tok, '(');
 
     if ((ast = cctrlGetVar(cc, name, len)) == NULL) {
         cctrlRewindUntilStrMatch(cc, name, len, NULL);
         peek = cctrlTokenPeek(cc);
         if (tok->tk_type == TK_PUNCT) {
             switch (tok->i64) {
-                case '(': {
-                    char *msg = mprintf("Try defining function `%.*s()`?",len,name);
-                    cctrlRaiseSuggestion(cc,msg,"Variable or function `%.*s` has not been defined", len, name);
-                    break;
-                }
-                case '[': {
-                    char *msg = mprintf("Try defining array `I64 %.*s[] = {1, 2, 3}`?",len,name);
-                    cctrlRaiseSuggestion(cc,msg,"Variable or function `%.*s` has not been defined", len, name);
-                    break;
-                }
-                default:
-                    cctrlRaiseException(cc,"Variable or function `%.*s` has not been defined", len, name);
-                    break;
+            case '(': {
+                char *msg = mprintf("Try defining function `%.*s()`?", len,
+                                    name);
+                cctrlRaiseSuggestion(
+                        cc, msg,
+                        "Variable or function `%.*s` has not been defined", len,
+                        name);
+                break;
+            }
+            case '[': {
+                char *msg =
+                        mprintf("Try defining array `I64 %.*s[] = {1, 2, 3}`?",
+                                len, name);
+                cctrlRaiseSuggestion(
+                        cc, msg,
+                        "Variable or function `%.*s` has not been defined", len,
+                        name);
+                break;
+            }
+            default:
+                cctrlRaiseException(
+                        cc, "Variable or function `%.*s` has not been defined",
+                        len, name);
+                break;
             }
         }
     }
@@ -634,18 +638,21 @@ static Ast *parseIdentifierOrFunction(Cctrl *cc,
         cctrlTokenRewind(cc);
         if (can_call_function) {
             /* Function calls with no arguments are 'Function;' */
-            if ((tokenPunctIs(tok,';') || tokenPunctIs(tok,',') || 
-                tokenPunctIs(tok,')'))  
-                    && parseIsFunction(ast)) {
-                if (ast->flags & AST_FLAG_INLINE && !(cc->flags & CCTRL_TRANSPILING)) {
-                    return parseInlineFunctionCall(cc,ast,ptrVecNew());
+            if ((tokenPunctIs(tok, ';') || tokenPunctIs(tok, ',') ||
+                 tokenPunctIs(tok, ')')) &&
+                parseIsFunction(ast)) {
+                if (ast->flags & AST_FLAG_INLINE &&
+                    !(cc->flags & CCTRL_TRANSPILING)) {
+                    return parseInlineFunctionCall(cc, ast, ptrVecNew());
                 }
-                if (ast->kind == AST_ASM_FUNC_BIND || ast->kind == AST_ASM_FUNCDEF) {
+                if (ast->kind == AST_ASM_FUNC_BIND ||
+                    ast->kind == AST_ASM_FUNCDEF) {
                     return astAsmFunctionCall(ast->type->rettype,
-                            aoStrDup(ast->asmfname),ptrVecNew());
+                                              aoStrDup(ast->asmfname),
+                                              ptrVecNew());
                 } else {
-                    return astFunctionCall(ast->type->rettype,
-                            ast->fname->data,ast->fname->len,ptrVecNew());
+                    return astFunctionCall(ast->type->rettype, ast->fname->data,
+                                           ast->fname->len, ptrVecNew());
                 }
             }
         }
@@ -653,18 +660,19 @@ static Ast *parseIdentifierOrFunction(Cctrl *cc,
     }
 
     /* Is a function call if the next char is '(' and the peek is not a type */
-    if (!cctrlIsKeyword(cc,peek->start,peek->len)) {
-        return parseFunctionArguments(cc,name,len,')');
+    if (!cctrlIsKeyword(cc, peek->start, peek->len)) {
+        return parseFunctionArguments(cc, name, len, ')');
     }
 
-    /* Is a postfix typecast, need to grap the variable and 'ParsePostFixExpr' will do the cast */
+    /* Is a postfix typecast, need to grap the variable and 'ParsePostFixExpr'
+     * will do the cast */
     cctrlTokenRewind(cc);
     return ast;
 }
 
 static Ast *parsePrimary(Cctrl *cc) {
     Ast *ast;
-    Lexeme *prev,*tok;
+    Lexeme *prev, *tok;
     int can_call_function = 1;
     cctrlTokenRewind(cc);
 
@@ -675,14 +683,14 @@ static Ast *parsePrimary(Cctrl *cc) {
         return NULL;
     }
 
-    if (tokenPunctIs(prev,'&')) {
+    if (tokenPunctIs(prev, '&')) {
         can_call_function = 0;
     }
 
     switch (tok->tk_type) {
     case TK_IDENT: {
         ast = parseIdentifierOrFunction(cc, tok->start, tok->len,
-                can_call_function);
+                                        can_call_function);
         if (tokenPunctIs(prev, '&')) {
             if (ast->flags & AST_FLAG_INLINE) {
                 Lexeme *peek = cctrlTokenPeek(cc);
@@ -690,7 +698,10 @@ static Ast *parsePrimary(Cctrl *cc) {
                     cctrlTokenRewind(cc);
                     peek = cctrlTokenPeek(cc);
                 }
-                cctrlRaiseException(cc,"Inline functions cannot be used as function pointers: '%.*s'",tok->len, tok->start);
+                cctrlRaiseException(
+                        cc,
+                        "Inline functions cannot be used as function pointers: '%.*s'",
+                        tok->len, tok->start);
             }
         }
         return ast;
@@ -713,8 +724,8 @@ static Ast *parsePrimary(Cctrl *cc) {
         cctrlTokenRewind(cc);
         /* Concatinate adjacent strings together */
         while ((tok = cctrlTokenGet(cc)) != NULL && tok->tk_type == TK_STR) {
-            aoStrCatFmt(str,"%.*s",tok->len,tok->start);
-            real_len += tok->i64-1;
+            aoStrCatFmt(str, "%.*s", tok->len, tok->start);
+            real_len += tok->i64 - 1;
         }
         real_len++;
         cctrlTokenRewind(cc);
@@ -725,16 +736,16 @@ static Ast *parsePrimary(Cctrl *cc) {
         cctrlTokenRewind(cc);
         return NULL;
     case TK_EOF:
-        cctrlRaiseException(cc,"Unexpected EOF");
-        break;
+        cctrlRaiseException(cc, "Unexpected EOF");
     default:
-        cctrlRaiseException(cc,"Unexpected input %s",astKindToString(tok->tk_type));
+        cctrlRaiseException(cc, "Unexpected input %s",
+                            astKindToString(tok->tk_type));
     }
 }
 
 static int parseGetPriority(Lexeme *tok) {
     switch (tok->i64) {
-    case TK_ARROW: 
+    case TK_ARROW:
     case '.':
     case '(':
         return 1;
@@ -744,13 +755,15 @@ static int parseGetPriority(Lexeme *tok) {
 
     case '!':
     case '~':
-    case TK_PLUS_PLUS: 
-    case TK_MINUS_MINUS: 
+    case TK_PLUS_PLUS:
+    case TK_MINUS_MINUS:
     case TK_PRE_PLUS_PLUS:
     case TK_PRE_MINUS_MINUS:
         return 3;
 
-    case '*': case '/': case '%':
+    case '*':
+    case '/':
+    case '%':
         return 4;
 
     case '-':
@@ -761,7 +774,7 @@ static int parseGetPriority(Lexeme *tok) {
     case TK_SHR:
         return 6;
 
-    case TK_LESS_EQU: 
+    case TK_LESS_EQU:
     case TK_GREATER_EQU:
     case '<':
     case '>':
@@ -771,7 +784,7 @@ static int parseGetPriority(Lexeme *tok) {
     case TK_NOT_EQU:
         return 8;
 
-    case '^': 
+    case '^':
         return 9;
     case '&':
         return 10;
@@ -785,15 +798,15 @@ static int parseGetPriority(Lexeme *tok) {
         return 13;
 
     case '=':
-    case TK_ADD_EQU: 
-    case TK_SUB_EQU: 
-    case TK_MUL_EQU: 
-    case TK_DIV_EQU: 
-    case TK_MOD_EQU: 
-    case TK_AND_EQU: 
-    case TK_OR_EQU:  
-    case TK_XOR_EQU: 
-    case TK_SHL_EQU: 
+    case TK_ADD_EQU:
+    case TK_SUB_EQU:
+    case TK_MUL_EQU:
+    case TK_DIV_EQU:
+    case TK_MOD_EQU:
+    case TK_AND_EQU:
+    case TK_OR_EQU:
+    case TK_XOR_EQU:
+    case TK_SHL_EQU:
     case TK_SHR_EQU:
         return 14;
 
@@ -803,15 +816,16 @@ static int parseGetPriority(Lexeme *tok) {
 }
 
 Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast) {
-    Ast *subscript = parseExpr(cc,16);
+    Ast *subscript = parseExpr(cc, 16);
     if (subscript == NULL) {
-        cctrlRewindUntilPunctMatch(cc,'[',NULL);
+        cctrlRewindUntilPunctMatch(cc, '[', NULL);
         Lexeme *tok = cctrlTokenPeek(cc);
-        cctrlRaiseException(cc,"Failed to parse subscript value last valid %s was `%.*s`",
-                lexemeTypeToString(tok->tk_type),tok->len,tok->start);
+        cctrlRaiseException(
+                cc, "Failed to parse subscript value last valid %s was `%.*s`",
+                lexemeTypeToString(tok->tk_type), tok->len, tok->start);
     }
     cctrlTokenExpect(cc, ']');
-    Ast *binop = parseCreateBinaryOp(cc,'+', ast, subscript);
+    Ast *binop = parseCreateBinaryOp(cc, '+', ast, subscript);
     return astUnaryOperator(binop->type->ptr, AST_DEREF, binop);
 }
 
@@ -819,37 +833,36 @@ Ast *parseGetClassField(Cctrl *cc, Ast *cls) {
     AstType *type;
     if (!parseIsClassOrUnion(cls->type->kind)) {
         char *type_str = astTypeToString(cls->type);
-        char *var_str = astLValueToString(cls,0);
+        char *var_str = astLValueToString(cls, 0);
         cctrlTokenRewind(cc);
         Lexeme *peek = cctrlTokenPeek(cc);
-        char *msg = mprintf("Using `%c` is an invalid operand for `%s %s`",peek->i64,
-                type_str,var_str);
+        char *msg = mprintf("Using `%c` is an invalid operand for `%s %s`",
+                            peek->i64, type_str, var_str);
         cctrlRaiseSuggestion(cc, msg,
-                                "Expected as class however got %s `%s %s`",
-                                astTypeKindToHumanReadable(cls->type),
-                                type_str,
-                                var_str);
+                             "Expected as class however got %s `%s %s`",
+                             astTypeKindToHumanReadable(cls->type), type_str,
+                             var_str);
     }
 
     type = cls->type;
 
     Lexeme *tok = cctrlTokenGet(cc);
     if (tok->tk_type != TK_IDENT) {
-        cctrlRaiseExceptionFromTo(cc,NULL,'-',*tok->start,"Expected class member got %s `%.*s`",
-                            lexemeTypeToString(tok->tk_type),
-                            tok->len,
-                            tok->start);
+        cctrlRaiseExceptionFromTo(cc, NULL, '-', *tok->start,
+                                  "Expected class member got %s `%.*s`",
+                                  lexemeTypeToString(tok->tk_type), tok->len,
+                                  tok->start);
     }
 
-    // XXX: This is hacky and only for recusive data types 
+    // XXX: This is hacky and only for recusive data types
     if (type->fields == NULL && cls->kind == AST_DEREF) {
         type = cls->cls->type;
     }
     AstType *field = strMapGetLen(type->fields, tok->start, tok->len);
     if (!field) {
         cctrlRewindUntilStrMatch(cc, tok->start, tok->len, NULL);
-        cctrlRaiseException(cc,"Property: %.*s does not exist on class", 
-                tok->len, tok->start);
+        cctrlRaiseException(cc, "Property: %.*s does not exist on class",
+                            tok->len, tok->start);
     }
     aoStr *field_name = aoStrDupRaw(tok->start, tok->len);
     return astClassRef(field, cls, aoStrMove(field_name));
@@ -861,23 +874,34 @@ static int parseCompoundAssign(Lexeme *tok) {
     }
 
     switch (tok->i64) {
-        case TK_ADD_EQU: return '+';
-        case TK_SUB_EQU: return '-';
-        case TK_MUL_EQU: return '*';
-        case TK_DIV_EQU: return '/';
-        case TK_MOD_EQU: return '%';
-        case TK_AND_EQU: return '&';
-        case TK_OR_EQU:  return '|';
-        case TK_XOR_EQU: return '^';
-        case TK_SHL_EQU: return TK_SHL;
-        case TK_SHR_EQU: return TK_SHR;
-        default: return 0;
+    case TK_ADD_EQU:
+        return '+';
+    case TK_SUB_EQU:
+        return '-';
+    case TK_MUL_EQU:
+        return '*';
+    case TK_DIV_EQU:
+        return '/';
+    case TK_MOD_EQU:
+        return '%';
+    case TK_AND_EQU:
+        return '&';
+    case TK_OR_EQU:
+        return '|';
+    case TK_XOR_EQU:
+        return '^';
+    case TK_SHL_EQU:
+        return TK_SHL;
+    case TK_SHR_EQU:
+        return TK_SHR;
+    default:
+        return 0;
     }
 }
 
 Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right) {
     int is_err = 0;
-    Ast *binop = astBinaryOp(operation,left,right,&is_err);
+    Ast *binop = astBinaryOp(operation, left, right, &is_err);
     if (!is_err) {
         return binop;
     } else if (is_err && !(cc->flags & CCTRL_TRANSPILING)) {
@@ -885,30 +909,31 @@ Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right) {
         const char *left_kind = astTypeKindToHumanReadable(left->type);
         const char *right_kind = astKindToHumanReadable(right);
         const char *right_type_kind = astTypeKindToHumanReadable(right->type);
-        cctrlRewindUntilPunctMatch(cc,operation,NULL);
+        cctrlRewindUntilPunctMatch(cc, operation, NULL);
         char *msg = mprintf("`%s %s %s` is invalid",
-                            astTypeToString(left->type),
-                            opstr,
+                            astTypeToString(left->type), opstr,
                             astTypeToString(right->type));
-        cctrlRaiseSuggestion(cc,msg,"The `%s` operator cannot be applied to a %s with a %s of %s", opstr, left_kind, right_kind, right_type_kind);
+        cctrlRaiseSuggestion(
+                cc, msg,
+                "The `%s` operator cannot be applied to a %s with a %s of %s",
+                opstr, left_kind, right_kind, right_type_kind);
     } else if (cc->flags & CCTRL_TRANSPILING) {
         binop->type = ast_int_type;
     }
     return binop;
-    
 }
 
 Ast *parseExpr(Cctrl *cc, int prec) {
-    Ast *LHS, *RHS;
+    Ast *LHS;
     Lexeme *tok;
-    int prec2, next_prec, compound_assign;
 
     if ((LHS = parseUnaryExpr(cc)) == NULL) {
         return NULL;
     }
 
     while (1) {
-        /* Can be TK_IDENT, or TK_F64 or TK_I64 or when type casting exists '(' TK_PUNCT */
+        /* Can be TK_IDENT, or TK_F64 or TK_I64 or when type casting exists '('
+         * TK_PUNCT */
         if ((tok = cctrlTokenGet(cc)) == NULL) {
             return LHS;
         }
@@ -918,51 +943,57 @@ Ast *parseExpr(Cctrl *cc, int prec) {
             return LHS;
         }
 
-        prec2 = parseGetPriority(tok);
+        int prec2 = parseGetPriority(tok);
         if (prec2 < 0 || prec <= prec2) {
             cctrlTokenRewind(cc);
             return LHS;
         }
 
-        if (tokenPunctIs(tok,'.')) {
-            LHS = parseGetClassField(cc,LHS);
+        if (tokenPunctIs(tok, '.')) {
+            LHS = parseGetClassField(cc, LHS);
             continue;
         }
 
-        if (tokenPunctIs(tok,'(')) {
-            /* XXX: Should this check still be here ? Not sure as 
+        if (tokenPunctIs(tok, '(')) {
+            /* XXX: Should this check still be here ? Not sure as
              * casting _anything_ makes sense */
             // assertLValue(LHS,cc->lineno);
             AstType *type = parseDeclSpec(cc);
-            LHS = astCast(LHS,type);
-            cctrlTokenExpect(cc,')');
+            LHS = astCast(LHS, type);
+            cctrlTokenExpect(cc, ')');
             continue;
         }
 
-        if (tokenPunctIs(tok, TK_PLUS_PLUS) || tokenPunctIs(tok, TK_MINUS_MINUS)) {
+        if (tokenPunctIs(tok, TK_PLUS_PLUS) ||
+            tokenPunctIs(tok, TK_MINUS_MINUS)) {
             if (!assertLValue(LHS)) {
-                char *ast_str = astLValueToString(LHS,0);
-                cctrlRaiseException(cc,"Expected an L-Value however got a %s - `%s`",
+                char *ast_str = astLValueToString(LHS, 0);
+                cctrlRaiseException(
+                        cc, "Expected an L-Value however got a %s - `%s`",
                         astKindToHumanReadable(LHS), ast_str);
             }
             LHS = astUnaryOperator(LHS->type, tok->i64, LHS);
             continue;
         }
 
-        if (tokenPunctIs(tok,'[')) {
-            if (LHS->type->kind != AST_TYPE_POINTER && LHS->type->kind != AST_TYPE_ARRAY) {
-                cctrlRewindUntilPunctMatch(cc,'[',NULL);
-                cctrlRaiseException(cc,"Cannot subscript a %s, only pointers or arrays can be subscripted with '['",
-                                   astTypeKindToHumanReadable(LHS->type));
+        if (tokenPunctIs(tok, '[')) {
+            if (LHS->type->kind != AST_TYPE_POINTER &&
+                LHS->type->kind != AST_TYPE_ARRAY) {
+                cctrlRewindUntilPunctMatch(cc, '[', NULL);
+                cctrlRaiseException(
+                        cc,
+                        "Cannot subscript a %s, only pointers or arrays can be subscripted with '['",
+                        astTypeKindToHumanReadable(LHS->type));
             }
-            LHS = parseSubscriptExpr(cc,LHS);
+            LHS = parseSubscriptExpr(cc, LHS);
             continue;
         }
 
         if (tokenPunctIs(tok, TK_ARROW)) {
             if (LHS->type->kind != AST_TYPE_POINTER) {
-                cctrlRaiseException(cc,"Pointer type expected got `%s` `%s`",
-                        astTypeToString(LHS->type), astLValueToString(LHS,0));
+                cctrlRaiseException(cc, "Pointer type expected got `%s` `%s`",
+                                    astTypeToString(LHS->type),
+                                    astLValueToString(LHS, 0));
             }
             LHS = astUnaryOperator(LHS->type->ptr, AST_DEREF, LHS);
             LHS->deref_symbol = TK_ARROW;
@@ -970,52 +1001,53 @@ Ast *parseExpr(Cctrl *cc, int prec) {
             continue;
         }
 
-        compound_assign = parseCompoundAssign(tok);
+        int compound_assign = parseCompoundAssign(tok);
         if (tokenPunctIs(tok, '=') || compound_assign) {
             if (!assertLValue(LHS)) {
-                char *ast_str = astLValueToString(LHS,0);
-                cctrlRaiseException(cc,"Expected an L-Value however got a %s - `%s`",
+                char *ast_str = astLValueToString(LHS, 0);
+                cctrlRaiseException(
+                        cc, "Expected an L-Value however got a %s - `%s`",
                         astKindToHumanReadable(LHS), ast_str);
             }
         }
-        
-        next_prec = prec2;
+
+        int next_prec = prec2;
         if (tok->i64 == '=') {
             next_prec++;
         }
 
-        RHS = parseExpr(cc,next_prec);
+        Ast *RHS = parseExpr(cc, next_prec);
         if (!RHS) {
-            Lexeme *peek = cctrlTokenPeek(cc);
+            const Lexeme *peek = cctrlTokenPeek(cc);
             cctrlTokenRewind(cc);
-            char *err_lvar = astLValueToString(LHS,0);
-            char *punct_str = lexemePunctToStringWithFlags(tok->i64,0);
-            char *msg = mprintf("`%s %s var2` is the expected usage however got `%.*s`",
-                    err_lvar,
-                    punct_str,peek->len,peek->start);
-            cctrlRaiseSuggestion(cc,msg,"Second operand missing to `%s %s` got invalid %s `%.*s`",
-                                 err_lvar,
-                                 punct_str,
-                                 lexemeTypeToString(peek->tk_type),
-                                 peek->len, 
-                                 peek->start);
+            char *err_lvar = astLValueToString(LHS, 0);
+            char *punct_str = lexemePunctToStringWithFlags(tok->i64, 0);
+            char *msg = mprintf(
+                    "`%s %s var2` is the expected usage however got `%.*s`",
+                    err_lvar, punct_str, peek->len, peek->start);
+            cctrlRaiseSuggestion(
+                    cc, msg,
+                    "Second operand missing to `%s %s` got invalid %s `%.*s`",
+                    err_lvar, punct_str, lexemeTypeToString(peek->tk_type),
+                    peek->len, peek->start);
         }
 
         if (compound_assign) {
-            AstType *ok = astTypeCheck(LHS->type,RHS,compound_assign);
+            const AstType *ok = astTypeCheck(LHS->type, RHS, compound_assign);
             if (!ok) {
-                typeCheckWarn(cc,compound_assign,LHS,RHS);
+                typeCheckWarn(cc, compound_assign, LHS, RHS);
             }
-            LHS = parseCreateBinaryOp(cc,'=', LHS, 
-                    parseCreateBinaryOp(cc,compound_assign, LHS, RHS));
+            LHS = parseCreateBinaryOp(cc, '=', LHS,
+                                      parseCreateBinaryOp(cc, compound_assign,
+                                                          LHS, RHS));
         } else {
             if (tok->i64 == '=') {
-                AstType *ok = astTypeCheck(LHS->type,RHS,'=');
+                const AstType *ok = astTypeCheck(LHS->type, RHS, '=');
                 if (!ok) {
-                    typeCheckWarn(cc,'=',LHS,RHS);
+                    typeCheckWarn(cc, '=', LHS, RHS);
                 }
             }
-            LHS = parseCreateBinaryOp(cc,tok->i64,LHS,RHS);
+            LHS = parseCreateBinaryOp(cc, tok->i64, LHS, RHS);
         }
     }
 }
@@ -1024,13 +1056,13 @@ static Ast *parseCast(Cctrl *cc) {
     Ast *ast;
     AstType *cast_type;
 
-    cctrlTokenExpect(cc,'<');
+    cctrlTokenExpect(cc, '<');
     cast_type = parseDeclSpec(cc);
-    cctrlTokenExpect(cc,'>');
-    cctrlTokenExpect(cc,'(');
-    ast = parseExpr(cc,16);
-    cctrlTokenExpect(cc,')');
-    ast = astCast(ast,cast_type);
+    cctrlTokenExpect(cc, '>');
+    cctrlTokenExpect(cc, '(');
+    ast = parseExpr(cc, 16);
+    cctrlTokenExpect(cc, ')');
+    ast = astCast(ast, cast_type);
     return ast;
 }
 
@@ -1040,9 +1072,9 @@ static Ast *parseSizeof(Cctrl *cc) {
     AstType *type = NULL;
     Ast *ast = NULL;
 
-    if (tokenPunctIs(tok,'(') && cctrlIsKeyword(cc,peek->start,peek->len)) {
+    if (tokenPunctIs(tok, '(') && cctrlIsKeyword(cc, peek->start, peek->len)) {
         type = parseFullType(cc);
-        cctrlTokenExpect(cc,')');
+        cctrlTokenExpect(cc, ')');
     } else {
         cctrlTokenRewind(cc);
         ast = parseUnaryExpr(cc);
@@ -1055,7 +1087,7 @@ static Ast *parseSizeof(Cctrl *cc) {
 
     /* If we have a string we want the _true_ length of it which as the string
      * is escaped needs to be calculated manually. */
-    long size = 0; 
+    long size = 0;
     if (ast && ast->kind == AST_STRING) {
         size = ast->real_len;
     } else {
@@ -1070,9 +1102,9 @@ static Ast *parseSizeof(Cctrl *cc) {
 Ast *parsePostFixExpr(Cctrl *cc) {
     Ast *ast;
     AstType *type;
-    Lexeme *tok,*peek;
+    Lexeme *tok, *peek;
 
-    /* parse primary rightly or wrongly, amongst other things, either gets a 
+    /* parse primary rightly or wrongly, amongst other things, either gets a
      * variable or parses a function call. */
     if ((ast = parsePrimary(cc)) == NULL) {
         return NULL;
@@ -1085,63 +1117,59 @@ Ast *parsePostFixExpr(Cctrl *cc) {
     while (1) {
         tok = cctrlTokenGet(cc);
 
-        if (tokenPunctIs(tok,'.')) {
-            ast = parseGetClassField(cc,ast);
+        if (tokenPunctIs(tok, '.')) {
+            ast = parseGetClassField(cc, ast);
             continue;
         }
 
         /* Postfix type cast OR function pointer on a class */
-        if (tokenPunctIs(tok,'(')) {
+        if (tokenPunctIs(tok, '(')) {
             peek = cctrlTokenPeek(cc);
-            if (cctrlIsKeyword(cc,peek->start,peek->len)) {
+            if (cctrlIsKeyword(cc, peek->start, peek->len)) {
                 type = parseDeclSpec(cc);
-                cctrlTokenExpect(cc,')');
-                ast = astCast(ast,type);
+                cctrlTokenExpect(cc, ')');
+                ast = astCast(ast, type);
                 continue;
-            } else if (ast->kind == AST_CLASS_REF) { 
+            } else if (ast->kind == AST_CLASS_REF) {
                 int len = strlen(ast->field);
-                PtrVec *argv = parseArgv(cc,ast,')',ast->field,len);
-                ast = astFunctionPtrCall(
-                        ast->type->rettype,
-                        ast->field,
-                        len,
-                        argv,
-                        ast);
+                PtrVec *argv = parseArgv(cc, ast, ')', ast->field, len);
+                ast = astFunctionPtrCall(ast->type->rettype, ast->field, len,
+                                         argv, ast);
                 continue;
             }
         }
 
-        if (tokenPunctIs(tok,TK_ARROW)) {
+        if (tokenPunctIs(tok, TK_ARROW)) {
             if (ast->type->kind != AST_TYPE_POINTER) {
                 char *type_str = astTypeToString(ast->type);
-                char *var_str = astLValueToString(ast,0);
-                cctrlRaiseException(cc,"Pointer expected got a %s `%s %s`",
-                                        astTypeKindToHumanReadable(ast->type),
-                                        type_str, 
-                                        var_str);
+                char *var_str = astLValueToString(ast, 0);
+                cctrlRaiseException(cc, "Pointer expected got a %s `%s %s`",
+                                    astTypeKindToHumanReadable(ast->type),
+                                    type_str, var_str);
             }
-            ast = astUnaryOperator(ast->type->ptr,AST_DEREF,ast);
+            ast = astUnaryOperator(ast->type->ptr, AST_DEREF, ast);
             ast->deref_symbol = TK_ARROW;
-            ast = parseGetClassField(cc,ast);
+            ast = parseGetClassField(cc, ast);
             continue;
         }
 
-        if (tokenPunctIs(tok,TK_PLUS_PLUS) || 
-            tokenPunctIs(tok,TK_MINUS_MINUS)) {
+        if (tokenPunctIs(tok, TK_PLUS_PLUS) ||
+            tokenPunctIs(tok, TK_MINUS_MINUS)) {
             if (!assertLValue(ast)) {
-                char *ast_str = astLValueToString(ast,0);
-                cctrlRaiseException(cc,"Expected an L-Value however got a %s - `%s`",
+                char *ast_str = astLValueToString(ast, 0);
+                cctrlRaiseException(
+                        cc, "Expected an L-Value however got a %s - `%s`",
                         astKindToHumanReadable(ast), ast_str);
             }
             if (tok->i64 == TK_PLUS_PLUS) {
-                return astUnaryOperator(ast->type,TK_PLUS_PLUS,ast);
+                return astUnaryOperator(ast->type, TK_PLUS_PLUS, ast);
             } else {
-                return astUnaryOperator(ast->type,TK_MINUS_MINUS,ast);
+                return astUnaryOperator(ast->type, TK_MINUS_MINUS, ast);
             }
         }
 
         cctrlTokenRewind(cc);
-        tok = cctrlTokenPeek(cc);
+
         return ast;
     }
 }
@@ -1151,89 +1179,124 @@ Ast *parseUnaryExpr(Cctrl *cc) {
     Ast *ast;
 
     if ((tok = cctrlTokenGet(cc)) == NULL) {
-        cctrlRaiseException(cc,"Unexpected end of input");
+        cctrlRaiseException(cc, "Unexpected end of input");
     }
 
     if (tok->tk_type == TK_KEYWORD) {
         switch (tok->i64) {
-            case KW_SIZEOF: return parseSizeof(cc);
-            case KW_CAST:   return parseCast(cc);
-            case KW_DEFINED: {
-                cctrlTokenExpect(cc,'(');
-                tok = cctrlTokenGet(cc);
+        case KW_SIZEOF:
+            return parseSizeof(cc);
+        case KW_CAST:
+            return parseCast(cc);
+        case KW_DEFINED: {
+            cctrlTokenExpect(cc, '(');
+            tok = cctrlTokenGet(cc);
 
-                if (tok->i64 != ')') {
-                    ast = astI64Type(1);
-                } else {
-                    ast = astI64Type(0);
-                }
-                if (tok->i64 != ')') {
-                    cctrlTokenExpect(cc,')');
-                }
-                return ast;
+            if (tok->i64 != ')') {
+                ast = astI64Type(1);
+            } else {
+                ast = astI64Type(0);
             }
-            default: {
-                cctrlTokenRewind(cc);
-                cctrlRaiseException(cc,"Unexpected keyword: %.*s while parsing unary expression",
-                        tok->len,tok->start);
+            if (tok->i64 != ')') {
+                cctrlTokenExpect(cc, ')');
             }
+            return ast;
+        }
+        default: {
+            cctrlTokenRewind(cc);
+            cctrlRaiseException(
+                    cc,
+                    "Unexpected keyword: %.*s while parsing unary expression",
+                    tok->len, tok->start);
+        }
         }
     }
 
-    if (tokenPunctIs(tok,'(')) {
-        ast = parseExpr(cc,16);
-        cctrlTokenExpect(cc,')');
+    if (tokenPunctIs(tok, '(')) {
+        ast = parseExpr(cc, 16);
+        cctrlTokenExpect(cc, ')');
         return ast;
     }
 
     if (tok->tk_type == TK_PUNCT) {
         long unary_op = -1;
         switch (tok->i64) {
-            case '&': { unary_op = AST_ADDR; break; }
-            case '*': { unary_op = AST_DEREF; break; }
-            case '~': { unary_op = '~'; break; }
-            case '!': { unary_op = '!'; break; }
-            case '-': { unary_op = '-'; break; }
-            case TK_PLUS_PLUS: { unary_op = TK_PRE_PLUS_PLUS; break; }
-            case TK_MINUS_MINUS: { unary_op = TK_PRE_MINUS_MINUS; break; }
-            default: {
-                cctrlTokenRewind(cc);
-                return parsePostFixExpr(cc);
-            }
+        case '&': {
+            unary_op = AST_ADDR;
+            break;
+        }
+        case '*': {
+            unary_op = AST_DEREF;
+            break;
+        }
+        case '~': {
+            unary_op = '~';
+            break;
+        }
+        case '!': {
+            unary_op = '!';
+            break;
+        }
+        case '-': {
+            unary_op = '-';
+            break;
+        }
+        case TK_PLUS_PLUS: {
+            unary_op = TK_PRE_PLUS_PLUS;
+            break;
+        }
+        case TK_MINUS_MINUS: {
+            unary_op = TK_PRE_MINUS_MINUS;
+            break;
+        }
+        default: {
+            cctrlTokenRewind(cc);
+            return parsePostFixExpr(cc);
+        }
         }
 
-        Lexeme *peek = cctrlTokenPeekBy(cc,1);
+        Lexeme *peek = cctrlTokenPeekBy(cc, 1);
         Ast *operand = NULL;
         AstType *type = NULL;
 
         /* XXX: This feels wrong but allows things like:
          * !arr[0][1][2] to work properly */
-        if (tokenPunctIs(peek, '[') && !(unary_op == AST_ADDR || unary_op == AST_DEREF)) {
-            operand = parseExpr(cc,16);
+        if (tokenPunctIs(peek, '[') &&
+            !(unary_op == AST_ADDR || unary_op == AST_DEREF)) {
+            operand = parseExpr(cc, 16);
         } else {
             operand = parseUnaryExpr(cc);
             peek = cctrlTokenPeek(cc);
-            if (tokenPunctIs(peek, '[') && (operand->kind == AST_CLASS_REF || operand->type->kind == AST_TYPE_ARRAY)) {
+            if (tokenPunctIs(peek, '[') &&
+                (operand->kind == AST_CLASS_REF ||
+                 operand->type->kind == AST_TYPE_ARRAY)) {
                 cctrlTokenGet(cc);
                 operand = parseSubscriptExpr(cc, operand);
             }
         }
-
 
         if (unary_op == AST_ADDR && parseIsFunction(operand)) {
             return operand;
         }
 
         switch (unary_op) {
-            case AST_ADDR:  type = astMakePointerType(operand->type); break;
-            case AST_DEREF: type = operand->type->ptr; break;
-            case '~':       type = ast_int_type; break;
-            default:        type = operand->type; break;
+        case AST_ADDR:
+            type = astMakePointerType(operand->type);
+            break;
+        case AST_DEREF:
+            type = operand->type->ptr;
+            break;
+        case '~':
+            type = ast_int_type;
+            break;
+        default:
+            type = operand->type;
+            break;
         }
 
         return astUnaryOperator(type, unary_op, operand);
     }
-    
+
     cctrlTokenRewind(cc);
     return parsePostFixExpr(cc);
 }

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -8,7 +8,7 @@ Ast *parseExpr(Cctrl *cc, int prec);
 Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, long terminator);
 PtrVec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store);
 void parseDeclInternal(Cctrl *cc, Lexeme **tok, AstType **type);
-void parseAssignAuto(Cctrl *cc, Ast *ast);
+void parseAssignAuto(Cctrl *cc, const Ast *ast);
 AstType *parseReturnAuto(Cctrl *cc, Ast *retval);
 AstType *parseArrayDimensions(Cctrl *cc, AstType *base_type);
 AstType *parsePointerType(Cctrl *cc, AstType *type);
@@ -16,8 +16,8 @@ AstType *parseBaseDeclSpec(Cctrl *cc);
 AstType *parseDeclSpec(Cctrl *cc);
 AstType *parseFullType(Cctrl *cc);
 Ast *parseFunctionPointer(Cctrl *cc, AstType *rettype);
-AstType *parseFunctionPointerType(Cctrl *cc,
-        char **fnptr_name, int *fnptr_name_len, AstType *rettype);
+AstType *parseFunctionPointerType(Cctrl *cc, char **fnptr_name,
+                                  int *fnptr_name_len, AstType *rettype);
 Ast *findFunctionDecl(Cctrl *cc, char *fname, int len);
 Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right);
 

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -6,47 +6,47 @@
 #include "lexer.h"
 #include "map.h"
 
-#define PUNCT_TERM_COMMA  (1<<0) // ';'
-#define PUNCT_TERM_SEMI   (1<<1) // ','
-#define PUNCT_TERM_RPAREN (1<<2) // ')'
-#define PUNCT_TERM_LPAREN (1<<3) // '('
-#define PUNCT_TERM_ARROW  (1<<4) // '->'
-#define PUNCT_TERM_DOT    (1<<5) // '.'
-#define PUNCT_TERM_LSQR   (1<<6) // '['
-#define PUNCT_TERM_RSQR   (1<<7) // ']'
+#define PUNCT_TERM_COMMA  (1 << 0) // ';'
+#define PUNCT_TERM_SEMI   (1 << 1) // ','
+#define PUNCT_TERM_RPAREN (1 << 2) // ')'
+#define PUNCT_TERM_LPAREN (1 << 3) // '('
+#define PUNCT_TERM_ARROW  (1 << 4) // '->'
+#define PUNCT_TERM_DOT    (1 << 5) // '.'
+#define PUNCT_TERM_LSQR   (1 << 6) // '['
+#define PUNCT_TERM_RSQR   (1 << 7) // ']'
 
 int align(int n, int m);
 
-
 /* Is the lexeme both of type TK_PUNCT and does 'ch' match */
-int parseIsFunctionCall(Ast *ast);
+int parseIsFunctionCall(const Ast *ast);
 AstType *parseGetType(Cctrl *cc, Lexeme *tok);
-int parseIsKeyword(Lexeme *tok, Cctrl *cc);
+int parseIsKeyword(const Lexeme *tok, const Cctrl *cc);
 double evalFloatExpr(Ast *ast);
-double evalFloatArithmeticOrErr(Ast *ast, int *_ok);
-double evalFloatExprOrErr(Ast *ast, int *_ok);
-double evalOneFloatExprOrErr(Ast *LHS, Ast *RHS, long op, int *_ok);
+double evalFloatArithmeticOrErr(const Ast *ast, int *_ok);
+double evalFloatExprOrErr(const Ast *ast, int *_ok);
+double evalOneFloatExprOrErr(const Ast *LHS, const Ast *RHS, long op, int *_ok);
 long evalIntConstExpr(Ast *ast);
-long evalIntConstExprOrErr(Ast *ast, int *_ok);
-long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, long op, int *_ok);
-long evalIntArithmeticOrErr(Ast *ast, int *_ok);
+long evalIntConstExprOrErr(const Ast *ast, int *_ok);
+long evalOneIntExprOrErr(const Ast *LHS, const Ast *RHS, long op, int *_ok);
+long evalIntArithmeticOrErr(const Ast *ast, int *_ok);
 int evalClassRef(Ast *ast, int offset);
-int assertLValue(Ast *ast);
-int parseIsFloatOrInt(Ast *ast);
+int assertLValue(const Ast *ast);
+int parseIsFloatOrInt(const Ast *ast);
 int parseIsClassOrUnion(int kind);
-int parseIsFunction(Ast *ast);
+int parseIsFunction(const Ast *ast);
 int astIsArithmetic(long op, int is_float);
 
 void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags);
 void assertTokenIsTerminatorWithMsg(Cctrl *cc, Lexeme *tok,
-        long terminator_flags, const char *fmt, ...);
-void assertUniqueSwitchCaseLabels(PtrVec *case_vector, Ast *case_);
-void assertIsFloatOrInt(Ast *ast, long lineno);
-void assertIsInt(Ast *ast, long lineno);
-void assertIsFloat(Ast *ast, long lineno);
+                                    long terminator_flags, const char *fmt,
+                                    ...);
+void assertUniqueSwitchCaseLabels(const PtrVec *case_vector, const Ast *case_);
+void assertIsFloatOrInt(const Ast *ast, long lineno);
+void assertIsInt(const Ast *ast, long lineno);
+void assertIsFloat(const Ast *ast, long lineno);
 void assertIsPointer(Ast *ast, long lineno);
 
-void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual);
-void typeCheckReturnTypeWarn(Cctrl *cc, Ast *maybe_func, 
-                             AstType *check, Ast *retval);
+void typeCheckWarn(Cctrl *cc, long op, const Ast *expected, Ast *actual);
+void typeCheckReturnTypeWarn(Cctrl *cc, const Ast *maybe_func,
+                             const AstType *check, const Ast *retval);
 #endif // PRS_UTIL

--- a/src/transpiler.c
+++ b/src/transpiler.c
@@ -16,8 +16,8 @@
 #include "transpiler.h"
 #include "util.h"
 
-#define TRANSPILE_FLAG_SWITCH_CHAR (1<<0)
-#define TRANSPILE_FLAG_ISATTY      (1<<1)
+#define TRANSPILE_FLAG_SWITCH_CHAR (1 << 0)
+#define TRANSPILE_FLAG_ISATTY      (1 << 1)
 
 typedef struct TranspilationMapping {
     char *name;
@@ -36,12 +36,8 @@ typedef struct TranspileCtx {
     aoStr *buf;
 } TranspileCtx;
 
-static void transpileFields(TranspileCtx *ctx,
-                            StrMap *fields,
-                            StrMap *seen,
-                            char *clsname, 
-                            aoStr *buf,
-                            ssize_t *ident);
+static void transpileFields(TranspileCtx *ctx, StrMap *fields, StrMap *seen,
+                            char *clsname, aoStr *buf, ssize_t *ident);
 aoStr *transpileVarDecl(TranspileCtx *ctx, AstType *type, char *name);
 void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent);
 aoStr *transpileArgvList(PtrVec *argv, TranspileCtx *ctx);
@@ -49,223 +45,207 @@ aoStr *transpileAst(Ast *ast, TranspileCtx *ctx);
 aoStr *transpileFunctionProto(TranspileCtx *ctx, AstType *type, char *name);
 
 static char *transpile_used_c_headers[] = {
-    "arpa/inet.h",
-    "dirent.h",
-    "fcntl.h",
-    "math.h",
-    "netdb.h",
-    "pthread.h",
+        "arpa/inet.h", "dirent.h",   "fcntl.h",  "math.h",    "netdb.h",
+        "pthread.h",
 #ifdef HCC_LINK_SQLITE3
-    "sqlite3.h",
+        "sqlite3.h",
 #endif
-    "stdio.h",
-    "stdlib.h",
-    "string.h",
-    "strings.h",
-    "sys/socket.h",
-    "sys/stat.h",
-    "sys/wait.h",
-    "time.h",
-    "unistd.h",
+        "stdio.h",     "stdlib.h",   "string.h", "strings.h", "sys/socket.h",
+        "sys/stat.h",  "sys/wait.h", "time.h",   "unistd.h",
 };
 
 static char *transpile_skip_defines[] = {
-    "__ARCH__",
-    "__TIME__",
-    "__DATE__",
-    "__TIMESTAMP__",
-    "NULL",
-    "EXIT_FAIL",
-    "EXIT_OK",
-    "STDOUT",
-    "STDERR",
-    "STDIN",
-    "SOL_SOCKET",
-    "AF_UNSPEC",
-    "AF_UNIX",
-    "AF_INET",
-    "AF_INET6",
-    "SOCK_STREAM",
-    "SOCK_DGRAM",
-    "SOCK_RAW",
-    "SOCK_SEQPACKET",
-    "SO_DEBUG",
-    "SO_ACCEPTCONN",
-    "SO_REUSEADDR",
-    "SO_KEEPALIVE",
-    "SO_DONTROUTE",
-    "SO_BROADCAST",
-    "SO_LINGER",
-    "SO_OOBINLINE",
-    "SO_REUSEPORT",
-    "SO_TIMESTAMP",
-    "SO_TIMESTAMP_MONOTONIC",
-    "IPPROTO_IP",
-    "IPPROTO_IPV6",
-    "TCP_NODELAY",
-    "TCP_MAXSEG",
-    "TCP_NOPUSH",
-    "TCP_NOOPT",
-    "TCP_KEEPALIVE",
-    "TCP_CONNECTIONTIMEOUT",
-    "PERSIST_TIMEOUT",
-    "TCP_RXT_CONNDROPTIME",
-    "TCP_RXT_FINDROP",
-    "TCP_KEEPINTVL",
-    "TCP_KEEPCNT",
-    "TCP_SENDMOREACKS",
-    "TCP_ENABLE_ECN",
-    "TCP_FASTOPEN",
-    "TCP_CONNECTION_INFO",
-    "INET6_ADDRSTRLEN",
-    "AI_PASSIVE",
-    "AI_CANONNAME",
-    "AI_NUMERICHOST",
-    "AI_NUMERICSERV",
-    "AI_UNUSABLE",
-    "_SS_PAD1SIZE",
-    "_SS_PAD2SIZE",
-    "F_DUPFD",
-    "F_GETFD",
-    "F_SETFD",
-    "F_GETFL",
-    "F_SETFL",
-    "F_FLUSH_DATA",
-    "F_CHKCLEAN",
-    "F_PREALLOCATE",
-    "F_SETSIZE",
-    "F_RDADVISE",
-    "F_RDAHEAD",
-    "FD_CLOEXEC",
-    "F_GETOWN",
-    "F_SETOWN",
-    "F_GETLK",
-    "F_SETLK",
-    "F_SETLKW",
-    "F_RDLCK",
-    "F_UNLCK",
-    "F_WRLCK",
-    "O_RDONLY",
-    "O_WRONLY",
-    "O_RDWR",
-    "O_ACCMODE",
-    "O_CREAT",
-    "O_TRUNC",
-    "O_EXCL",
-    "O_NONBLOCK",
-    "O_APPEND",
-    "SEEK_SET",
-    "SEEK_CUR",
-    "SEEK_END",
-    "DT_UNKNOWN",
-    "DT_FIFO",
-    "DT_CHR",
-    "DT_DIR",
-    "DT_BLK",
-    "DT_REG",
-    "DT_LNK",
-    "DT_SOCK",
-    "DT_WHT",
-    "S_IFMT",
-    "S_IFIFO",
-    "S_IFCHR",
-    "S_IFDIR",
-    "S_IFBLK",
-    "S_IFREG",
-    "S_IFLNK",
-    "S_IFSOCK",
-    "S_IRWXU",
-    "S_IRUSR",
-    "S_IWUSR",
-    "S_IXUSR",
-    "S_IRWXG",
-    "S_IRGRP",
-    "S_IWGRP",
-    "S_IXGRP",
-    "S_IRWXO",
-    "S_IROTH",
-    "S_IWOTH",
-    "S_IXOTH",
-    "S_ISUID",
-    "S_ISGID",
-    "S_ISVTX",
+        "__ARCH__",
+        "__TIME__",
+        "__DATE__",
+        "__TIMESTAMP__",
+        "NULL",
+        "EXIT_FAIL",
+        "EXIT_OK",
+        "STDOUT",
+        "STDERR",
+        "STDIN",
+        "SOL_SOCKET",
+        "AF_UNSPEC",
+        "AF_UNIX",
+        "AF_INET",
+        "AF_INET6",
+        "SOCK_STREAM",
+        "SOCK_DGRAM",
+        "SOCK_RAW",
+        "SOCK_SEQPACKET",
+        "SO_DEBUG",
+        "SO_ACCEPTCONN",
+        "SO_REUSEADDR",
+        "SO_KEEPALIVE",
+        "SO_DONTROUTE",
+        "SO_BROADCAST",
+        "SO_LINGER",
+        "SO_OOBINLINE",
+        "SO_REUSEPORT",
+        "SO_TIMESTAMP",
+        "SO_TIMESTAMP_MONOTONIC",
+        "IPPROTO_IP",
+        "IPPROTO_IPV6",
+        "TCP_NODELAY",
+        "TCP_MAXSEG",
+        "TCP_NOPUSH",
+        "TCP_NOOPT",
+        "TCP_KEEPALIVE",
+        "TCP_CONNECTIONTIMEOUT",
+        "PERSIST_TIMEOUT",
+        "TCP_RXT_CONNDROPTIME",
+        "TCP_RXT_FINDROP",
+        "TCP_KEEPINTVL",
+        "TCP_KEEPCNT",
+        "TCP_SENDMOREACKS",
+        "TCP_ENABLE_ECN",
+        "TCP_FASTOPEN",
+        "TCP_CONNECTION_INFO",
+        "INET6_ADDRSTRLEN",
+        "AI_PASSIVE",
+        "AI_CANONNAME",
+        "AI_NUMERICHOST",
+        "AI_NUMERICSERV",
+        "AI_UNUSABLE",
+        "_SS_PAD1SIZE",
+        "_SS_PAD2SIZE",
+        "F_DUPFD",
+        "F_GETFD",
+        "F_SETFD",
+        "F_GETFL",
+        "F_SETFL",
+        "F_FLUSH_DATA",
+        "F_CHKCLEAN",
+        "F_PREALLOCATE",
+        "F_SETSIZE",
+        "F_RDADVISE",
+        "F_RDAHEAD",
+        "FD_CLOEXEC",
+        "F_GETOWN",
+        "F_SETOWN",
+        "F_GETLK",
+        "F_SETLK",
+        "F_SETLKW",
+        "F_RDLCK",
+        "F_UNLCK",
+        "F_WRLCK",
+        "O_RDONLY",
+        "O_WRONLY",
+        "O_RDWR",
+        "O_ACCMODE",
+        "O_CREAT",
+        "O_TRUNC",
+        "O_EXCL",
+        "O_NONBLOCK",
+        "O_APPEND",
+        "SEEK_SET",
+        "SEEK_CUR",
+        "SEEK_END",
+        "DT_UNKNOWN",
+        "DT_FIFO",
+        "DT_CHR",
+        "DT_DIR",
+        "DT_BLK",
+        "DT_REG",
+        "DT_LNK",
+        "DT_SOCK",
+        "DT_WHT",
+        "S_IFMT",
+        "S_IFIFO",
+        "S_IFCHR",
+        "S_IFDIR",
+        "S_IFBLK",
+        "S_IFREG",
+        "S_IFLNK",
+        "S_IFSOCK",
+        "S_IRWXU",
+        "S_IRUSR",
+        "S_IWUSR",
+        "S_IXUSR",
+        "S_IRWXG",
+        "S_IRGRP",
+        "S_IWGRP",
+        "S_IXGRP",
+        "S_IRWXO",
+        "S_IROTH",
+        "S_IWOTH",
+        "S_IXOTH",
+        "S_ISUID",
+        "S_ISGID",
+        "S_ISVTX",
 };
 
-static char *transpile_skip_classes[] = {
-    "hostent",
-    "netent",
-    "servent",
-    "protoent",
-    "sockaddr",
-    "in_addr",
-    "sockaddr_in",
-    "in6_addr",
-    "sockaddr_in6",
-    "addrinfo",
-    "sockaddr_storage",
-    "sockaddr_un",
-    "iovec",
-    "pthread_mutex_t",
-    "pthread_mutexattr_t",
-    "pthread_cond_t",
-    "pthread_condattr_t",
-    "pthread_handler_rec",
-    "pthread_attr_t",
-    "pthread_t",
-    "tm",
-    "timeval",
-    "msghdr"
-};
+static char *transpile_skip_classes[] = {"hostent",
+                                         "netent",
+                                         "servent",
+                                         "protoent",
+                                         "sockaddr",
+                                         "in_addr",
+                                         "sockaddr_in",
+                                         "in6_addr",
+                                         "sockaddr_in6",
+                                         "addrinfo",
+                                         "sockaddr_storage",
+                                         "sockaddr_un",
+                                         "iovec",
+                                         "pthread_mutex_t",
+                                         "pthread_mutexattr_t",
+                                         "pthread_cond_t",
+                                         "pthread_condattr_t",
+                                         "pthread_handler_rec",
+                                         "pthread_attr_t",
+                                         "pthread_t",
+                                         "tm",
+                                         "timeval",
+                                         "msghdr"};
 
 static TranspilationMapping transpile_function_substitutions_table[] = {
-    {str_lit("_MALLOC"), str_lit("malloc")},
-    {str_lit("_CALLOC"), str_lit("calloc")},
-    {str_lit("_REALLOC"), str_lit("realloc")},
-    {str_lit("_MEMCPY"), str_lit("memcpy")},
-    {str_lit("_MEMSET"), str_lit("memset")},
-    {str_lit("_FREE"), str_lit("free")},
-    {str_lit("_STRLEN_FAST"), str_lit("strlen")},
-    {str_lit("_STRNCMP"), str_lit("strncmp")},
-    {str_lit("_STRNICMP"), str_lit("strncasecmp")},
-    {str_lit("_STRCMP"), str_lit("strcmp")},
-    {str_lit("_STRCPY"), str_lit("strcpy")},
-    {str_lit("_TOLOWER"), str_lit("tolower")},
-    {str_lit("_TOUPPER"), str_lit("toupper")},
-    {str_lit("_ISSPACE"), str_lit("isspace")},
-    {str_lit("_ATOI"), str_lit("atoi")},
-    {str_lit("_EXIT"), str_lit("exit")},
-    {str_lit("Exit"), str_lit("exit")},
+        {str_lit("_MALLOC"), str_lit("malloc")},
+        {str_lit("_CALLOC"), str_lit("calloc")},
+        {str_lit("_REALLOC"), str_lit("realloc")},
+        {str_lit("_MEMCPY"), str_lit("memcpy")},
+        {str_lit("_MEMSET"), str_lit("memset")},
+        {str_lit("_FREE"), str_lit("free")},
+        {str_lit("_STRLEN_FAST"), str_lit("strlen")},
+        {str_lit("_STRNCMP"), str_lit("strncmp")},
+        {str_lit("_STRNICMP"), str_lit("strncasecmp")},
+        {str_lit("_STRCMP"), str_lit("strcmp")},
+        {str_lit("_STRCPY"), str_lit("strcpy")},
+        {str_lit("_TOLOWER"), str_lit("tolower")},
+        {str_lit("_TOUPPER"), str_lit("toupper")},
+        {str_lit("_ISSPACE"), str_lit("isspace")},
+        {str_lit("_ATOI"), str_lit("atoi")},
+        {str_lit("_EXIT"), str_lit("exit")},
+        {str_lit("Exit"), str_lit("exit")},
 };
 
 /* singleton maps, we don't need unique instances and do not mutate these */
 static StrMap *transpile_function_substitutions = NULL;
 static StrMap *transpile_skip_defines_map = NULL;
 static StrMap *transpile_skip_classes_map = NULL;
-static int is_init = 0;
 
 void transpileInitMaps(void) {
-    if (!is_init) {
-        transpile_function_substitutions = strMapNew(32);
-        transpile_skip_defines_map = strMapNew(32);
-        transpile_skip_classes_map = strMapNew(32);
+    transpile_function_substitutions = strMapNew(32);
+    transpile_skip_defines_map = strMapNew(32);
+    transpile_skip_classes_map = strMapNew(32);
 
-        ssize_t len = static_size(transpile_skip_defines);
-        for (ssize_t i = 0; i < len; ++i) {
-            char *define = transpile_skip_defines[i];
-            strMapAdd(transpile_skip_defines_map, define, define);
-        }
+    ssize_t len = static_size(transpile_skip_defines);
+    for (ssize_t i = 0; i < len; ++i) {
+        char *define = transpile_skip_defines[i];
+        strMapAdd(transpile_skip_defines_map, define, define);
+    }
 
-        len = static_size(transpile_skip_classes);
-        for (ssize_t i = 0; i < len; ++i) {
-            char *cls = transpile_skip_classes[i];
-            strMapAdd(transpile_skip_classes_map, cls, cls);
-        }
-    
-        len = static_size(transpile_function_substitutions_table);
-        for (ssize_t i = 0; i < len; ++i) {
-            TranspilationMapping *sub = &transpile_function_substitutions_table[i]; 
-            strMapAdd(transpile_function_substitutions,sub->name,sub->sub);
-        }
+    len = static_size(transpile_skip_classes);
+    for (ssize_t i = 0; i < len; ++i) {
+        char *cls = transpile_skip_classes[i];
+        strMapAdd(transpile_skip_classes_map, cls, cls);
+    }
+
+    len = static_size(transpile_function_substitutions_table);
+    for (ssize_t i = 0; i < len; ++i) {
+        TranspilationMapping *sub = &transpile_function_substitutions_table[i];
+        strMapAdd(transpile_function_substitutions, sub->name, sub->sub);
     }
 }
 
@@ -287,26 +267,26 @@ TranspileCtx *transpileCtxNew(Cctrl *cc) {
     return ctx;
 }
 
-void transpileCtxAddType(TranspileCtx *ctx, char *type_name) {
-    strMapAdd(ctx->used_types,type_name,type_name);
+void transpileCtxAddType(const TranspileCtx *ctx, char *type_name) {
+    strMapAdd(ctx->used_types, type_name, type_name);
 }
 
-void transpileCtxAddDefine(TranspileCtx *ctx, char *def_name) {
-    strMapAdd(ctx->used_defines,def_name,def_name);
+void transpileCtxAddDefine(const TranspileCtx *ctx, char *def_name) {
+    strMapAdd(ctx->used_defines, def_name, def_name);
 }
 
 void transpileCtxSetBuffer(TranspileCtx *ctx, aoStr *buf) {
     ctx->buf = buf;
 }
 
-int transpileCtxShouldEmitType(TranspileCtx *ctx, char *name, int len) {
+int transpileCtxShouldEmitType(const TranspileCtx *ctx, char *name, int len) {
     if (strMapGetLen(ctx->skip_types, name, len) != NULL) {
         return 0;
     }
     return 1;
 }
 
-int transpileCtxShouldEmitDefine(TranspileCtx *ctx, char *name, int len) {
+int transpileCtxShouldEmitDefine(const TranspileCtx *ctx, char *name, int len) {
     if (strMapGetLen(ctx->skip_defines, name, len) != NULL) {
         return 0;
     }
@@ -314,109 +294,143 @@ int transpileCtxShouldEmitDefine(TranspileCtx *ctx, char *name, int len) {
 }
 
 /* make lower camelcase */
-aoStr *transpileFormatFunction(aoStr *fname) {
+aoStr *transpileFormatFunction(const aoStr *fname) {
     aoStr *dupped = aoStrDup(fname);
     dupped->data[0] = tolower(dupped->data[0]);
     return dupped;
 }
 
-char *transpileKeyWordHighlight(TranspileCtx *ctx, int ast_kind) {
+char *transpileKeyWordHighlight(const TranspileCtx *ctx, int ast_kind) {
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
         switch (ast_kind) {
-            case KW_DO: return ESC_WHITE"do"ESC_RESET;
-            case KW_WHILE: return ESC_WHITE"while"ESC_RESET;
-            case KW_FOR: return ESC_WHITE"for"ESC_RESET;
-            case KW_SWITCH: return ESC_WHITE"switch"ESC_RESET;
-            case KW_IF: return ESC_WHITE"if"ESC_RESET;
-            case KW_ELSE: return ESC_WHITE"else"ESC_RESET;
-            case KW_DEFAULT: return ESC_WHITE"default"ESC_RESET;
-            case KW_SIZEOF: return ESC_WHITE"sizeof"ESC_RESET;
-            case KW_CONTINUE: return ESC_WHITE"continue"ESC_RESET;
-            case KW_BREAK: return ESC_WHITE"break"ESC_RESET;
-            case KW_STATIC: return ESC_WHITE"static"ESC_RESET;
-            case KW_INLINE: return ESC_WHITE"inline"ESC_RESET;
-            case KW_RETURN: return ESC_WHITE"return"ESC_RESET;
-            case KW_GOTO: return ESC_WHITE"goto"ESC_RESET;
-            case KW_CASE: return ESC_WHITE"case"ESC_RESET;
-            case KW_VOLATILE: return ESC_WHITE"volatile"ESC_RESET;
-            default: loggerDebug("Internal error - invalid keyword!");
+        case KW_DO:
+            return ESC_WHITE "do" ESC_RESET;
+        case KW_WHILE:
+            return ESC_WHITE "while" ESC_RESET;
+        case KW_FOR:
+            return ESC_WHITE "for" ESC_RESET;
+        case KW_SWITCH:
+            return ESC_WHITE "switch" ESC_RESET;
+        case KW_IF:
+            return ESC_WHITE "if" ESC_RESET;
+        case KW_ELSE:
+            return ESC_WHITE "else" ESC_RESET;
+        case KW_DEFAULT:
+            return ESC_WHITE "default" ESC_RESET;
+        case KW_SIZEOF:
+            return ESC_WHITE "sizeof" ESC_RESET;
+        case KW_CONTINUE:
+            return ESC_WHITE "continue" ESC_RESET;
+        case KW_BREAK:
+            return ESC_WHITE "break" ESC_RESET;
+        case KW_STATIC:
+            return ESC_WHITE "static" ESC_RESET;
+        case KW_INLINE:
+            return ESC_WHITE "inline" ESC_RESET;
+        case KW_RETURN:
+            return ESC_WHITE "return" ESC_RESET;
+        case KW_GOTO:
+            return ESC_WHITE "goto" ESC_RESET;
+        case KW_CASE:
+            return ESC_WHITE "case" ESC_RESET;
+        case KW_VOLATILE:
+            return ESC_WHITE "volatile" ESC_RESET;
+        default:
+            loggerDebug("Internal error - invalid keyword!");
         }
     } else {
         switch (ast_kind) {
-            case KW_DO: return "do";
-            case KW_WHILE: return "while";
-            case KW_FOR: return "for";
-            case KW_SWITCH: return "switch";
-            case KW_IF: return "if";
-            case KW_ELSE: return "else";
-            case KW_DEFAULT: return "default";
-            case KW_SIZEOF: return "sizeof";
-            case KW_CONTINUE: return "continue";
-            case KW_BREAK: return "break";
-            case KW_STATIC: return "static";
-            case KW_INLINE: return "inline";
-            case KW_RETURN: return "return";
-            case KW_GOTO: return "goto";
-            case KW_CASE: return "case";
-            case KW_VOLATILE: return "volatile";
-            default: loggerDebug("Internal error - invalid keyword!");
+        case KW_DO:
+            return "do";
+        case KW_WHILE:
+            return "while";
+        case KW_FOR:
+            return "for";
+        case KW_SWITCH:
+            return "switch";
+        case KW_IF:
+            return "if";
+        case KW_ELSE:
+            return "else";
+        case KW_DEFAULT:
+            return "default";
+        case KW_SIZEOF:
+            return "sizeof";
+        case KW_CONTINUE:
+            return "continue";
+        case KW_BREAK:
+            return "break";
+        case KW_STATIC:
+            return "static";
+        case KW_INLINE:
+            return "inline";
+        case KW_RETURN:
+            return "return";
+        case KW_GOTO:
+            return "goto";
+        case KW_CASE:
+            return "case";
+        case KW_VOLATILE:
+            return "volatile";
+        default:
+            loggerDebug("Internal error - invalid keyword!");
         }
     }
     return NULL;
 }
 
-char *transpileHighlightInt(TranspileCtx *ctx, long integer) {
+char *transpileHighlightInt(const TranspileCtx *ctx, long integer) {
     static char buf[64];
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        snprintf(buf,sizeof(buf),ESC_WHITE"%ld"ESC_RESET,integer);
+        snprintf(buf, sizeof(buf), ESC_WHITE "%ld" ESC_RESET, integer);
     } else {
-        snprintf(buf,sizeof(buf),"%ld",integer);
+        snprintf(buf, sizeof(buf), "%ld", integer);
     }
     return buf;
 }
 
-char *transpileHighlightChar(TranspileCtx *ctx, char character) {
+char *transpileHighlightChar(const TranspileCtx *ctx, char character) {
     static char buf[64];
     ssize_t len = 0;
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        len = snprintf(buf,sizeof(buf),ESC_CYAN"'%c'"ESC_RESET,character);
+        len = snprintf(buf, sizeof(buf), ESC_CYAN "'%c'" ESC_RESET, character);
     } else {
-        len = snprintf(buf,sizeof(buf),"'%c'",character);
+        len = snprintf(buf, sizeof(buf), "'%c'", character);
     }
     buf[len] = '\0';
     return buf;
 }
 
-char *transpileHighlightStringAsCharacter(TranspileCtx *ctx, char *str) {
+char *transpileHighlightStringAsCharacter(const TranspileCtx *ctx, char *str) {
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        return mprintf(ESC_CYAN"'%s'"ESC_RESET,str);
+        return mprintf(ESC_CYAN "'%s'" ESC_RESET, str);
     } else {
-        return mprintf("'%s'",str);
+        return mprintf("'%s'", str);
     }
 }
 
-char *transpileHighlightStringAsInt(TranspileCtx *ctx, char *str) {
+char *transpileHighlightStringAsInt(const TranspileCtx *ctx, char *str) {
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        return mprintf(ESC_WHITE"%s"ESC_RESET,str);
+        return mprintf(ESC_WHITE "%s" ESC_RESET, str);
     } else {
-        return mprintf("%s",str);
+        return mprintf("%s", str);
     }
 }
 
-char *transpileHighlightString(TranspileCtx *ctx, char *str) {
+char *transpileHighlightString(const TranspileCtx *ctx, char *str) {
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        return mprintf(ESC_GREEN"\"%s\""ESC_RESET,str);
+        return mprintf(ESC_GREEN "\"%s\"" ESC_RESET, str);
     } else {
-        return mprintf("\"%s\"",str);
+        return mprintf("\"%s\"", str);
     }
 }
 
-char *transpileHighlightFloat(TranspileCtx *ctx, double floatingpoint) {
+char *transpileHighlightFloat(const TranspileCtx *ctx, double floatingpoint) {
     static char buf[64];
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        snprintf(buf,sizeof(buf),ESC_WHITE"%g"ESC_RESET,floatingpoint);
+        snprintf(buf, sizeof(buf), ESC_WHITE "%g" ESC_RESET, floatingpoint);
     } else {
-        snprintf(buf,sizeof(buf),"%g",floatingpoint);
+        snprintf(buf, sizeof(buf), "%g", floatingpoint);
     }
     return buf;
 }
@@ -426,68 +440,65 @@ char *transpileGetFunctionSub(char *name, int len) {
 }
 
 static void transpileEndStmt(aoStr *str) {
-    if (str->data[str->len-1] != '\n' && str->data[str->len-2] != ';' && str->data[str->len-2] != '}') {
-        aoStrCatLen(str,str_lit(";\n"));
+    if (str->data[str->len - 1] != '\n' && str->data[str->len - 2] != ';' &&
+        str->data[str->len - 2] != '}') {
+        aoStrCatLen(str, str_lit(";\n"));
     }
 }
 
-
-void transpileBinaryOp(TranspileCtx *ctx, aoStr *buf, char *op, Ast *ast, ssize_t *indent) {
+void transpileBinaryOp(TranspileCtx *ctx, aoStr *buf, char *op, Ast *ast,
+                       ssize_t *indent) {
     ssize_t saved_indent = *indent;
     int needs_brackets = 0;
 
     *indent = 0;
     if (ast->left && ast->left->kind == AST_DEREF) {
-        int is_bang = !strncmp(op,"!",1);
+        int is_bang = !strncmp(op, "!", 1);
         if (is_bang) {
             aoStrCatFmt(buf, "%s", op);
         }
 
-        if (ast->left) {
-            transpileAstInternal(ast->left,ctx, indent);
-        } else {
-            transpileAstInternal(ast,ctx, indent);
-        }
+        transpileAstInternal(ast->left, ctx, indent);
 
         if (!is_bang) {
             aoStrCatFmt(buf, " %s ", op);
         }
 
         if (ast->right) {
-            transpileAstInternal(ast->right,ctx, indent);
+            transpileAstInternal(ast->right, ctx, indent);
         }
     } else if (!ast->right) { // unary
         /* If the operation on the left is a binary op then we need brackets */
-        aoStrCatFmt(buf, "%s",op);
+        aoStrCatFmt(buf, "%s", op);
         if (ast->left && ast->left->right) {
             needs_brackets = 1;
             aoStrPutChar(buf, '(');
         }
-        transpileAstInternal(ast->left,ctx, indent);
+        transpileAstInternal(ast->left, ctx, indent);
         if (needs_brackets) {
             aoStrPutChar(buf, ')');
         }
     } else {
-        /* We need to add parenthesis around something like: 
+        /* We need to add parenthesis around something like:
          * ```
          * while ((var = funCall()) != NULL) {
-         *   // ... 
+         *   // ...
          * }
          * ```
          *
-         * Which is where the left hand side is an assignment and the operator 
+         * Which is where the left hand side is an assignment and the operator
          * for the binary expression is a comparison.
          * */
         if (astIsAssignment(ast->left->kind) && astIsBinCmp(ast->kind)) {
             needs_brackets = 1;
-            aoStrPutChar(buf,'(');
+            aoStrPutChar(buf, '(');
         }
 
-        transpileAstInternal(ast->left,ctx, indent);
+        transpileAstInternal(ast->left, ctx, indent);
         if (needs_brackets) {
-            aoStrPutChar(buf,')');
+            aoStrPutChar(buf, ')');
         }
-        aoStrCatFmt(buf, " %s ",op);
+        aoStrCatFmt(buf, " %s ", op);
         transpileAstInternal(ast->right, ctx, indent);
     }
     *indent = saved_indent;
@@ -498,7 +509,7 @@ aoStr *transpileLValue(Ast *ast, TranspileCtx *ctx) {
     ssize_t indent = 0;
     aoStr *saved = ctx->buf;
     transpileCtxSetBuffer(ctx, buf);
-    transpileAstInternal(ast,ctx,&indent);
+    transpileAstInternal(ast, ctx, &indent);
     transpileCtxSetBuffer(ctx, saved);
     return buf;
 }
@@ -512,48 +523,88 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     ssize_t saved_indent = 0;
     List *node;
-    aoStr *escaped;
 
-    switch(ast->kind) {
+    switch (ast->kind) {
     case AST_LITERAL: {
         switch (ast->type->kind) {
-        case AST_TYPE_VOID: break;
+        case AST_TYPE_VOID:
+            break;
         case AST_TYPE_INT: {
             aoStrCat(buf, transpileHighlightInt(ctx, ast->i64));
             break;
-        }    
-        case AST_TYPE_CHAR:  {
+        }
+        case AST_TYPE_CHAR: {
             char tmp_buf[32];
             char *tmp_ptr = tmp_buf;
             unsigned long ch = ast->i64;
             int i = 0;
             for (; i < 8; ++i) {
-                unsigned long idx = i * 8;
+                unsigned long idx = (unsigned long)i * 8;
                 char ch2 = ((unsigned long)ch) >> idx & 0xFF;
-                if ((idx > 0 && !ch2) || (ch2 < 0)) break;
+                if ((idx > 0 && !ch2) || (ch2 < 0))
+                    break;
                 switch (ch2) {
-                    case '\'': { *tmp_ptr++ = '\\'; *tmp_ptr++ = '\''; break; }
-                    case '\\': { *tmp_ptr++ = '\\'; *tmp_ptr++ = '\\'; break; }
-                    case '\0': { *tmp_ptr++ = '\\'; *tmp_ptr++ = '0'; break; }
-                    case '\b': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 'b'; break; }
-                    case '\n': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 'n'; break; }
-                    case '\t': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 't'; break; }
-                    case '\v': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 'v'; break; }
-                    case '\f': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 'f'; break; }
-                    case '\r': { *tmp_ptr++ = '\\'; *tmp_ptr++ = 'r'; break; }
-                    default: *tmp_ptr++ = ch2; break;
+                case '\'': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = '\'';
+                    break;
+                }
+                case '\\': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = '\\';
+                    break;
+                }
+                case '\0': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = '0';
+                    break;
+                }
+                case '\b': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 'b';
+                    break;
+                }
+                case '\n': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 'n';
+                    break;
+                }
+                case '\t': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 't';
+                    break;
+                }
+                case '\v': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 'v';
+                    break;
+                }
+                case '\f': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 'f';
+                    break;
+                }
+                case '\r': {
+                    *tmp_ptr++ = '\\';
+                    *tmp_ptr++ = 'r';
+                    break;
+                }
+                default:
+                    *tmp_ptr++ = ch2;
+                    break;
                 }
             }
             if (tmp_ptr - tmp_buf == 1) {
                 tmp_buf[i] = '\0';
             } else {
-                tmp_buf[i+1] = '\0';
+                tmp_buf[i + 1] = '\0';
             }
-            char *defn = transpileHighlightStringAsCharacter(ctx, tmp_buf);
-            aoStrCat(buf,defn);
+            const char *defn = transpileHighlightStringAsCharacter(ctx,
+                                                                   tmp_buf);
+            aoStrCat(buf, defn);
             break;
         }
-        
+
         case AST_TYPE_FLOAT: {
             aoStrCat(buf, transpileHighlightFloat(ctx, ast->f64));
             break;
@@ -563,11 +614,11 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         }
         break;
 
-        case AST_STRING: {
-            char *defn = transpileHighlightString(ctx,ast->sval->data);
-            aoStrCat(buf,defn);
-            break;
-        }
+    case AST_STRING: {
+        const char *defn = transpileHighlightString(ctx, ast->sval->data);
+        aoStrCat(buf, defn);
+        break;
+    }
     }
 
     case AST_COMMENT: {
@@ -577,27 +628,27 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     /* we are not defining anything ... */
     case AST_LVAR: {
-        strMapAdd(ctx->used_defines,ast->lname->data,ast->lname->data);
-        aoStrCatAoStr(buf,ast->lname);
+        strMapAdd(ctx->used_defines, ast->lname->data, ast->lname->data);
+        aoStrCatAoStr(buf, ast->lname);
         break;
-    }    
-    
+    }
+
     case AST_DECL: {
         char *name = NULL;
         if (ast->declvar->kind == AST_FUNPTR) {
             name = ast->declvar->fname->data;
         } else if (ast->declvar->kind == AST_LVAR) {
             name = ast->declvar->lname->data;
-            strMapAdd(ctx->used_defines,name,name);
+            strMapAdd(ctx->used_defines, name, name);
         } else if (ast->declvar->kind == AST_GVAR) {
             name = ast->declvar->gname->data;
         } else {
             loggerPanic("Unhandled declaration\n");
         }
 
-        aoStr *decl = transpileVarDecl(ctx, ast->declvar->type, name);
+        const aoStr *decl = transpileVarDecl(ctx, ast->declvar->type, name);
         if (ast->declvar->kind == AST_GVAR && ast->declvar->is_static) {
-            aoStrCatFmt(buf,  "%s ", transpileKeyWordHighlight(ctx,KW_STATIC));
+            aoStrCatFmt(buf, "%s ", transpileKeyWordHighlight(ctx, KW_STATIC));
         }
 
         aoStrCatAoStr(buf, decl);
@@ -605,7 +656,7 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
             aoStrCatFmt(buf, " = ");
             saved_indent = *indent;
             *indent = 0;
-            transpileAstInternal(ast->declinit,ctx,indent);
+            transpileAstInternal(ast->declinit, ctx, indent);
             *indent = saved_indent;
         }
         break;
@@ -614,7 +665,7 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
     case AST_GVAR:
         aoStrCatFmt(buf, "%S", ast->gname);
         break;
-    
+
     case AST_ASM_FUNCALL: {
         Ast *asm_stmt = strMapGet(ctx->cc->asm_functions, ast->fname->data);
         char *substitution_name = transpileGetFunctionSub(ast->fname->data,
@@ -627,8 +678,8 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
     }
 
     case AST_FUNPTR_CALL:
-        /* For when a function pointer exists on a class, interestingly 
-         * due to maintaining a reference to the class this we be trivial 
+        /* For when a function pointer exists on a class, interestingly
+         * due to maintaining a reference to the class this we be trivial
          * to create class methods */
         if (ast->ref && ast->ref->kind == AST_CLASS_REF) {
             Ast *ref = ast->ref;
@@ -665,7 +716,8 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
     }
 
     case AST_ASM_FUNC_BIND: {
-        aoStrCatFmt(buf, "// unsupported x86 function bind %S\n",ast->asmfname);
+        aoStrCatFmt(buf, "// unsupported x86 function bind %S\n",
+                    ast->asmfname);
         break;
     }
 
@@ -682,7 +734,7 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         while (node != ast->arrayinit) {
             transpileAstInternal(node->value, ctx, indent);
             if (node->next != ast->arrayinit) {
-                aoStrCatLen(buf,str_lit(", "));
+                aoStrCatLen(buf, str_lit(", "));
             }
             node = node->next;
         }
@@ -692,24 +744,24 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
     }
 
     case AST_IF: {
-        char *_if = transpileKeyWordHighlight(ctx,KW_IF);
-        char *_else = transpileKeyWordHighlight(ctx,KW_ELSE);
+        char *_if = transpileKeyWordHighlight(ctx, KW_IF);
+        char *_else = transpileKeyWordHighlight(ctx, KW_ELSE);
         aoStrCatFmt(buf, "%s (", _if);
 
         saved_indent = *indent;
         *indent = 0;
-        transpileAstInternal(ast->cond,ctx, indent);
+        transpileAstInternal(ast->cond, ctx, indent);
         *indent = saved_indent;
 
         aoStrCatFmt(buf, ") {\n");
         *indent += 4;
         if (ast->then) {
             if (ast->then->kind != AST_COMPOUND_STMT) {
-                aoStrRepeatChar(buf,' ',*indent);
+                aoStrRepeatChar(buf, ' ', *indent);
             }
-            transpileAstInternal(ast->then,ctx, indent);
+            transpileAstInternal(ast->then, ctx, indent);
             if (ast->then->kind != AST_COMPOUND_STMT) {
-                transpileEndStmt(buf); 
+                transpileEndStmt(buf);
             }
         }
         *indent -= 4;
@@ -730,12 +782,12 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
             if (els_body->kind != AST_COMPOUND_STMT) {
                 if (!has_cond) {
-                    aoStrRepeatChar(buf,' ',*indent);
+                    aoStrRepeatChar(buf, ' ', *indent);
                 }
             }
-            transpileAstInternal(els_body,ctx, indent);
+            transpileAstInternal(els_body, ctx, indent);
             if (els_body->kind != AST_COMPOUND_STMT) {
-                transpileEndStmt(buf); 
+                transpileEndStmt(buf);
             }
 
             if (!has_cond) {
@@ -744,20 +796,20 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
                 aoStrCatFmt(buf, "}\n");
             }
         } else {
-            aoStrPutChar(buf,'\n');
+            aoStrPutChar(buf, '\n');
         }
         break;
     }
 
     case AST_DO_WHILE: {
-        char *_do = transpileKeyWordHighlight(ctx,KW_DO);
-        char *_while = transpileKeyWordHighlight(ctx,KW_WHILE);
+        char *_do = transpileKeyWordHighlight(ctx, KW_DO);
+        char *_while = transpileKeyWordHighlight(ctx, KW_WHILE);
         aoStrCatFmt(buf, "%s {\n", _do);
         *indent += 4;
         if (ast->whilebody && ast->whilebody->kind != AST_COMPOUND_STMT) {
             aoStrRepeatChar(buf, ' ', *indent);
         }
-        transpileAstInternal(ast->whilebody,ctx, indent);
+        transpileAstInternal(ast->whilebody, ctx, indent);
         if (ast->whilebody && ast->whilebody->kind != AST_COMPOUND_STMT) {
             transpileEndStmt(buf);
         }
@@ -766,23 +818,23 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         aoStrRepeatChar(buf, ' ', *indent);
         aoStrCatFmt(buf, "} %s (", _while);
         *indent = 0;
-        transpileAstInternal(ast->whilecond,ctx, indent);
+        transpileAstInternal(ast->whilecond, ctx, indent);
         *indent = saved_indent;
         aoStrCatFmt(buf, ");\n");
         break;
     }
 
     case AST_WHILE: {
-        char *_while = transpileKeyWordHighlight(ctx,KW_WHILE);
-        aoStrCatFmt(buf, "%s (", _while); 
+        char *_while = transpileKeyWordHighlight(ctx, KW_WHILE);
+        aoStrCatFmt(buf, "%s (", _while);
         saved_indent = *indent;
         *indent = 0;
-        transpileAstInternal(ast->whilecond,ctx, indent);
+        transpileAstInternal(ast->whilecond, ctx, indent);
         aoStrCatFmt(buf, ")");
         *indent = saved_indent;
         *indent += 4;
         if (!ast->whilebody) {
-            aoStrPutChar(buf,'\n');
+            aoStrPutChar(buf, '\n');
             aoStrRepeatChar(buf, ' ', *indent);
             *indent -= 4;
         } else {
@@ -790,13 +842,13 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
             if (ast->whilebody->kind != AST_COMPOUND_STMT) {
                 aoStrRepeatChar(buf, ' ', *indent);
             }
-            transpileAstInternal(ast->whilebody,ctx, indent);
+            transpileAstInternal(ast->whilebody, ctx, indent);
             if (ast->whilebody->kind != AST_COMPOUND_STMT) {
                 transpileEndStmt(buf);
             }
             *indent -= 4;
-            aoStrRepeatChar(buf,' ', *indent);
-            aoStrCatFmt(buf,"}\n");
+            aoStrRepeatChar(buf, ' ', *indent);
+            aoStrCatFmt(buf, "}\n");
         }
         break;
     }
@@ -808,43 +860,43 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         saved_indent = *indent;
         if (ast->forinit) {
             *indent = 0;
-            transpileAstInternal(ast->forinit,ctx, indent);
+            transpileAstInternal(ast->forinit, ctx, indent);
             *indent = saved_indent;
         }
-        aoStrCatLen(buf,str_lit("; "));
+        aoStrCatLen(buf, str_lit("; "));
 
         if (ast->forcond) {
             *indent = 0;
-            transpileAstInternal(ast->forcond,ctx, indent);
+            transpileAstInternal(ast->forcond, ctx, indent);
             *indent = saved_indent;
         }
-        aoStrCatLen(buf,str_lit("; "));
+        aoStrCatLen(buf, str_lit("; "));
 
         if (ast->forstep) {
             *indent = 0;
-            transpileAstInternal(ast->forstep,ctx, indent);
+            transpileAstInternal(ast->forstep, ctx, indent);
             *indent = saved_indent;
         }
 
-        aoStrCatFmt(buf,") {\n");
+        aoStrCatFmt(buf, ") {\n");
         *indent += 4;
         if (ast->forbody && ast->forbody->kind != AST_COMPOUND_STMT) {
             aoStrRepeatChar(buf, ' ', *indent);
         }
-        transpileAstInternal(ast->forbody,ctx, indent);
+        transpileAstInternal(ast->forbody, ctx, indent);
         if (ast->forbody && ast->forbody->kind != AST_COMPOUND_STMT) {
             transpileEndStmt(buf);
         }
         *indent -= 4;
         aoStrRepeatChar(buf, ' ', *indent);
-        aoStrCatFmt(buf,"}\n");
+        aoStrCatFmt(buf, "}\n");
         break;
     }
 
     case AST_RETURN: {
-        char *_return = transpileKeyWordHighlight(ctx,KW_RETURN);
+        char *_return = transpileKeyWordHighlight(ctx, KW_RETURN);
         aoStrCatFmt(buf, "%s ", _return);
-        transpileAstInternal(ast->retval,ctx,indent);
+        transpileAstInternal(ast->retval, ctx, indent);
         break;
     }
 
@@ -856,7 +908,7 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         listForEach(ast->stms) {
             Ast *next = (Ast *)it->value;
             aoStrRepeatChar(buf, ' ', *indent);
-            transpileAstInternal(next,ctx, indent);
+            transpileAstInternal(next, ctx, indent);
             transpileEndStmt(buf);
         }
         break;
@@ -874,7 +926,8 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     case AST_JUMP: {
         char *label = ast->jump_label->data;
-        if (*label == '.') label++;
+        if (*label == '.')
+            label++;
         char *_goto = transpileKeyWordHighlight(ctx, KW_GOTO);
         aoStrCatFmt(buf, "%s %s;\n", _goto, label);
         break;
@@ -882,7 +935,8 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     case AST_GOTO: {
         char *label = ast->slabel->data;
-        if (*label == '.') label++;
+        if (*label == '.')
+            label++;
         char *_goto = transpileKeyWordHighlight(ctx, KW_GOTO);
         aoStrCatFmt(buf, "%s %s;\n", _goto, label);
         break;
@@ -890,17 +944,18 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     /* XXX: fix labels */
     case AST_LABEL: {
-        char *label = ast->slabel ? ast->slabel->data : ast->slabel->data;
+        char *label = ast->slabel->data;
         while (buf->data[buf->len - 1] != '\n') {
             buf->len--;
         }
-        if (*label == '.') label++;
+        if (*label == '.')
+            label++;
         aoStrCatFmt(buf, "\n%s:\n", label);
         break;
     }
 
     case AST_CAST: {
-        aoStr *type_cast = transpileVarDecl(ctx, ast->type,NULL);
+        aoStr *type_cast = transpileVarDecl(ctx, ast->type, NULL);
         aoStr *lvalue = transpileLValue(ast->operand, ctx);
         aoStrCatFmt(buf, "(%S)%S", type_cast, lvalue);
         break;
@@ -922,60 +977,64 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         for (int i = 0; i < ast->cases->size; ++i) {
             Ast *_case = ast->cases->entries[i];
             aoStrRepeatChar(buf, ' ', *indent);
-            transpileAstInternal(_case,ctx,indent);
+            transpileAstInternal(_case, ctx, indent);
         }
         ctx->flags &= ~TRANSPILE_FLAG_SWITCH_CHAR;
         if (ast->case_default) {
-            aoStrRepeatChar(buf,' ', *indent);
-            transpileAstInternal(ast->case_default,ctx,indent);
+            aoStrRepeatChar(buf, ' ', *indent);
+            transpileAstInternal(ast->case_default, ctx, indent);
         }
         *indent -= 4;
-        aoStrRepeatChar(buf,' ', *indent);
-        aoStrCatFmt(buf,"}\n");
+        aoStrRepeatChar(buf, ' ', *indent);
+        aoStrCatFmt(buf, "}\n");
         break;
     }
 
     case AST_CASE: {
-        char *_case = transpileKeyWordHighlight(ctx,KW_CASE);
+        char *_case = transpileKeyWordHighlight(ctx, KW_CASE);
         aoStrCatFmt(buf, "%s ", _case);
         if (ast->type->kind == AST_TYPE_VOID) {
-            aoStrCatFmt(buf, "%s:", transpileHighlightStringAsInt(ctx, ast->case_label->data));
+            aoStrCatFmt(buf, "%s:",
+                        transpileHighlightStringAsInt(ctx,
+                                                      ast->case_label->data));
         } else if (ctx->flags & TRANSPILE_FLAG_SWITCH_CHAR) {
             if (ast->case_begin == ast->case_end) {
-                aoStrCatFmt(buf, "%s:",transpileHighlightChar(ctx, ast->case_begin));
+                aoStrCatFmt(buf, "%s:",
+                            transpileHighlightChar(ctx, ast->case_begin));
             } else {
                 aoStrCatFmt(buf, "%s ... %s:",
-                        transpileHighlightChar(ctx,(char)ast->case_begin),
-                        transpileHighlightChar(ctx,(char)ast->case_end));
+                            transpileHighlightChar(ctx, (char)ast->case_begin),
+                            transpileHighlightChar(ctx, (char)ast->case_end));
             }
         } else {
             if (ast->case_begin == ast->case_end) {
-                aoStrCatFmt(buf, "%s:", transpileHighlightInt(ctx, ast->case_begin));
+                aoStrCatFmt(buf,
+                            "%s:", transpileHighlightInt(ctx, ast->case_begin));
             } else {
                 aoStrCatFmt(buf, "%s ... %s:",
-                        transpileHighlightInt(ctx, ast->case_begin),
-                        transpileHighlightInt(ctx, ast->case_end));
+                            transpileHighlightInt(ctx, ast->case_begin),
+                            transpileHighlightInt(ctx, ast->case_end));
             }
         }
 
         if (!listEmpty(ast->case_asts)) {
-            aoStrCatFmt(buf," {\n");
+            aoStrCatFmt(buf, " {\n");
             *indent += 4;
             listForEach(ast->case_asts) {
                 Ast *case_ast = (Ast *)it->value;
                 if (case_ast->kind != AST_COMPOUND_STMT) {
-                    aoStrRepeatChar(buf,' ', *indent);
+                    aoStrRepeatChar(buf, ' ', *indent);
                 }
-                transpileAstInternal(case_ast,ctx, indent);
+                transpileAstInternal(case_ast, ctx, indent);
                 if (case_ast->kind != AST_COMPOUND_STMT) {
                     transpileEndStmt(buf);
                 }
             }
             *indent -= 4;
-            aoStrRepeatChar(buf,' ', *indent);
-            aoStrCatFmt(buf,"}\n\n");
+            aoStrRepeatChar(buf, ' ', *indent);
+            aoStrCatFmt(buf, "}\n\n");
         } else {
-            aoStrPutChar(buf,'\n');
+            aoStrPutChar(buf, '\n');
         }
         break;
     }
@@ -986,23 +1045,23 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         if (!listEmpty(ast->case_asts)) {
             *indent += 4;
             listForEach(ast->case_asts) {
-                aoStrRepeatChar(buf,' ', *indent);
-                transpileAstInternal((Ast *)it->value,ctx,indent);
+                aoStrRepeatChar(buf, ' ', *indent);
+                transpileAstInternal((Ast *)it->value, ctx, indent);
                 transpileEndStmt(buf);
             }
             *indent -= 4;
-            aoStrRepeatChar(buf,' ', *indent);
+            aoStrRepeatChar(buf, ' ', *indent);
         }
-        aoStrCatFmt(buf,"}\n");
+        aoStrCatFmt(buf, "}\n");
         break;
     }
 
     case AST_BREAK:
-        aoStrCatFmt(buf, "%s;\n", transpileKeyWordHighlight(ctx,KW_BREAK));
+        aoStrCatFmt(buf, "%s;\n", transpileKeyWordHighlight(ctx, KW_BREAK));
         break;
 
     case AST_CONTINUE:
-        aoStrCatFmt(buf, "%s;\n", transpileKeyWordHighlight(ctx,KW_CONTINUE));
+        aoStrCatFmt(buf, "%s;\n", transpileKeyWordHighlight(ctx, KW_CONTINUE));
         break;
 
     case AST_DEFAULT_PARAM: {
@@ -1012,15 +1071,16 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     case AST_SIZEOF: {
         aoStr *type_str = transpileVarDecl(ctx, ast->type, NULL);
-        aoStrCatFmt(buf, "%s(%S)", transpileKeyWordHighlight(ctx,KW_SIZEOF), type_str);
+        aoStrCatFmt(buf, "%s(%S)", transpileKeyWordHighlight(ctx, KW_SIZEOF),
+                    type_str);
         break;
     }
 
     case TK_PLUS_PLUS:
     case TK_MINUS_MINUS: {
         char *op = lexemePunctToString(ast->kind);
-        transpileAstInternal(ast->left,ctx, indent);
-        aoStrCatFmt(buf, "%s",op);
+        transpileAstInternal(ast->left, ctx, indent);
+        aoStrCatFmt(buf, "%s", op);
         break;
     }
 
@@ -1036,23 +1096,24 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
         if (ast->operand->kind == '+') {
             Ast *left = ast->operand->left;
             Ast *right = ast->operand->right;
-            transpileAstInternal(left,ctx,indent);
+            transpileAstInternal(left, ctx, indent);
             aoStrPutChar(buf, '[');
-            transpileAstInternal(right,ctx,indent);
+            transpileAstInternal(right, ctx, indent);
             aoStrPutChar(buf, ']');
         } else {
-            /* As `->` is a dereference we need to be able to distinguish 
+            /* As `->` is a dereference we need to be able to distinguish
              * between a class dereference and a general pointer dereference */
             if (ast->deref_symbol != TK_ARROW) {
                 aoStrCatFmt(buf, "*");
             }
-            transpileAstInternal(ast->operand,ctx,indent);
+            transpileAstInternal(ast->operand, ctx, indent);
         }
         break;
     }
 
     default: {
-        transpileBinaryOp(ctx,buf,lexemePunctToString(ast->kind),ast,indent);
+        transpileBinaryOp(ctx, buf, lexemePunctToString(ast->kind), ast,
+                          indent);
         break;
     }
     }
@@ -1063,7 +1124,7 @@ aoStr *transpileAst(Ast *ast, TranspileCtx *ctx) {
     aoStr *body_buf = aoStrNew();
     aoStr *saved = ctx->buf;
     transpileCtxSetBuffer(ctx, body_buf);
-    transpileAstInternal(ast,ctx,&indent);
+    transpileAstInternal(ast, ctx, &indent);
     transpileCtxSetBuffer(ctx, saved);
     return body_buf;
 }
@@ -1073,17 +1134,16 @@ aoStr *transpileParamsList(PtrVec *params, TranspileCtx *ctx) {
     aoStr *decl = NULL;
     for (int i = 0; i < params->size; ++i) {
         Ast *param = params->entries[i];
-        aoStr *var = transpileLValue(param, ctx);
         if (param->kind == AST_DEFAULT_PARAM) {
             decl = transpileVarDecl(ctx, param->declvar->type,
-                    param->declvar->lname->data);
+                                    param->declvar->lname->data);
         } else if (param->kind == AST_FUNPTR) {
             decl = transpileVarDecl(ctx, param->type, param->fname->data);
         } else if (param->kind == AST_VAR_ARGS) {
             decl = aoStrPrintf("...");
-        } else  {
+        } else {
             decl = transpileVarDecl(ctx, param->type, param->lname->data);
-        } 
+        }
         aoStrCatFmt(buf, "%S", decl);
         if (i + 1 != params->size) {
             aoStrCatLen(buf, str_lit(", "));
@@ -1093,7 +1153,8 @@ aoStr *transpileParamsList(PtrVec *params, TranspileCtx *ctx) {
 }
 
 aoStr *transpileArgvList(PtrVec *argv, TranspileCtx *ctx) {
-    if (!argv) return NULL;
+    if (!argv)
+        return NULL;
     aoStr *buf = aoStrNew();
     for (int i = 0; i < argv->size; ++i) {
         Ast *arg = argv->entries[i];
@@ -1115,45 +1176,57 @@ typedef struct TypeInfo {
     aoStr *array_init_label;
 } TypeInfo;
 
-static void transpileTypeInternal(TranspileCtx *ctx, AstType *type, TypeInfo *info) {
+static void transpileTypeInternal(TranspileCtx *ctx, AstType *type,
+                                  TypeInfo *info) {
     switch (type->kind) {
     case AST_TYPE_VOID: {
         info->base_name = aoStrPrintf("void");
         break;
     }
-    
+
     case AST_TYPE_INT: {
-        aoStr *type_str= aoStrNew();
+        aoStr *type_str = aoStrNew();
         switch (type->size) {
-            case 0:
-                aoStrCatFmt(type_str, "void");
-                break;
-            case 1:
-                if (type->issigned) aoStrCatFmt(type_str, "char");
-                else                aoStrCatFmt(type_str, "unsigned char");
-                break;
-            case 2:
-                if (type->issigned) aoStrCatFmt(type_str, "short");
-                else                aoStrCatFmt(type_str, "unsigned short");
-                break;
-            case 4:
-                if (type->issigned) aoStrCatFmt(type_str, "int");
-                else                aoStrCatFmt(type_str, "unsigned int");
-                break;
-            case 8:
-                if (type->issigned) aoStrCatFmt(type_str, "long");
-                else                aoStrCatFmt(type_str, "unsigned long");
-                break;
-            default: loggerPanic("Unknown integer size: %d\n", type->size);
+        case 0:
+            aoStrCatFmt(type_str, "void");
+            break;
+        case 1:
+            if (type->issigned)
+                aoStrCatFmt(type_str, "char");
+            else
+                aoStrCatFmt(type_str, "unsigned char");
+            break;
+        case 2:
+            if (type->issigned)
+                aoStrCatFmt(type_str, "short");
+            else
+                aoStrCatFmt(type_str, "unsigned short");
+            break;
+        case 4:
+            if (type->issigned)
+                aoStrCatFmt(type_str, "int");
+            else
+                aoStrCatFmt(type_str, "unsigned int");
+            break;
+        case 8:
+            if (type->issigned)
+                aoStrCatFmt(type_str, "long");
+            else
+                aoStrCatFmt(type_str, "unsigned long");
+            break;
+        default:
+            loggerPanic("Unknown integer size: %d\n", type->size);
         }
         info->base_name = type_str;
         break;
     }
-    
+
     case AST_TYPE_CHAR: {
-        aoStr *type_str= aoStrNew();
-        if (type->issigned) aoStrCatFmt(type_str, "char");
-        else                aoStrCatFmt(type_str, "unsigned char");
+        aoStr *type_str = aoStrNew();
+        if (type->issigned)
+            aoStrCatFmt(type_str, "char");
+        else
+            aoStrCatFmt(type_str, "unsigned char");
         info->base_name = type_str;
         break;
     }
@@ -1164,7 +1237,7 @@ static void transpileTypeInternal(TranspileCtx *ctx, AstType *type, TypeInfo *in
 
     case AST_TYPE_POINTER: {
         info->stars++;
-        transpileTypeInternal(ctx,type->ptr,info);
+        transpileTypeInternal(ctx, type->ptr, info);
         break;
     }
 
@@ -1211,14 +1284,14 @@ static void transpileTypeInternal(TranspileCtx *ctx, AstType *type, TypeInfo *in
 aoStr *transpileVarDeclInfo(TranspileCtx *ctx, TypeInfo *info, char *name) {
     aoStr *str = aoStrNew();
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        aoStrCatFmt(str,ESC_WHITE"%S"ESC_RESET,info->base_name);
+        aoStrCatFmt(str, ESC_WHITE "%S" ESC_RESET, info->base_name);
     } else {
-        aoStrCatFmt(str, "%S",info->base_name);
+        aoStrCatFmt(str, "%S", info->base_name);
     }
-    strMapAdd(ctx->used_types,info->base_name->data,info->base_name);
+    strMapAdd(ctx->used_types, info->base_name->data, info->base_name);
 
     if (name || info->stars > 0) {
-        aoStrPutChar(str,' ');
+        aoStrPutChar(str, ' ');
     }
 
     if (info->stars) {
@@ -1230,51 +1303,50 @@ aoStr *transpileVarDeclInfo(TranspileCtx *ctx, TypeInfo *info, char *name) {
     /* a function pointer */
     if (info->params) {
         if (name) {
-            aoStrCatFmt(str, "(*%s)",name);
+            aoStrCatFmt(str, "(*%s)", name);
         }
         aoStrCatFmt(str, "(%S)", info->params);
     } else if (info->array_dimensions) {
         if (name) {
-            aoStrCatFmt(str, "%s",name);
+            aoStrCatFmt(str, "%s", name);
         }
-        aoStrCatFmt(str, "[%i]",info->array_dimensions);
+        aoStrCatFmt(str, "[%i]", info->array_dimensions);
     } else if (info->array_init_label) {
         if (name) {
-            aoStrCatFmt(str, "%s",name);
+            aoStrCatFmt(str, "%s", name);
         }
-        aoStrCatFmt(str, "[%S]",info->array_init_label);
+        aoStrCatFmt(str, "[%S]", info->array_init_label);
     } else {
         if (name) {
-            aoStrCatFmt(str, "%s",name);
+            aoStrCatFmt(str, "%s", name);
         }
     }
-    
+
     return str;
 }
-
 
 /* types cannot be parsed in isolation if you want a string */
 aoStr *transpileVarDecl(TranspileCtx *ctx, AstType *type, char *name) {
     TypeInfo info;
-    memset(&info,0,sizeof(TypeInfo));
-    transpileTypeInternal(ctx,type,&info);
-    return transpileVarDeclInfo(ctx,&info,name);
+    memset(&info, 0, sizeof(TypeInfo));
+    transpileTypeInternal(ctx, type, &info);
+    return transpileVarDeclInfo(ctx, &info, name);
 }
 
 aoStr *transpileFunctionProto(TranspileCtx *ctx, AstType *type, char *name) {
     TypeInfo info;
-    memset(&info,0,sizeof(TypeInfo));
+    memset(&info, 0, sizeof(TypeInfo));
 
-    transpileTypeInternal(ctx,type,&info);
+    transpileTypeInternal(ctx, type, &info);
     aoStr *str = aoStrNew();
     if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-        aoStrCatFmt(str,ESC_WHITE"%S"ESC_RESET,info.base_name);
+        aoStrCatFmt(str, ESC_WHITE "%S" ESC_RESET, info.base_name);
     } else {
-        aoStrCatFmt(str, "%S",info.base_name);
+        aoStrCatFmt(str, "%S", info.base_name);
     }
 
     if (info.stars) {
-        aoStrPutChar(str,' ');
+        aoStrPutChar(str, ' ');
         for (int i = 0; i < info.stars; ++i) {
             aoStrPutChar(str, '*');
         }
@@ -1283,42 +1355,38 @@ aoStr *transpileFunctionProto(TranspileCtx *ctx, AstType *type, char *name) {
 
     /* a function pointer */
     if (info.params) {
-        aoStrCatFmt(str, "%s",name);
+        aoStrCatFmt(str, "%s", name);
         if (info.params->len > 0) {
             aoStrCatFmt(str, "(%S)", info.params);
         } else {
             if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-                aoStrCatFmt(str, "("ESC_WHITE"void"ESC_RESET")");
+                aoStrCatFmt(str, "(" ESC_WHITE "void" ESC_RESET ")");
             } else {
                 aoStrCatFmt(str, "(void)");
             }
         }
     } else if (info.array_dimensions) {
-        aoStrCatFmt(str, "%s",name);
-        aoStrCatFmt(str, "[%i]",info.array_dimensions);
+        aoStrCatFmt(str, "%s", name);
+        aoStrCatFmt(str, "[%i]", info.array_dimensions);
     } else {
-        aoStrCatFmt(str, "%s",name);
+        aoStrCatFmt(str, "%s", name);
     }
-    
+
     return str;
 }
 
-static void transpileFields(TranspileCtx *ctx,
-                            StrMap *fields,
-                            StrMap *seen,
-                            char *clsname,
-                            aoStr *buf,
-                            ssize_t *indent)
-{
+static void transpileFields(TranspileCtx *ctx, StrMap *fields, StrMap *seen,
+                            char *clsname, aoStr *buf, ssize_t *indent) {
     StrMapIterator *it = strMapIteratorNew(fields);
     StrMapNode *n = NULL;
     while ((n = strMapNext(it)) != NULL) {
         AstType *field = n->value;
-        /* When transpiling we save the nested flattened class properties on the 
-         * class AND in a separate struct, however when parsing we save the struct 
-         * first so this check ensures we do not double up. It's not _really_ 
-         * needed but makes the code symantically similar */
-        if (strMapGetLen(seen,n->key,n->key_len) != NULL) continue;
+        /* When transpiling we save the nested flattened class properties on the
+         * class AND in a separate struct, however when parsing we save the
+         * struct first so this check ensures we do not double up. It's not
+         * _really_ needed but makes the code symantically similar */
+        if (strMapGetLen(seen, n->key, n->key_len) != NULL)
+            continue;
 
         aoStrCatRepeat(buf, " ", *indent);
         if (!strncmp(n->key, str_lit("cls_label "))) {
@@ -1328,20 +1396,20 @@ static void transpileFields(TranspileCtx *ctx,
                 aoStrCatFmt(buf, "struct {\n");
             }
             *indent += 4;
-            transpileFields(ctx,field->fields,seen,clsname,buf,indent);
+            transpileFields(ctx, field->fields, seen, clsname, buf, indent);
             *indent -= 4;
             aoStrCatRepeat(buf, " ", *indent);
             aoStrCatLen(buf, str_lit("};\n"));
         } else {
             TypeInfo info;
-            memset(&info,0,sizeof(TypeInfo));
-            transpileTypeInternal(ctx,field,&info);
-            aoStr *decl = transpileVarDeclInfo(ctx,&info,n->key);
+            memset(&info, 0, sizeof(TypeInfo));
+            transpileTypeInternal(ctx, field, &info);
+            aoStr *decl = transpileVarDeclInfo(ctx, &info, n->key);
 
-            if (!strncmp(clsname,info.base_name->data,info.base_name->len)) {
-                aoStrCatFmt(buf,"struct %S;\n", decl);
+            if (!strncmp(clsname, info.base_name->data, info.base_name->len)) {
+                aoStrCatFmt(buf, "struct %S;\n", decl);
             } else {
-                aoStrCatFmt(buf,"%S;\n", decl);
+                aoStrCatFmt(buf, "%S;\n", decl);
             }
         }
         strMapAdd(seen, n->key, n->value);
@@ -1349,7 +1417,8 @@ static void transpileFields(TranspileCtx *ctx,
     strMapIteratorRelease(it);
 }
 
-void transpileClassDefinitions(Cctrl *cc, TranspileCtx *ctx, StrMap *built_in_types) {
+void transpileClassDefinitions(const Cctrl *cc, TranspileCtx *ctx,
+                               const StrMap *built_in_types) {
     StrMapIterator *it = strMapIteratorNew(cc->clsdefs);
     StrMapNode *n = NULL;
     aoStr *buf = ctx->buf;
@@ -1360,9 +1429,9 @@ void transpileClassDefinitions(Cctrl *cc, TranspileCtx *ctx, StrMap *built_in_ty
         if (!transpileCtxShouldEmitType(ctx, n->key, n->key_len)) {
             continue;
         }
-        
-        if (strMapGetLen(built_in_types,n->key,n->key_len)) {
-            if (!strMapGetLen(ctx->used_types, n->key,n->key_len)) {
+
+        if (strMapGetLen(built_in_types, n->key, n->key_len)) {
+            if (!strMapGetLen(ctx->used_types, n->key, n->key_len)) {
                 continue;
             }
         }
@@ -1370,11 +1439,11 @@ void transpileClassDefinitions(Cctrl *cc, TranspileCtx *ctx, StrMap *built_in_ty
         AstType *cls = n->value;
         /* Line numbers on an AST would be great... */
         if (cls->kind != AST_TYPE_CLASS) {
-            loggerPanic("Should not be here\n"); 
+            loggerPanic("Should not be here\n");
         }
 
         aoStrCatFmt(buf, "typedef struct %s {\n", n->key);
-        transpileFields(ctx,cls->fields,seen,n->key,buf,&indent);
+        transpileFields(ctx, cls->fields, seen, n->key, buf, &indent);
         aoStrCatFmt(buf, "} %s;\n\n", n->key);
     }
     strMapIteratorRelease(it);
@@ -1395,11 +1464,11 @@ void transpileUnionDefinitions(Cctrl *cc, TranspileCtx *ctx) {
         AstType *cls = n->value;
         /* Line numbers on an AST would be great... */
         if (cls->kind != AST_TYPE_UNION) {
-            loggerPanic("Should not be here\n"); 
+            loggerPanic("Should not be here\n");
         }
 
         aoStrCatFmt(buf, "typedef union %s {\n", n->key);
-        transpileFields(ctx,cls->fields,seen,n->key,buf,&indent);
+        transpileFields(ctx, cls->fields, seen, n->key, buf, &indent);
         aoStrCatFmt(buf, "} %s;\n\n", n->key);
     }
     strMapIteratorRelease(it);
@@ -1417,23 +1486,38 @@ void transpileDefines(Cctrl *cc, TranspileCtx *ctx) {
         }
 
         if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-            aoStrCatFmt(buf,ESC_WHITE"#define %s "ESC_RESET,n->key);
+            aoStrCatFmt(buf, ESC_WHITE "#define %s " ESC_RESET, n->key);
             switch (tok->tk_type) {
-                case TK_I64: aoStrCatFmt(buf, ESC_PURPLE"%I\n"ESC_RESET,tok->i64); break;
-                case TK_F64: aoStrCatFmt(buf, ESC_PURPLE"%f\n"ESC_RESET,tok->f64); break;
-                case TK_STR: aoStrCatFmt(buf, ESC_GREEN"\"%s\"\n"ESC_RESET,tok->start); break;
-                default:     aoStrCatFmt(buf, "\n"); break;
+            case TK_I64:
+                aoStrCatFmt(buf, ESC_PURPLE "%I\n" ESC_RESET, tok->i64);
+                break;
+            case TK_F64:
+                aoStrCatFmt(buf, ESC_PURPLE "%f\n" ESC_RESET, tok->f64);
+                break;
+            case TK_STR:
+                aoStrCatFmt(buf, ESC_GREEN "\"%s\"\n" ESC_RESET, tok->start);
+                break;
+            default:
+                aoStrCatFmt(buf, "\n");
+                break;
             }
         } else {
-            aoStrCatFmt(buf,"#define %s ",n->key);
+            aoStrCatFmt(buf, "#define %s ", n->key);
             switch (tok->tk_type) {
-                case TK_I64: aoStrCatFmt(buf, "%I\n",tok->i64); break;
-                case TK_F64: aoStrCatFmt(buf, "%f\n",tok->f64); break;
-                case TK_STR: aoStrCatFmt(buf, "\"%s\"\n",tok->start); break;
-                default:     aoStrCatFmt(buf, "\n"); break;
+            case TK_I64:
+                aoStrCatFmt(buf, "%I\n", tok->i64);
+                break;
+            case TK_F64:
+                aoStrCatFmt(buf, "%f\n", tok->f64);
+                break;
+            case TK_STR:
+                aoStrCatFmt(buf, "\"%s\"\n", tok->start);
+                break;
+            default:
+                aoStrCatFmt(buf, "\n");
+                break;
             }
         }
-
     }
     strMapIteratorRelease(it);
 }
@@ -1442,12 +1526,12 @@ aoStr *transpileFunction(Ast *fn, TranspileCtx *ctx) {
     aoStr *function = aoStrNew();
     aoStr *fn_proto = NULL;
     aoStr *fname = transpileFormatFunction(fn->fname);
-    if (fname->len == 4 && !memcmp(fname->data,"main",4)) {
+    if (fname->len == 4 && !memcmp(fname->data, "main", 4)) {
         AstType *c_main_type = astMakeFunctionType(ast_i32_type,
-                fn->type->params);
-        fn_proto = transpileFunctionProto(ctx, c_main_type,"main");
+                                                   fn->type->params);
+        fn_proto = transpileFunctionProto(ctx, c_main_type, "main");
     } else {
-        fn_proto = transpileFunctionProto(ctx, fn->type,fname->data);
+        fn_proto = transpileFunctionProto(ctx, fn->type, fname->data);
     }
 
     /* Parse out the function body */
@@ -1455,52 +1539,58 @@ aoStr *transpileFunction(Ast *fn, TranspileCtx *ctx) {
 
     /* Add inline modifier if the function is inline */
     if (fn->flags & AST_FLAG_INLINE) {
-        aoStrCatFmt(function, "%s ",
-                       transpileKeyWordHighlight(ctx,KW_INLINE));
+        aoStrCatFmt(function, "%s ", transpileKeyWordHighlight(ctx, KW_INLINE));
     }
 
-    aoStrCatFmt(function, "%S\n{\n%S}",fn_proto, body);
+    aoStrCatFmt(function, "%S\n{\n%S}", fn_proto, body);
     return function;
 }
 
-/* Format the assembly to remove the tabs, leading whitespace and make calls 
+/* Format the assembly to remove the tabs, leading whitespace and make calls
  * to the c function wrappers rather than the original assmebly */
-char *transpileFormatAsmLine(Cctrl *cc, char *line) {
+char *transpileFormatAsmLine(const Cctrl *cc, char *line) {
     static char buffer[128];
     static char tmp_fname[128];
-    char *tmp_fname_ptr;
     char *tmp_ptr = buffer;
     int first_space = 1;
     ssize_t len = 0;
 
     while (*line) {
         /* Swap out the assembly names for c function names */
-        if (!strncmp(line,str_lit("syscall"))) {
-            len = snprintf(buffer,sizeof(buffer),"syscall");
-            tmp_ptr = buffer+len;
+        if (!strncmp(line, str_lit("syscall"))) {
+            len = snprintf(buffer, sizeof(buffer), "syscall");
+            tmp_ptr = buffer + len;
             break;
-        } else if (!strncmp(line, str_lit("call"))) {
-            while (!isspace(*line)) line++;
-            while (isspace(*line)) line++;
-            tmp_fname_ptr = tmp_fname;
-            while (*line != '\0') *tmp_fname_ptr++ = *line++;
+        }
+
+        if (!strncmp(line, str_lit("call"))) {
+            while (!isspace(*line))
+                line++;
+            while (isspace(*line))
+                line++;
+            char *tmp_fname_ptr = tmp_fname;
+            while (*line != '\0')
+                *tmp_fname_ptr++ = *line++;
             *tmp_fname_ptr = '\0';
 
-            /* If we have a HC function name use that rather than the raw 
+            /* If we have a HC function name use that rather than the raw
              * assembly function name */
-            Ast *maybe_asm_fn = strMapGet(cc->asm_functions, tmp_fname);
+            const Ast *maybe_asm_fn = strMapGet(cc->asm_functions, tmp_fname);
             if (maybe_asm_fn) {
-                aoStr *name = astNormaliseFunctionName(maybe_asm_fn->fname->data);
-                len = snprintf(buffer,sizeof(buffer),"call %s", name->data);
+                const aoStr *name = astNormaliseFunctionName(
+                        maybe_asm_fn->fname->data);
+                len = snprintf(buffer, sizeof(buffer), "call %s", name->data);
             } else {
-                /* Otherwise we are probably not looking at a call to an 
+                /* Otherwise we are probably not looking at a call to an
                  * assembly routine */
-                len = snprintf(buffer,sizeof(buffer),"call %s", tmp_fname);
+                len = snprintf(buffer, sizeof(buffer), "call %s", tmp_fname);
             }
             /* make tmp_ptr point to the end of the buffer and break the loop */
-            tmp_ptr = buffer+len;
+            tmp_ptr = buffer + len;
             break;
-        } else if (!isspace(*line)) {
+        }
+
+        if (!isspace(*line)) {
             if (*line == '%') {
                 /* It needs %% to be valid */
                 *tmp_ptr++ = '%';
@@ -1519,22 +1609,24 @@ char *transpileFormatAsmLine(Cctrl *cc, char *line) {
 }
 
 /* This is a best effort! */
-aoStr *transpileAsmFunction(Cctrl *cc, Ast *asmfn, Ast *asm_stmt, TranspileCtx *ctx) {
-    static char c_regs[] = {'D', 'S', 'd', 'c', 'b', 'a'};
+aoStr *transpileAsmFunction(const Cctrl *cc, const Ast *asmfn,
+                            const Ast *asm_stmt, TranspileCtx *ctx) {
+    static const char c_regs[] = {'D', 'S', 'd', 'c', 'b', 'a'};
     int is_void = asmfn->type->rettype->kind == AST_TYPE_VOID;
     AstType *retval_type = is_void ? ast_int_type : asmfn->type->rettype;
 
-    aoStr *fn_proto = transpileFunctionProto(ctx, asmfn->type,asmfn->fname->data);
+    aoStr *fn_proto = transpileFunctionProto(ctx, asmfn->type,
+                                             asmfn->fname->data);
     aoStr *var_type = transpileVarDecl(ctx, retval_type, "retval");
 
-    aoStr *assembly = asm_stmt->body->asm_stmt;
+    const aoStr *assembly = asm_stmt->body->asm_stmt;
 
     int line_count = 0;
-    aoStr **lines = aoStrSplit(assembly->data,'\n',&line_count);
+    aoStr **lines = aoStrSplit(assembly->data, '\n', &line_count);
     aoStr *c_asm_blk = aoStrNew();
     int indent = 4;
 
-    /* Initial function preamble: 
+    /* Initial function preamble:
      *
      * <type>
      * <ident(<args ...>)
@@ -1543,13 +1635,14 @@ aoStr *transpileAsmFunction(Cctrl *cc, Ast *asmfn, Ast *asm_stmt, TranspileCtx *
      *     __asm__ volatile (\n
      * */
     aoStrCatFmt(c_asm_blk, "%S\n{\n", fn_proto);
-    aoStrRepeatChar(c_asm_blk,' ', indent);
+    aoStrRepeatChar(c_asm_blk, ' ', indent);
     aoStrCatFmt(c_asm_blk, "%S;\n", var_type);
-    aoStrRepeatChar(c_asm_blk,' ', indent);
-    aoStrCatFmt(c_asm_blk, "__asm__ %s (\n", transpileKeyWordHighlight(ctx,KW_VOLATILE));
+    aoStrRepeatChar(c_asm_blk, ' ', indent);
+    aoStrCatFmt(c_asm_blk, "__asm__ %s (\n",
+                transpileKeyWordHighlight(ctx, KW_VOLATILE));
 
     indent += 4;
-    /* we need to remove `pushq %rbp\n movq %rsp, %rbp` as the function we are 
+    /* we need to remove `pushq %rbp\n movq %rsp, %rbp` as the function we are
      * wrapping this in will do that */
     for (int i = 0; i < line_count; ++i) {
         aoStr *line = lines[i];
@@ -1559,77 +1652,92 @@ aoStr *transpileAsmFunction(Cctrl *cc, Ast *asmfn, Ast *asm_stmt, TranspileCtx *
         }
         /* Check the first line for push<ch> %rbp */
         if (i == 0) {
-            if (!strncmp(ptr,str_lit("push"))) {
-                while (!isspace(*ptr)) ptr++;
-                while (isspace(*ptr)) ptr++;
-                if (!strncmp(ptr,str_lit("%rbp"))) continue;
+            if (!strncmp(ptr, str_lit("push"))) {
+                while (!isspace(*ptr))
+                    ptr++;
+                while (isspace(*ptr))
+                    ptr++;
+                if (!strncmp(ptr, str_lit("%rbp")))
+                    continue;
             }
         } else if (i == 1) {
             /* Check the first line for mov<ch> %rsp, %rbp */
-            if (!strncmp(ptr,str_lit("mov"))) {
-                while (!isspace(*ptr)) ptr++;
-                while (isspace(*ptr)) ptr++;
-                if (!strncmp(ptr,str_lit("%rsp"))) {
-                    while (*ptr != ',') ptr++;
+            if (!strncmp(ptr, str_lit("mov"))) {
+                while (!isspace(*ptr))
                     ptr++;
-                    while (isspace(*ptr)) ptr++;
-                    if (!strncmp(ptr,str_lit("%rbp"))) continue;
+                while (isspace(*ptr))
+                    ptr++;
+                if (!strncmp(ptr, str_lit("%rsp"))) {
+                    while (*ptr != ',')
+                        ptr++;
+                    ptr++;
+                    while (isspace(*ptr))
+                        ptr++;
+                    if (!strncmp(ptr, str_lit("%rbp")))
+                        continue;
                 }
             }
         }
-        if (!*ptr) continue;
-        aoStrRepeatChar(c_asm_blk,' ', indent);
-        aoStrCatFmt(c_asm_blk, "\"%s\\n\\t\"\n",transpileFormatAsmLine(cc, ptr));
+        if (!*ptr)
+            continue;
+        aoStrRepeatChar(c_asm_blk, ' ', indent);
+        aoStrCatFmt(c_asm_blk, "\"%s\\n\\t\"\n",
+                    transpileFormatAsmLine(cc, ptr));
     }
 
     /* Prepare the registers needed for the function */
-    aoStrRepeatChar(c_asm_blk,' ', indent);
+    aoStrRepeatChar(c_asm_blk, ' ', indent);
     aoStrCatFmt(c_asm_blk, ": \"=a\"(retval)\n");
     int params_count = asmfn->params->size;
     if (params_count) {
-        aoStrRepeatChar(c_asm_blk,' ', indent);
+        aoStrRepeatChar(c_asm_blk, ' ', indent);
         aoStrCat(c_asm_blk, ": ");
 
         for (int i = 0; i < params_count; i++) {
-            Ast *ast_param = asmfn->params->entries[i];
-            char reg = c_regs[i];
-            char *param = astLValueToString(ast_param,0);
-            aoStrCatFmt(c_asm_blk, "\"%c\"(%s)",reg,param);
+            const Ast *ast_param = asmfn->params->entries[i];
+            const char reg = c_regs[i];
+            char *param = astLValueToString(ast_param, 0);
+            aoStrCatFmt(c_asm_blk, "\"%c\"(%s)", reg, param);
             if (i + 1 != params_count) {
                 aoStrCat(c_asm_blk, ", ");
             }
         }
-        aoStrPutChar(c_asm_blk,'\n');
+        aoStrPutChar(c_asm_blk, '\n');
     }
     indent -= 4;
-    aoStrRepeatChar(c_asm_blk,' ', indent);
+    aoStrRepeatChar(c_asm_blk, ' ', indent);
     aoStrCatLen(c_asm_blk, str_lit(");"));
     if (!is_void) {
         aoStrPutChar(c_asm_blk, '\n');
-        aoStrRepeatChar(c_asm_blk,' ', indent);
-        aoStrCatFmt(c_asm_blk, "%s retval;", transpileKeyWordHighlight(ctx,KW_RETURN));
+        aoStrRepeatChar(c_asm_blk, ' ', indent);
+        aoStrCatFmt(c_asm_blk, "%s retval;",
+                    transpileKeyWordHighlight(ctx, KW_RETURN));
     }
     aoStrCat(c_asm_blk, "\n}");
 
     return c_asm_blk;
 }
 
-void transpileAstList(Cctrl *cc, TranspileCtx *ctx) {
+void transpileAstList(const Cctrl *cc, TranspileCtx *ctx) {
     StrMap *seen = strMapNew(32);
     listForEach(cc->ast_list) {
         Ast *ast = (Ast *)it->value;
         if (ast->kind == AST_FUNC) {
-            if (strMapGet(seen, ast->fname->data) != NULL) continue;
-            aoStr *c_function = transpileFunction(ast, ctx);
-            aoStrCatAoStr(ctx->buf,c_function);
+            if (strMapGet(seen, ast->fname->data) != NULL)
+                continue;
+            const aoStr *c_function = transpileFunction(ast, ctx);
+            aoStrCatAoStr(ctx->buf, c_function);
             aoStrRepeatChar(ctx->buf, '\n', 2);
             strMapAdd(seen, ast->fname->data, ast);
         } else if (ast->kind == AST_ASM_FUNC_BIND) {
-            Ast *asm_stmt = strMapGet(cc->asm_functions, ast->asmfname->data);
+            const Ast *asm_stmt = strMapGet(cc->asm_functions,
+                                            ast->asmfname->data);
             if (asm_stmt) {
-                if (strMapGet(seen, ast->asmfname->data) != NULL) continue;
-                aoStr *asm_func = transpileAsmFunction(cc, ast, asm_stmt, ctx);
-                aoStrCatAoStr(ctx->buf,asm_func);
+                if (strMapGet(seen, ast->asmfname->data) != NULL)
+                    continue;
+                const aoStr *asm_func = transpileAsmFunction(cc, ast, asm_stmt,
+                                                             ctx);
+                aoStrCatAoStr(ctx->buf, asm_func);
                 aoStrRepeatChar(ctx->buf, '\n', 2);
                 strMapAdd(seen, ast->asmfname->data, ast);
             }
@@ -1640,15 +1748,16 @@ void transpileAstList(Cctrl *cc, TranspileCtx *ctx) {
     }
 }
 
-aoStr *transpileIncludes(TranspileCtx *ctx) {
+aoStr *transpileIncludes(const TranspileCtx *ctx) {
     ssize_t len = static_size(transpile_used_c_headers);
     aoStr *buf = aoStrNew();
     for (ssize_t i = 0; i < len; ++i) {
         if (ctx->flags & TRANSPILE_FLAG_ISATTY) {
-            aoStrCatFmt(buf,ESC_GREEN"#include"ESC_RESET);
-            aoStrCatFmt(buf,ESC_RED" <%s>\n"ESC_RESET,transpile_used_c_headers[i]);
+            aoStrCatFmt(buf, ESC_GREEN "#include" ESC_RESET);
+            aoStrCatFmt(buf, ESC_RED " <%s>\n" ESC_RESET,
+                        transpile_used_c_headers[i]);
         } else {
-            aoStrCatFmt(buf,"#include <%s>\n",transpile_used_c_headers[i]);
+            aoStrCatFmt(buf, "#include <%s>\n", transpile_used_c_headers[i]);
         }
     }
     return buf;
@@ -1657,39 +1766,40 @@ aoStr *transpileIncludes(TranspileCtx *ctx) {
 aoStr *transpileToC(Cctrl *cc, CliArgs *args) {
     TranspileCtx *ctx = transpileCtxNew(cc);
     transpileInitMaps();
-    
-    cc->flags |= (CCTRL_SAVE_ANONYMOUS|CCTRL_PASTE_DEFINES|CCTRL_PRESERVE_SIZEOF|CCTRL_TRANSPILING);
+
+    cc->flags |= (CCTRL_SAVE_ANONYMOUS | CCTRL_PASTE_DEFINES |
+                  CCTRL_PRESERVE_SIZEOF | CCTRL_TRANSPILING);
     StrMap *built_in_types = strMapNew(32);
     StrMap *clsdefs = cc->clsdefs;
 
     aoStr *builtin_path = aoStrPrintf("%s/include/tos.HH", args->install_dir);
-    char *root = mprintf("%s/include",args->install_dir);
+    char *root = mprintf("%s/include", args->install_dir);
 
     Lexer *l = (Lexer *)globalArenaAllocate(sizeof(Lexer));
     l->lineno = 1;
-    
-    lexInit(l,NULL,(CCF_PRE_PROC));
-    lexSetBuiltinRoot(l,root);
-    lexPushFile(l,builtin_path);
 
-    cctrlInitParse(cc,l);
+    lexInit(l, NULL, (CCF_PRE_PROC));
+    lexSetBuiltinRoot(l, root);
+    lexPushFile(l, builtin_path);
+
+    cctrlInitParse(cc, l);
     // we are parsing the built in types
     cc->clsdefs = built_in_types;
     parseToAst(cc);
 
-    lexPushFile(l,aoStrDupRaw(args->infile,strlen(args->infile)));
-    cctrlInitParse(cc,l);
+    lexPushFile(l, aoStrDupRaw(args->infile, strlen(args->infile)));
+    cctrlInitParse(cc, l);
     cc->clsdefs = clsdefs;
     strMapMerge(clsdefs, built_in_types);
     parseToAst(cc);
     lexReleaseAllFiles(l);
-    listRelease(l->files,NULL);
+    listRelease(l->files, NULL);
 
     aoStr *include_buf = transpileIncludes(ctx);
 
     aoStr *ast_buf = aoStrNew();
     transpileCtxSetBuffer(ctx, ast_buf);
-    transpileAstList(cc,ctx);
+    transpileAstList(cc, ctx);
 
     aoStr *define_buf = aoStrNew();
     transpileCtxSetBuffer(ctx, define_buf);
@@ -1697,28 +1807,24 @@ aoStr *transpileToC(Cctrl *cc, CliArgs *args) {
 
     aoStr *class_buf = aoStrNew();
     transpileCtxSetBuffer(ctx, class_buf);
-    transpileClassDefinitions(cc,ctx, built_in_types);
+    transpileClassDefinitions(cc, ctx, built_in_types);
 
     aoStr *union_buf = aoStrNew();
     transpileCtxSetBuffer(ctx, union_buf);
-    transpileUnionDefinitions(cc,ctx);
+    transpileUnionDefinitions(cc, ctx);
 
     aoStr *buffers[] = {
-        include_buf,
-        define_buf,
-        class_buf,
-        union_buf,
-        ast_buf,
+            include_buf, define_buf, class_buf, union_buf, ast_buf,
     };
 
-    aoStr *code = aoStrAlloc(ast_buf->len + define_buf->len +
-                             class_buf->len + union_buf->len);
+    aoStr *code = aoStrAlloc(ast_buf->len + define_buf->len + class_buf->len +
+                             union_buf->len);
 
     ssize_t len = static_size(buffers);
     for (ssize_t i = 0; i < len; ++i) {
-        aoStr *buf = buffers[i];
+        const aoStr *buf = buffers[i];
         if (buf->len > 0) {
-            aoStrCatAoStr(code,buf);
+            aoStrCatAoStr(code, buf);
             aoStrPutChar(code, '\n');
             aoStrRelease(buf);
         }

--- a/src/transpiler.h
+++ b/src/transpiler.h
@@ -1,8 +1,8 @@
 #ifndef TRANSPILER_H
 #define TRANSPILER_H
 
-#include "cli.h"
 #include "cctrl.h"
+#include "cli.h"
 
 aoStr *transpileToC(Cctrl *cc, CliArgs *args);
 

--- a/src/util.h
+++ b/src/util.h
@@ -4,27 +4,27 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#define static_size(x) (sizeof((x)) / sizeof((x[0])))
+#define static_size(x)    (sizeof((x)) / sizeof((x[0])))
 #define cast(type, value) (((type)(value)))
-#define str_lit(s) s,sizeof(s)-1
+#define str_lit(s)        s, sizeof(s) - 1
 
-#define ESC_GREEN  "\033[0;32m"
-#define ESC_BLACK  "\033[0;30m"
-#define ESC_RED    "\033[0;31m"
-#define ESC_BOLD_RED "\033[1;91m"
-#define ESC_GREEN  "\033[0;32m"
-#define ESC_YELLOW "\033[0;33m"
+#define ESC_GREEN       "\033[0;32m"
+#define ESC_BLACK       "\033[0;30m"
+#define ESC_RED         "\033[0;31m"
+#define ESC_BOLD_RED    "\033[1;91m"
+#define ESC_GREEN       "\033[0;32m"
+#define ESC_YELLOW      "\033[0;33m"
 #define ESC_BOLD_YELLOW "\033[1;33m"
-#define ESC_BLUE   "\033[0;34m"
-#define ESC_PURPLE "\x1b[38;5;171m"
-#define ESC_CYAN   "\033[0;36m"
+#define ESC_BLUE        "\033[0;34m"
+#define ESC_PURPLE      "\x1b[38;5;171m"
+#define ESC_CYAN        "\033[0;36m"
 #define ESC_BOLD_CYAN   "\033[1;36m"
-#define ESC_WHITE  "\033[0;37m"
-#define ESC_RESET  "\033[0m"
-#define ESC_BOLD   "\x1b[1m"
-#define ESC_CLEAR_BOLD "\x1b[0m"
+#define ESC_WHITE       "\033[0;37m"
+#define ESC_RESET       "\033[0m"
+#define ESC_BOLD        "\x1b[1m"
+#define ESC_CLEAR_BOLD  "\x1b[0m"
 
-#define min(x,y) (((x) < (y) ? (x) : (y)))
+#define min(x, y) (((x) < (y) ? (x) : (y)))
 
 extern int is_terminal;
 
@@ -67,6 +67,5 @@ extern int is_terminal;
     } while (0)
 
 #endif
-
 
 #endif // !UTIL_H

--- a/src/x86.c
+++ b/src/x86.c
@@ -16,7 +16,7 @@
 #include "util.h"
 #include "version.h"
 
-#define VAR_ARG_MAX 20
+#define VAR_ARG_MAX            20
 #define ASM_INORDER_ARITHMETIC 0
 #define ASM_REVERSE_ARITHMETIC 1
 
@@ -28,14 +28,15 @@
  * Fifth Argument: %r8
  * Sixth Argument: %r9
  */
-static char *REGISTERS[] = {"rdi", "rsi", "rdx", "rcx",
-    "r8", "r9", "r10", "r11", "r12", "r13", "r14", "r15"};
+static char *REGISTERS[] = {"rdi", "rsi", "rdx", "rcx", "r8",  "r9",
+                            "r10", "r11", "r12", "r13", "r14", "r15"};
 /**
  * the first 8 are function args
  */
-static char *FLOAT_REGISTERS[] = {"xmm0", "xmm1", "xmm2", "xmm3",
-    "xmm4", "xmm5", "xmm6", "xmm7", "xmm8", "xmm9", "xmm10", "xmm11",
-    "xmm12", "xmm13", "xmm14", "xmm15"};
+static char *FLOAT_REGISTERS[] = {"xmm0",  "xmm1",  "xmm2",  "xmm3",
+                                  "xmm4",  "xmm5",  "xmm6",  "xmm7",
+                                  "xmm8",  "xmm9",  "xmm10", "xmm11",
+                                  "xmm12", "xmm13", "xmm14", "xmm15"};
 
 static int stack_pointer = 0;
 static int has_initialisers = 0;
@@ -54,7 +55,8 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast);
     gvar->is_static ? gvar->glabel->data : gvar->gname->data
 
 uint64_t ieee754(double _f64) {
-    if (_f64 == 0.0) return 0;  // Handle zero value explicitly
+    if (_f64 == 0.0)
+        return 0; // Handle zero value explicitly
 
     // Calculate exponent and adjust fraction
     long double base2_exp = floorl(log2l(fabs(_f64)));
@@ -62,13 +64,13 @@ uint64_t ieee754(double _f64) {
 
     // Initialize fraction and calculate it bit by bit
     uint64_t fraction = 0;
-    long double digit = 0.5;  // Start with 1/2
+    long double digit = 0.5; // Start with 1/2
     for (long i = 0; i != 53; i++) {
         if (exponet2_removed >= digit) {
             exponet2_removed -= digit;
             fraction |= 1ULL << (52 - i);
         }
-        digit *= 0.5;  // Move to the next digit (1/4, 1/8, ...)
+        digit *= 0.5; // Move to the next digit (1/4, 1/8, ...)
     }
 
     // Calculate exponent representation
@@ -78,9 +80,8 @@ uint64_t ieee754(double _f64) {
     uint64_t sign = (_f64 < 0.0) ? 1 : 0;
 
     // Assemble the IEEE 754 representation
-    return (sign << 63) |
-           ((exponent & 0x7FF) << 52) |
-           (fraction & ~(1ULL << 52));
+    return (sign << 63) | ((exponent & 0x7FF) << 52) |
+            (fraction & ~(1ULL << 52));
 }
 
 /* This is a hacky, but seemingly functional way of me being able
@@ -89,7 +90,7 @@ char *asmNormaliseFunctionName(char *fname) {
     aoStr *newfn = astNormaliseFunctionName(fname);
     if (!strncasecmp(fname, "Main", 4)) {
         if (has_initialisers) {
-            aoStrCatPrintf(newfn,"Fn");
+            aoStrCatPrintf(newfn, "Fn");
         } else {
             aoStrToLowerCase(newfn);
         }
@@ -98,104 +99,130 @@ char *asmNormaliseFunctionName(char *fname) {
 }
 
 void asmRemovePreviousTab(aoStr *buf) {
-    if (buf->data[buf->len-1] == '\t') {
+    if (buf->data[buf->len - 1] == '\t') {
         buf->len--;
     }
 }
 
-char *asmGetMov(AstType *type) {
+char *asmGetMov(const AstType *type) {
     if (type->kind == AST_TYPE_CLASS && type->is_intrinsic) {
         return "movq";
     }
     switch (type->size) {
-        case 1: return "movb";
-        case 2: return "movw";
-        case 4: return "movl";
-        case 8: return "movq";
-        default:
-            loggerPanic("Unsupported size: %d\n",type->size);
+    case 1:
+        return "movb";
+    case 2:
+        return "movw";
+    case 4:
+        return "movl";
+    case 8:
+        return "movq";
+    default:
+        loggerPanic("Unsupported size: %d\n", type->size);
     }
 }
 
-char *asmGetMovWithSign(AstType *type) {
+char *asmGetMovWithSign(const AstType *type) {
     if (type->kind == AST_TYPE_CLASS && type->is_intrinsic) {
         return "movq";
     }
     switch (type->size) {
-        case 1: 
-            if (type->issigned) return "movsb";
-            else                return "movzb";
-        case 2:
-            if (type->issigned) return "movswl";
-            else                return "movzwl";
-        case 4:
-            if (type->issigned) return "movsl";
-            else                return "mov";
-        case 8: return "movq";
-        default:
-            loggerPanic("Unsupported size: %d\n",type->size);
+    case 1:
+        if (type->issigned)
+            return "movsb";
+        else
+            return "movzb";
+    case 2:
+        if (type->issigned)
+            return "movswl";
+        else
+            return "movzwl";
+    case 4:
+        if (type->issigned)
+            return "movsl";
+        else
+            return "mov";
+    case 8:
+        return "movq";
+    default:
+        loggerPanic("Unsupported size: %d\n", type->size);
     }
 }
 
-char *asmGetPtrMove(AstType *type) {
+char *asmGetPtrMove(const AstType *type) {
     switch (type->kind) {
-        case AST_TYPE_ARRAY: return "leaq";
-        default:             return "mov";
+    case AST_TYPE_ARRAY:
+        return "leaq";
+    default:
+        return "mov";
     }
 }
 
 char *asmGetLoadReg(AstType *type, char ch) {
     (void)type;
-    if (ch == 'a') return "rax";
-    else           return "rcx";
+    if (ch == 'a')
+        return "rax";
+    else
+        return "rcx";
 }
 
-char *asmGetLoadMov(AstType *type) {
-    if (type->kind == AST_TYPE_CLASS
-            && type->is_intrinsic) return "movq";
+char *asmGetLoadMov(const AstType *type) {
+    if (type->kind == AST_TYPE_CLASS && type->is_intrinsic)
+        return "movq";
     switch (type->size) {
-        case 1:
-            if (type->issigned) return "movsbq";
-            else                return "movzbq";
-        case 2:
-            if (type->issigned) return "movswq";
-            else                return "movzwq";
-        case 4: return "movslq";
-        case 8:
-            return "movq";
-        default:
-            loggerPanic("Unknown size for loading: %s %d\n",
-                    astTypeToString(type), type->size);
+    case 1:
+        if (type->issigned)
+            return "movsbq";
+        else
+            return "movzbq";
+    case 2:
+        if (type->issigned)
+            return "movswq";
+        else
+            return "movzwq";
+    case 4:
+        return "movslq";
+    case 8:
+        return "movq";
+    default:
+        loggerPanic("Unknown size for loading: %s %d\n", astTypeToString(type),
+                    type->size);
     }
 }
 
-char *asmGetIntReg(AstType *type, char ch) {
+char *asmGetIntReg(const AstType *type, char ch) {
     if (ch == 'a') {
         if (type->kind == AST_TYPE_CLASS && type->is_intrinsic) {
             return "rax";
         }
         switch (type->size) {
-            case 1: return "al";
-            case 2: return "ax";
-            case 4: return "eax";
-            case 8: return "rax";
-            default:
-                loggerPanic("Unknown size for reg prefix '%c': %s %d\n",
-                        ch, astTypeToString(type), type->size);
+        case 1:
+            return "al";
+        case 2:
+            return "ax";
+        case 4:
+            return "eax";
+        case 8:
+            return "rax";
+        default:
+            loggerPanic("Unknown size for reg prefix '%c': %s %d\n", ch,
+                        astTypeToString(type), type->size);
         }
     } else if (ch == 'c') {
         if (type->kind == AST_TYPE_CLASS && type->is_intrinsic) {
             return "rcx";
         }
         switch (type->size) {
-            case 1: return "cl";
-            case 2: return "cx";
-            case 4: return "ecx";
-            case 8: return "rcx";
-            default:
-         return "rcx";
-                loggerPanic("Unknown size for reg prefix '%c': %s %d\n",
-                        ch,
+        case 1:
+            return "cl";
+        case 2:
+            return "cx";
+        case 4:
+            return "ecx";
+        case 8:
+            return "rcx";
+        default:
+            loggerPanic("Unknown size for reg prefix '%c': %s %d\n", ch,
                         astTypeToString(type), type->size);
         }
     } else {
@@ -203,13 +230,13 @@ char *asmGetIntReg(AstType *type, char ch) {
     }
 }
 
-void asmToInt(aoStr *buf, AstType *type) {
+void asmToInt(aoStr *buf, const AstType *type) {
     if (type->kind == AST_TYPE_FLOAT) {
         aoStrCatPrintf(buf, "cvttsd2si  %%xmm0, %%rax\n\t");
     }
 }
 
-void asmToFloat(aoStr *buf, AstType *type) {
+void asmToFloat(aoStr *buf, const AstType *type) {
     if (type->kind != AST_TYPE_FLOAT) {
         if (type->has_var_args) {
             aoStrCatPrintf(buf, "movq    %%rax, %%xmm0\n\t");
@@ -220,14 +247,18 @@ void asmToFloat(aoStr *buf, AstType *type) {
 }
 
 void asmPushXMM(aoStr *str, int reg) {
-    aoStrCatPrintf(str, "sub   $8, %%rsp\n\t"
-                        "movsd %%xmm%d, (%%rsp)\n\t", reg);
+    aoStrCatPrintf(str,
+                   "sub   $8, %%rsp\n\t"
+                   "movsd %%xmm%d, (%%rsp)\n\t",
+                   reg);
     stack_pointer += 8;
 }
 
 void asmPopXMM(aoStr *str, int reg) {
-    aoStrCatPrintf(str, "movsd  (%%rsp), %%xmm%d\n\t"
-                        "add    $8, %%rsp\n\t", reg);
+    aoStrCatPrintf(str,
+                   "movsd  (%%rsp), %%xmm%d\n\t"
+                   "add    $8, %%rsp\n\t",
+                   reg);
     stack_pointer -= 8;
     if (stack_pointer < 0) {
         loggerPanic("Stack underflow\n");
@@ -235,12 +266,12 @@ void asmPopXMM(aoStr *str, int reg) {
 }
 
 void asmPush(aoStr *buf, char *reg) {
-    aoStrCatPrintf(buf,"push   %%%s\n\t", reg);
+    aoStrCatPrintf(buf, "push   %%%s\n\t", reg);
     stack_pointer += 8;
 }
 
 void asmPop(aoStr *buf, char *reg) {
-    aoStrCatPrintf(buf,"pop    %%%s\n\t", reg);
+    aoStrCatPrintf(buf, "pop    %%%s\n\t", reg);
     stack_pointer -= 8;
     if (stack_pointer < 0) {
         loggerPanic("Int register stack underflow\n");
@@ -249,18 +280,17 @@ void asmPop(aoStr *buf, char *reg) {
 
 void asmCall(aoStr *buf, char *fname) {
     char *_fname = asmNormaliseFunctionName(fname);
-    aoStrCatPrintf(buf,"call   %s\n\t", _fname);
+    aoStrCatPrintf(buf, "call   %s\n\t", _fname);
 }
 
 /* Save a global variable */
-void asmGSave(aoStr *buf, char *name, AstType *type, int offset) {
+void asmGSave(aoStr *buf, char *name, const AstType *type, int offset) {
     assert(type->kind != AST_TYPE_ARRAY);
-    char *reg;
 
     if (type->kind == AST_TYPE_FLOAT) {
-        aoStrCatPrintf(buf,"movq   %%xmm0, %%rax\n\t");
+        aoStrCatPrintf(buf, "movq   %%xmm0, %%rax\n\t");
     }
-    reg = asmGetIntReg(type, 'a');
+    char *reg = asmGetIntReg(type, 'a');
     if (offset) {
         aoStrCatPrintf(buf, "movq  %%%s, %s+%d(%%rip)\n\t", reg, name, offset);
     } else {
@@ -272,25 +302,22 @@ void asmPlaceString(aoStr *buf, aoStr *str, int offset) {
     int i = 0;
     /* Place string on the stack character by character */
     for (; i < (int)str->len; ++i) {
-        aoStrCatPrintf(buf,"movb   $%d, %d(%%rbp)\n\t",
-                (int)str->data[i], 
-                -(offset - i));
+        aoStrCatPrintf(buf, "movb   $%d, %d(%%rbp)\n\t", (int)str->data[i],
+                       -(offset - i));
     }
     /* Place '\0' */
-    aoStrCatPrintf(buf, "movb   $0, %d(%%rbp)\n\t", 
-            -(offset - i));
+    aoStrCatPrintf(buf, "movb   $0, %d(%%rbp)\n\t", -(offset - i));
 }
 
-void asmGLoad(aoStr *buf, AstType *type, aoStr *label, int offset) {
+void asmGLoad(aoStr *buf, const AstType *type, const aoStr *label, int offset) {
     char *reg = NULL;
 
     if (type->kind == AST_TYPE_ARRAY) {
         if (offset) {
-            aoStrCatPrintf(buf, "lea    %s+%d(%%rip), %%rax\n\t",
-                    label->data, offset);
+            aoStrCatPrintf(buf, "lea    %s+%d(%%rip), %%rax\n\t", label->data,
+                           offset);
         } else {
-            aoStrCatPrintf(buf, "lea    %s(%%rip), %%rax\n\t",
-                    label->data);
+            aoStrCatPrintf(buf, "lea    %s(%%rip), %%rax\n\t", label->data);
         }
         return;
     }
@@ -300,14 +327,13 @@ void asmGLoad(aoStr *buf, AstType *type, aoStr *label, int offset) {
         aoStrCatPrintf(buf, "movl  $0, %%eax\n\t");
     }
     if (offset) {
-        aoStrCatPrintf(buf, "movq  %s+%d(%%rip), %%%s\n\t",
-                label->data, offset, reg);
+        aoStrCatPrintf(buf, "movq  %s+%d(%%rip), %%%s\n\t", label->data, offset,
+                       reg);
     } else {
-        aoStrCatPrintf(buf, "movq  %s(%%rip), %%%s\n\t",
-                label->data, reg);
+        aoStrCatPrintf(buf, "movq  %s(%%rip), %%%s\n\t", label->data, reg);
     }
     if (type->kind == AST_TYPE_FLOAT) {
-        aoStrCatPrintf(buf,"movq   %%rax, %%xmm0\n\t");
+        aoStrCatPrintf(buf, "movq   %%rax, %%xmm0\n\t");
     }
 }
 
@@ -315,96 +341,108 @@ void asmLLoad(aoStr *buf, AstType *type, int offset) {
     char *reg = NULL;
 
     switch (type->kind) {
-        case AST_TYPE_ARRAY:
-            aoStrCatPrintf(buf, "# LOAD LEAQ START: %s\n\t", astKindToString(type->kind));
-            aoStrCatPrintf(buf, "leaq   %d(%%rbp), %%rax\n\t", offset);
-            aoStrCatPrintf(buf, "# LOAD LEAQ END: %s\n\t", astKindToString(type->kind));
-            return;
-        case AST_TYPE_FLOAT:
-            aoStrCatPrintf(buf, "movsd  %d(%%rbp), %%xmm0\n\t", offset);
-            return;
-        default:
-            reg =  asmGetLoadReg(type, 'a');
-            aoStrCatPrintf(buf, "# LOAD %s %s START\n\t",reg,astKindToString(type->kind));
+    case AST_TYPE_ARRAY:
+        aoStrCatPrintf(buf, "# LOAD LEAQ START: %s\n\t",
+                       astKindToString(type->kind));
+        aoStrCatPrintf(buf, "leaq   %d(%%rbp), %%rax\n\t", offset);
+        aoStrCatPrintf(buf, "# LOAD LEAQ END: %s\n\t",
+                       astKindToString(type->kind));
+        return;
+    case AST_TYPE_FLOAT:
+        aoStrCatPrintf(buf, "movsd  %d(%%rbp), %%xmm0\n\t", offset);
+        return;
+    default:
+        reg = asmGetLoadReg(type, 'a');
+        aoStrCatPrintf(buf, "# LOAD %s %s START\n\t", reg,
+                       astKindToString(type->kind));
 
-            aoStrCatPrintf(buf, "%-4s  %d(%%rbp), %%%s\n\t",
-                    asmGetLoadMov(type), offset, reg);
-            aoStrCatPrintf(buf, "# LOAD %s END\n\t",reg);
+        aoStrCatPrintf(buf, "%-4s  %d(%%rbp), %%%s\n\t", asmGetLoadMov(type),
+                       offset, reg);
+        aoStrCatPrintf(buf, "# LOAD %s END\n\t", reg);
     }
 }
 
-void asmLSave(aoStr *buf, AstType *type, int offset) {
-    char *reg, *mov;
+void asmLSave(aoStr *buf, const AstType *type, int offset) {
+    char *mov;
     switch (type->kind) {
-        case AST_TYPE_FLOAT:
-            aoStrCatPrintf(buf, "movsd   %%xmm0, %d(%%rbp)\n\t", offset);
-            break;
-        default:
-            reg = asmGetIntReg(type,'a');
-            mov = asmGetMov(type);
-            aoStrCatPrintf(buf, "%-4s   %%%s, %d(%%rbp)\n\t",mov, reg, offset);
-            break;
+    case AST_TYPE_FLOAT:
+        aoStrCatPrintf(buf, "movsd   %%xmm0, %d(%%rbp)\n\t", offset);
+        break;
+    default:
+        char *reg = asmGetIntReg(type, 'a');
+        mov = asmGetMov(type);
+        aoStrCatPrintf(buf, "%-4s   %%%s, %d(%%rbp)\n\t", mov, reg, offset);
+        break;
     }
 }
 
-void AstUpCastInt(aoStr *buf, AstType *type, int issigned) {
-    switch(type->kind) {
+void AstUpCastInt(aoStr *buf, const AstType *type, int issigned) {
+    switch (type->kind) {
     case AST_TYPE_CHAR:
-        if (issigned) aoStrCatPrintf(buf, "movsbq   %%al, %%rax\n\t");
-        else          aoStrCatPrintf(buf, "movzbq   %%al, %%rax\n\t");
+        if (issigned)
+            aoStrCatPrintf(buf, "movsbq   %%al, %%rax\n\t");
+        else
+            aoStrCatPrintf(buf, "movzbq   %%al, %%rax\n\t");
         break;
     case AST_TYPE_INT:
-        if (issigned) aoStrCatPrintf(buf, "cltq\n\t");
-        else          aoStrCatPrintf(buf, "movslq   %%eax, %%rax #upcast :%d\n\t",type->size);
+        if (issigned)
+            aoStrCatPrintf(buf, "cltq\n\t");
+        else
+            aoStrCatPrintf(buf, "movslq   %%eax, %%rax #upcast :%d\n\t",
+                           type->size);
         break;
+    default:;
     }
 }
 
-void asmDownCastInt(aoStr *buf, AstType *type, int issigned) {
-    switch(type->kind) {
+void asmDownCastInt(aoStr *buf, const AstType *type, int issigned) {
+    switch (type->kind) {
     case AST_TYPE_INT:
-        if (issigned) aoStrCatPrintf(buf, "movsx  %%al, %%rax\n\t");
-        else          aoStrCatPrintf(buf, "movzx  %%al, %%rax\n\t");
+        if (issigned)
+            aoStrCatPrintf(buf, "movsx  %%al, %%rax\n\t");
+        else
+            aoStrCatPrintf(buf, "movzx  %%al, %%rax\n\t");
         break;
+    default:;
     }
 }
 
-void asmFloatToInt(aoStr *buf, AstType *type) {
+void asmFloatToInt(aoStr *buf, const AstType *type) {
     if (type->kind == AST_TYPE_FLOAT)
         aoStrCatPrintf(buf, "cvttsd2si %%xmm0, %%eax\n\t");
 }
 
-void asmCast(aoStr *buf, AstType *from, AstType *to) {
-    if (from->kind == to->kind && from->size == to->size) return;
+void asmCast(aoStr *buf, const AstType *from, const AstType *to) {
+    if (from->kind == to->kind && from->size == to->size)
+        return;
     if (astIsIntType(from) && to->kind == AST_TYPE_FLOAT) {
         asmToFloat(buf, from);
     } else if (astIsIntType(from) && astIsIntType(to)) {
         if (to->size > from->size) {
-            if (to->is_intrinsic && from->size == 8) return;
+            if (to->is_intrinsic && from->size == 8)
+                return;
             AstUpCastInt(buf, from, to->issigned);
         } else if (to->size < from->size) {
             asmDownCastInt(buf, from, to->issigned);
         }
-    }
-    else if (astIsIntType(to))
+    } else if (astIsIntType(to))
         asmFloatToInt(buf, from);
 }
 
-void asmTypeCast(Cctrl *cc, aoStr *buf, Ast *ast) {
-    asmExpression(cc,buf,ast->operand);
-    asmCast(buf,ast->operand->type,ast->type);
+void asmTypeCast(Cctrl *cc, aoStr *buf, const Ast *ast) {
+    asmExpression(cc, buf, ast->operand);
+    asmCast(buf, ast->operand->type, ast->type);
 }
 
-void asmAssignDerefInternal(aoStr *buf, AstType *type, int offset) {
-    char *reg,*mov;
+void asmAssignDerefInternal(aoStr *buf, const AstType *type, int offset) {
     aoStrCatPrintf(buf, "# ASSIGN DREF INTERNAL START: %s\n\t",
-            astKindToString(type->kind));
+                   astKindToString(type->kind));
 
     aoStrCatPrintf(buf, "movq   (%%rax), %%rcx #OK mov\n\t");
     asmPop(buf, "rcx");
 
-    reg = asmGetIntReg(type, 'c');
-    mov = asmGetMov(type);
+    char *reg = asmGetIntReg(type, 'c');
+    char *mov = asmGetMov(type);
 
     if (type->kind == AST_TYPE_FLOAT) {
         if (offset) {
@@ -414,211 +452,237 @@ void asmAssignDerefInternal(aoStr *buf, AstType *type, int offset) {
         }
     } else {
         if (offset) {
-            aoStrCatPrintf(buf, "%s %%%s, %d(%%rax)\n\t",mov, reg, offset);
+            aoStrCatPrintf(buf, "%s %%%s, %d(%%rax)\n\t", mov, reg, offset);
         } else {
-            aoStrCatPrintf(buf, "%s  %%%s, (%%rax)\n\t",mov, reg);
+            aoStrCatPrintf(buf, "%s  %%%s, (%%rax)\n\t", mov, reg);
         }
     }
 
     aoStrCatPrintf(buf, "# ASSIGN DREF INTERNAL end\n\t");
 }
 
-void asmAssignDeref(Cctrl *cc,aoStr *buf, Ast *ast) {
+void asmAssignDeref(Cctrl *cc, aoStr *buf, Ast *ast) {
     asmPush(buf, REG_RAX);
-    asmExpression(cc,buf,ast->operand);
-    asmAssignDerefInternal(buf,ast->operand->type->ptr, 0);
+    asmExpression(cc, buf, ast->operand);
+    asmAssignDerefInternal(buf, ast->operand->type->ptr, 0);
 }
 
-void asmLoadDeref(aoStr *buf, AstType *result, AstType *op_type, int off) {
-    char *reg,*ptr_mov;
+void asmLoadDeref(aoStr *buf, const AstType *result, const AstType *op_type,
+                  int off) {
     if (op_type->kind == AST_TYPE_POINTER &&
-            op_type->ptr->kind == AST_TYPE_ARRAY) {
+        op_type->ptr->kind == AST_TYPE_ARRAY) {
         return;
     }
     aoStrCatPrintf(buf, "# LOAD DEREF: %s %s\n\t",
-            astKindToString(result->kind),
-            astKindToString(op_type->kind));
+                   astKindToString(result->kind),
+                   astKindToString(op_type->kind));
 
-    ptr_mov = asmGetPtrMove(op_type);
+    char *ptr_mov = asmGetPtrMove(op_type);
 
     if (op_type->kind == AST_TYPE_FLOAT) {
-        if (off) aoStrCatPrintf(buf, "movq   %d(%%rax), %%xmm1\n\t", off);
-        else     aoStrCatPrintf(buf,"movq   (%%rax), %%xmm1\n\t");
-        aoStrCatPrintf(buf,"movsd   %%xmm1, %%xmm0\n\t");
+        if (off)
+            aoStrCatPrintf(buf, "movq   %d(%%rax), %%xmm1\n\t", off);
+        else
+            aoStrCatPrintf(buf, "movq   (%%rax), %%xmm1\n\t");
+        aoStrCatPrintf(buf, "movsd   %%xmm1, %%xmm0\n\t");
     } else {
-        reg = asmGetIntReg(result,'c');
+        char *reg = asmGetIntReg(result, 'c');
         if (result->size < 4) {
             aoStrCatPrintf(buf, "mov    $0, %%ecx\n\t");
         }
 
         switch (op_type->kind) {
-            case AST_TYPE_CHAR:
-                if (off) aoStrCatPrintf(buf,"movzbl   %d(%%rax), %%ecx\n\t", off);
-                else     aoStrCatPrintf(buf,"movzbl   (%%rax), %%ecx\n\t");
-                aoStrCatPrintf(buf,"movzbl   %%cl, %%ecx\n\t");
-                break;
-            default:
-                if (off) aoStrCatPrintf(buf,"%s   %d(%%rax), %%%s\n\t",  ptr_mov, off, reg);
-                else     aoStrCatPrintf(buf,"%s   (%%rax), %%%s\n\t", ptr_mov, reg);
+        case AST_TYPE_CHAR:
+            if (off)
+                aoStrCatPrintf(buf, "movzbl   %d(%%rax), %%ecx\n\t", off);
+            else
+                aoStrCatPrintf(buf, "movzbl   (%%rax), %%ecx\n\t");
+            aoStrCatPrintf(buf, "movzbl   %%cl, %%ecx\n\t");
+            break;
+        default:
+            if (off)
+                aoStrCatPrintf(buf, "%s   %d(%%rax), %%%s\n\t", ptr_mov, off,
+                               reg);
+            else
+                aoStrCatPrintf(buf, "%s   (%%rax), %%%s\n\t", ptr_mov, reg);
         }
 
-
         /* Move back for the next recursive call */
-        aoStrCatPrintf(buf,"movq   %%%s, %%rax\n\t", reg);
+        aoStrCatPrintf(buf, "movq   %%%s, %%rax\n\t", reg);
     }
     aoStrCatPrintf(buf, "# LOAD DEREF END: %s %s\n\t",
-            astKindToString(result->kind),
-            astKindToString(op_type->kind));
+                   astKindToString(result->kind),
+                   astKindToString(op_type->kind));
 }
 
 void asmPointerArithmetic(Cctrl *cc, aoStr *buf, long op, Ast *LHS, Ast *RHS) {
-    //assert(LHS->type->kind == AST_TYPE_POINTER);
+    // assert(LHS->type->kind == AST_TYPE_POINTER);
     int size;
     char *fn;
 
     aoStrCatPrintf(buf, "# Pointer Arithmetic start: %s %s\n\t",
-            astKindToString(LHS->kind), astKindToString(RHS->kind));
-    asmExpression(cc,buf,LHS);
+                   astKindToString(LHS->kind), astKindToString(RHS->kind));
+    asmExpression(cc, buf, LHS);
     aoStrCatPrintf(buf, "# Pointer Arithmetic MID\n\t");
-    asmPush(buf,REG_RAX);
-    asmExpression(cc,buf,RHS);
+    asmPush(buf, REG_RAX);
+    asmExpression(cc, buf, RHS);
 
     /* XXX: What is going on */
     if (LHS->type->ptr->ptr != NULL) {
         if (LHS->type->ptr->kind == AST_TYPE_POINTER) {
             size = 8;
         } else {
-            size = LHS->type->ptr->size; 
+            size = LHS->type->ptr->size;
         }
     } else {
-        size = LHS->type->ptr->size; 
+        size = LHS->type->ptr->size;
     }
 
     switch (op) {
-        case '+': fn = "addq"; break;
-        case '-': fn = "subq"; break;
-        case '>': fn = "setg"; break;
-        case '<': fn = "setl"; break;
-        case TK_GREATER_EQU: fn = "setge"; break;
-        case TK_LESS_EQU: fn =  "setle"; break;
-        case TK_EQU_EQU: fn = "sete"; break;
-        case TK_NOT_EQU: fn = "setne"; break;
-        default: loggerPanic("op: %c is not implemented for pointer arithmetic\n",(char)op);
+    case '+':
+        fn = "addq";
+        break;
+    case '-':
+        fn = "subq";
+        break;
+    case '>':
+        fn = "setg";
+        break;
+    case '<':
+        fn = "setl";
+        break;
+    case TK_GREATER_EQU:
+        fn = "setge";
+        break;
+    case TK_LESS_EQU:
+        fn = "setle";
+        break;
+    case TK_EQU_EQU:
+        fn = "sete";
+        break;
+    case TK_NOT_EQU:
+        fn = "setne";
+        break;
+    default:
+        loggerPanic("op: %c is not implemented for pointer arithmetic\n",
+                    (char)op);
     }
 
     if (op == '+' || op == '-') {
         if (size > 1) {
             aoStrCatPrintf(buf, "imul   $%d, %%rax\n\t", size);
         }
-        asmPop(buf,REG_RCX);
+        asmPop(buf, REG_RCX);
         aoStrCatPrintf(buf,
-            "%-3s   %%rax, %%rcx\n\t"
-            "movq   %%rcx, %%rax\n\t", fn);
+                       "%-3s   %%rax, %%rcx\n\t"
+                       "movq   %%rcx, %%rax\n\t",
+                       fn);
     } else {
-        asmPop(buf,REG_RCX);
+        asmPop(buf, REG_RCX);
         aoStrCatPrintf(buf,
-                "cmpq   %%rax, %%rcx\n\t"
-                "%-3s   %%al\n\t"
-                "movzb  %%al, %%rax\n\t", fn);
+                       "cmpq   %%rax, %%rcx\n\t"
+                       "%-3s   %%al\n\t"
+                       "movzb  %%al, %%rax\n\t",
+                       fn);
     }
     aoStrCatPrintf(buf, "# Pointer Arithmetic end\n\t");
 }
 
-void asmAssignClassRef(Cctrl *cc, aoStr *buf, Ast *cls, AstType *field, int offset) {
+void asmAssignClassRef(Cctrl *cc, aoStr *buf, Ast *cls, AstType *field,
+                       int offset) {
     int total_offset;
     switch (cls->kind) {
-        case AST_LVAR:
-            total_offset = cls->loff + field->offset + offset;
-            asmLSave(buf,field,total_offset);
-            break;
+    case AST_LVAR:
+        total_offset = cls->loff + field->offset + offset;
+        asmLSave(buf, field, total_offset);
+        break;
 
-        case AST_GVAR:
-            loggerPanic("Global variables unimplemented: %s\n", astToString(cls));
-           // total_offset = field->offset + offset;
-           // asmGSave(buf,cls->clsname->data,field,total_offset);
-            break;
+    case AST_GVAR:
+        loggerPanic("Global variables unimplemented: %s\n", astToString(cls));
+        // total_offset = field->offset + offset;
+        // asmGSave(buf,cls->clsname->data,field,total_offset);
+        break;
 
-        case AST_CLASS_REF:
-            total_offset = offset + cls->type->offset;
-            asmAssignClassRef(cc,buf,cls->cls, field, total_offset);
-            break;
+    case AST_CLASS_REF:
+        total_offset = offset + cls->type->offset;
+        asmAssignClassRef(cc, buf, cls->cls, field, total_offset);
+        break;
 
-        case AST_DEREF:
-            aoStrCatPrintf(buf, "\n# Problem >code START %s \n\t",
-                    astKindToString(field->kind));
-            total_offset = field->offset+offset;
+    case AST_DEREF:
+        aoStrCatPrintf(buf, "\n# Problem >code START %s \n\t",
+                       astKindToString(field->kind));
+        total_offset = field->offset + offset;
 
-            switch (field->kind) {
-                case AST_TYPE_FLOAT:{
-                    asmPushXMM(buf,0);
-                    asmExpression(cc,buf,cls->operand);
-                    asmPopXMM(buf,1);
-                    if (total_offset > 0) {
-                        aoStrCatPrintf(buf, "movsd   %%xmm1, %d(%%rax)\n\t",
-                                field->offset+offset);
-                    } else {
-                        aoStrCatPrintf(buf, "movsd   %%xmm1, (%%rax)\n\t");
-                    }
-                    /* Whatever we were assigning we put back, allows for chaining
-                     * assignments */
-                    aoStrCatPrintf(buf,"movsd    %%xmm1, %%xmm0\n\t");
-                    break;
-                }
-                default: {
-                    asmPush(buf, REG_RAX);
-                    asmExpression(cc,buf,cls->operand);
-                    asmPop(buf,REG_RCX);
-                    if (total_offset > 0) {
-                        aoStrCatPrintf(buf, "movq   %%rcx, %d(%%rax)\n\t",
-                                field->offset+offset);
-                    } else {
-                        aoStrCatPrintf(buf, "movq   %%rcx, (%%rax)\n\t");
-                    }
-                    
-                    /* Whatever we were assigning we put back, allows for chaining
-                     * assignments */
-                    aoStrCatPrintf(buf,"movq    %%rcx, %%rax\n\t");
-                    break;
-                }
+        switch (field->kind) {
+        case AST_TYPE_FLOAT: {
+            asmPushXMM(buf, 0);
+            asmExpression(cc, buf, cls->operand);
+            asmPopXMM(buf, 1);
+            if (total_offset > 0) {
+                aoStrCatPrintf(buf, "movsd   %%xmm1, %d(%%rax)\n\t",
+                               field->offset + offset);
+            } else {
+                aoStrCatPrintf(buf, "movsd   %%xmm1, (%%rax)\n\t");
             }
-            
-            aoStrCatPrintf(buf, "\n# Problem >code END \n\t");
+            /* Whatever we were assigning we put back, allows for chaining
+             * assignments */
+            aoStrCatPrintf(buf, "movsd    %%xmm1, %%xmm0\n\t");
             break;
-        default:
-            loggerPanic("Failed to create ASM for: %s\n",
-                    astToString(cls));
+        }
+        default: {
+            asmPush(buf, REG_RAX);
+            asmExpression(cc, buf, cls->operand);
+            asmPop(buf, REG_RCX);
+            if (total_offset > 0) {
+                aoStrCatPrintf(buf, "movq   %%rcx, %d(%%rax)\n\t",
+                               field->offset + offset);
+            } else {
+                aoStrCatPrintf(buf, "movq   %%rcx, (%%rax)\n\t");
+            }
+
+            /* Whatever we were assigning we put back, allows for chaining
+             * assignments */
+            aoStrCatPrintf(buf, "movq    %%rcx, %%rax\n\t");
+            break;
+        }
+        }
+
+        aoStrCatPrintf(buf, "\n# Problem >code END \n\t");
+        break;
+    default:
+        loggerPanic("Failed to create ASM for: %s\n", astToString(cls));
     }
 }
 
-void asmLoadClassRef(Cctrl *cc, aoStr *buf, Ast *cls, AstType *field, int offset) {
+void asmLoadClassRef(Cctrl *cc, aoStr *buf, Ast *cls, AstType *field,
+                     int offset) {
     int total_offset;
     switch (cls->kind) {
-        case AST_LVAR:
-            total_offset = cls->loff + field->offset + offset;
-            aoStrCatPrintf(buf, "# CLASS LOAD\n\t");
-            asmLLoad(buf, field, total_offset);
-            break;
-        
-        case AST_GVAR:
-            loggerPanic("Global variables unimplemented: %s\n", astToString(cls));
-            //total_offset = field->offset + offset;
-            //AsmGLoad(buf,field,cls->clsname,total_offset);
-            break;
+    case AST_LVAR:
+        total_offset = cls->loff + field->offset + offset;
+        aoStrCatPrintf(buf, "# CLASS LOAD\n\t");
+        asmLLoad(buf, field, total_offset);
+        break;
 
-        case AST_CLASS_REF:
-            total_offset = offset + cls->type->offset;
-            asmLoadClassRef(cc,buf,cls->cls, field,total_offset);
-            break;
+    case AST_GVAR:
+        loggerPanic("Global variables unimplemented: %s\n", astToString(cls));
+        // total_offset = field->offset + offset;
+        // AsmGLoad(buf,field,cls->clsname,total_offset);
+        break;
 
-        case AST_DEREF:
-            total_offset = field->offset+offset;
-            asmExpression(cc,buf,cls->operand);
-            asmLoadDeref(buf,cls->cls->type,field,total_offset);
-            break;
-        
-        default:
-            loggerPanic("Failed to create ASM for: %s\n",
-                    astToString(cls));
+    case AST_CLASS_REF:
+        total_offset = offset + cls->type->offset;
+        asmLoadClassRef(cc, buf, cls->cls, field, total_offset);
+        break;
+
+    case AST_DEREF:
+        total_offset = field->offset + offset;
+        asmExpression(cc, buf, cls->operand);
+        asmLoadDeref(buf, cls->cls->type, field, total_offset);
+        break;
+
+    default:
+        loggerPanic("Failed to create ASM for: %s\n", astToString(cls));
     }
 }
 
@@ -628,188 +692,213 @@ void asmAssign(Cctrl *cc, aoStr *buf, Ast *variable) {
     }
     switch (variable->kind) {
     case AST_CAST:
-        asmCast(buf,variable->operand->type,variable->type);
+        asmCast(buf, variable->operand->type, variable->type);
         variable->operand->type = astTypeCopy(variable->type);
-        asmAssign(cc,buf,variable->operand);
+        asmAssign(cc, buf, variable->operand);
         break;
 
-    case AST_DEREF: 
-        asmAssignDeref(cc,buf, variable);
+    case AST_DEREF:
+        asmAssignDeref(cc, buf, variable);
         break;
 
     case AST_CLASS_REF:
-        asmAssignClassRef(cc,buf,variable->cls,variable->type,0);
+        asmAssignClassRef(cc, buf, variable->cls, variable->type, 0);
         break;
 
     case AST_FUNPTR:
-    case AST_LVAR: 
-        asmLSave(buf,variable->type,variable->loff);
+    case AST_LVAR:
+        asmLSave(buf, variable->type, variable->loff);
         break;
 
     case AST_GVAR: {
         char *label = asmGetGlabel(variable);
-        asmGSave(buf,label,variable->type,0);
+        asmGSave(buf, label, variable->type, 0);
         break;
     }
     default:
-        loggerPanic("Cannot assign: %s\n",
-                astToString(variable));
+        loggerPanic("Cannot assign: %s\n", astToString(variable));
     }
 }
 
 void asmCompare(Cctrl *cc, aoStr *buf, char *instruction, Ast *ast) {
-    Ast *LHS,*RHS;
+    Ast *LHS, *RHS;
     LHS = ast->left;
     RHS = ast->right;
-    
+
     if ((LHS->type->kind == AST_TYPE_FLOAT &&
-                RHS->type->kind == AST_TYPE_FLOAT)) {
-        asmExpression(cc,buf,LHS);
-        asmToFloat(buf,LHS->type);
-        asmPushXMM(buf,0);
-        asmExpression(cc,buf,RHS);
-        asmToFloat(buf,LHS->type);
-        asmPopXMM(buf,1);
+         RHS->type->kind == AST_TYPE_FLOAT)) {
+        asmExpression(cc, buf, LHS);
+        asmToFloat(buf, LHS->type);
+        asmPushXMM(buf, 0);
+        asmExpression(cc, buf, RHS);
+        asmToFloat(buf, LHS->type);
+        asmPopXMM(buf, 1);
 
         switch (ast->kind) {
-            case '<': {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm1, %%xmm0\n\t"
-                        "seta     %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
-            case TK_LESS_EQU: {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm0, %%xmm1\n\t"
-                        "setae    %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
-            case '>': {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm0, %%xmm1\n\t"
-                        "seta     %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
-            case TK_GREATER_EQU: {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm0, %%xmm1\n\t"
-                        "setae    %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
-            case TK_EQU_EQU: {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm0, %%xmm1\n\t"
-                        "sete     %%al\n\t"
-                        "setnp    %%cl\n\t"
-                        "andb     %%cl, %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
-            case TK_NOT_EQU: {
-                aoStrCatPrintf(buf,
-                        "ucomisd  %%xmm0, %%xmm1\n\t"
-                        "setne    %%al\n\t"
-                        "setnp    %%cl\n\t"
-                        "andb     %%cl, %%al\n\t"
-                        "andb     $1, %%al\n\t"
-                        "movzbl   %%al, %%eax\n\t");
-                break;
-            }
+        case '<': {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm1, %%xmm0\n\t"
+                           "seta     %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
+        case TK_LESS_EQU: {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm0, %%xmm1\n\t"
+                           "setae    %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
+        case '>': {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm0, %%xmm1\n\t"
+                           "seta     %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
+        case TK_GREATER_EQU: {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm0, %%xmm1\n\t"
+                           "setae    %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
+        case TK_EQU_EQU: {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm0, %%xmm1\n\t"
+                           "sete     %%al\n\t"
+                           "setnp    %%cl\n\t"
+                           "andb     %%cl, %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
+        case TK_NOT_EQU: {
+            aoStrCatPrintf(buf,
+                           "ucomisd  %%xmm0, %%xmm1\n\t"
+                           "setne    %%al\n\t"
+                           "setnp    %%cl\n\t"
+                           "andb     %%cl, %%al\n\t"
+                           "andb     $1, %%al\n\t"
+                           "movzbl   %%al, %%eax\n\t");
+            break;
+        }
         }
     } else {
-        asmExpression(cc,buf,LHS);
-        asmToInt(buf,LHS->type);
-        asmPush(buf,REG_RAX);
-        asmExpression(cc,buf,RHS);
-        asmToInt(buf,RHS->type);
-        asmPop(buf,REG_RCX);
+        asmExpression(cc, buf, LHS);
+        asmToInt(buf, LHS->type);
+        asmPush(buf, REG_RAX);
+        asmExpression(cc, buf, RHS);
+        asmToInt(buf, RHS->type);
+        asmPop(buf, REG_RCX);
 
         switch (LHS->type->size) {
-            case 1: aoStrCatPrintf(buf,"cmp    %%al, %%cl\n\t");break;
-            case 2:
-            case 4: aoStrCatPrintf(buf,"cmp    %%eax, %%ecx\n\t"); break;
-            case 8: aoStrCatPrintf(buf,"cmp    %%rax, %%rcx\n\t"); break;
-            default:
-                loggerPanic("Cannot compare type with size: %d\n", LHS->type->size);
+        case 1:
+            aoStrCatPrintf(buf, "cmp    %%al, %%cl\n\t");
+            break;
+        case 2:
+        case 4:
+            aoStrCatPrintf(buf, "cmp    %%eax, %%ecx\n\t");
+            break;
+        case 8:
+            aoStrCatPrintf(buf, "cmp    %%rax, %%rcx\n\t");
+            break;
+        default:
+            loggerPanic("Cannot compare type with size: %d\n", LHS->type->size);
         }
         aoStrCatPrintf(buf,
-                "%-3s   %%al\n\t"
-                "movzb  %%al, %%eax\n\t", instruction);
+                       "%-3s   %%al\n\t"
+                       "movzb  %%al, %%eax\n\t",
+                       instruction);
     }
 }
 
-void asmBinaryOpIntArithmetic(Cctrl *cc,aoStr *buf, Ast *ast, int reverse) {
+void asmBinaryOpIntArithmetic(Cctrl *cc, aoStr *buf, Ast *ast, int reverse) {
     aoStrCatPrintf(buf, "# INt arithmetic START \n\t");
     char *op = NULL;
-    Ast *LHS,*RHS;
+    Ast *LHS, *RHS;
     LHS = ast->left;
     RHS = ast->right;
     int is_unsinged = 0;
     if (!LHS->type->issigned || !RHS->type->issigned) {
-       is_unsinged = 1; 
+        is_unsinged = 1;
     }
 
     int ok = 1;
-    ssize_t result = evalIntArithmeticOrErr(ast,&ok);
+    ssize_t result = evalIntArithmeticOrErr(ast, &ok);
     if (!ok) {
         ok = 1;
-        result = evalOneIntExprOrErr(LHS,RHS,ast->kind,&ok);
+        result = evalOneIntExprOrErr(LHS, RHS, ast->kind, &ok);
     }
 
     if (ok) {
-        aoStrCatPrintf(buf, "movq   $%lld, %%rax\n\t",result);
+        aoStrCatPrintf(buf, "movq   $%lld, %%rax\n\t", result);
         aoStrCatPrintf(buf, "# INt arithmetic END, folded value \n\t");
         return;
     }
 
-    switch(ast->kind) {
-    case '+':    op = "addq"; break;
-    case '-':    op = "subq"; break;
-    case '*':    op = "imulq"; break;
-    case '^':    op = "xorq"; break;
-    case '&':    op = "and"; break;
-    case '|':    op = "or"; break;
-    case TK_SHL: op = "salq"; break;
-    case TK_SHR: op = "sarq"; break;
-    case '/': case '%': break;
+    switch (ast->kind) {
+    case '+':
+        op = "addq";
+        break;
+    case '-':
+        op = "subq";
+        break;
+    case '*':
+        op = "imulq";
+        break;
+    case '^':
+        op = "xorq";
+        break;
+    case '&':
+        op = "and";
+        break;
+    case '|':
+        op = "or";
+        break;
+    case TK_SHL:
+        op = "salq";
+        break;
+    case TK_SHR:
+        op = "sarq";
+        break;
+    case '/':
+    case '%':
+        break;
     default:
-        loggerPanic("Invalid operator: '%s'\n",
-                astKindToString(ast->kind));
+        loggerPanic("Invalid operator: '%s'\n", astKindToString(ast->kind));
     }
 
     if (reverse == ASM_REVERSE_ARITHMETIC) {
-        asmExpression(cc,buf,RHS);
-        asmToInt(buf,RHS->type);
+        asmExpression(cc, buf, RHS);
+        asmToInt(buf, RHS->type);
         aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t");
 
-        asmExpression(cc,buf,LHS);
-        asmToInt(buf,LHS->type);
-        asmPush(buf,REG_RAX);
+        asmExpression(cc, buf, LHS);
+        asmToInt(buf, LHS->type);
+        asmPush(buf, REG_RAX);
     } else {
-        asmExpression(cc,buf,LHS);
-        asmToInt(buf,LHS->type);
-        asmPush(buf,REG_RAX);
+        asmExpression(cc, buf, LHS);
+        asmToInt(buf, LHS->type);
+        asmPush(buf, REG_RAX);
 
-        asmExpression(cc,buf,RHS);
-        asmToInt(buf,RHS->type);
+        asmExpression(cc, buf, RHS);
+        asmToInt(buf, RHS->type);
         aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t");
     }
-    asmPop(buf,REG_RAX);
+    asmPop(buf, REG_RAX);
 
     if (ast->kind == '/' || ast->kind == '%') {
         aoStrCatPrintf(buf, "movq   $0, %%rdx\n\t");
         aoStrCatPrintf(buf, "cqto\n\t");
-        if (is_unsinged) aoStrCatPrintf(buf, "divq  %%rcx\n\t");
-        else             aoStrCatPrintf(buf, "idivq  %%rcx\n\t");
+        if (is_unsinged)
+            aoStrCatPrintf(buf, "divq  %%rcx\n\t");
+        else
+            aoStrCatPrintf(buf, "idivq  %%rcx\n\t");
         if (ast->kind == '%') {
             aoStrCatPrintf(buf, "movq   %%rdx, %%rax\n\t");
         }
@@ -824,69 +913,81 @@ void asmBinaryOpIntArithmetic(Cctrl *cc,aoStr *buf, Ast *ast, int reverse) {
 
 void asmBinaryOpFloatArithmetic(Cctrl *cc, aoStr *buf, Ast *ast, int reverse) {
     char *op;
-    Ast *LHS,*RHS;
+    Ast *LHS, *RHS;
     LHS = ast->left;
     RHS = ast->right;
 
-    switch(ast->kind) {
-    case '+': op = "addsd"; break;
-    case '-': op = "subsd"; break;
-    case '*': op = "mulsd"; break;
-    case '/': op = "divsd"; break;
+    switch (ast->kind) {
+    case '+':
+        op = "addsd";
+        break;
+    case '-':
+        op = "subsd";
+        break;
+    case '*':
+        op = "mulsd";
+        break;
+    case '/':
+        op = "divsd";
+        break;
     default:
         loggerPanic("Invalid operator: '%c'\n", (char)ast->kind);
     }
 
     if (reverse == ASM_REVERSE_ARITHMETIC) {
-        asmExpression(cc,buf,RHS);
-        asmToFloat(buf,RHS->type);
+        asmExpression(cc, buf, RHS);
+        asmToFloat(buf, RHS->type);
         aoStrCatPrintf(buf, "movsd  %%xmm0, %%xmm1\n\t");
 
-        asmExpression(cc,buf,LHS);
-        asmToFloat(buf,LHS->type);
-        asmPushXMM(buf,0);
+        asmExpression(cc, buf, LHS);
+        asmToFloat(buf, LHS->type);
+        asmPushXMM(buf, 0);
     } else {
-        asmExpression(cc,buf,LHS);
-        asmToFloat(buf,LHS->type);
-        asmPushXMM(buf,0);
+        asmExpression(cc, buf, LHS);
+        asmToFloat(buf, LHS->type);
+        asmPushXMM(buf, 0);
 
-        asmExpression(cc,buf,RHS);
-        asmToFloat(buf,RHS->type);
+        asmExpression(cc, buf, RHS);
+        asmToFloat(buf, RHS->type);
         aoStrCatPrintf(buf, "movsd  %%xmm0, %%xmm1\n\t");
     }
-    asmPopXMM(buf,0);
+    asmPopXMM(buf, 0);
 
     aoStrCatPrintf(buf, "%s     %%xmm1, %%xmm0\n\t", op);
 }
 
-void asmLoadConvert(aoStr *buf, AstType *to, AstType *from) {
+void asmLoadConvert(aoStr *buf, const AstType *to, AstType *from) {
     (void)from;
     if (to->kind == AST_TYPE_FLOAT) {
-        asmToFloat(buf,to);
+        asmToFloat(buf, to);
     } else {
-        asmToInt(buf,to);
+        asmToInt(buf, to);
     }
 }
 
-void asmSaveConvert(aoStr *buf, AstType *to, AstType *from) {
+void asmSaveConvert(aoStr *buf, const AstType *to, AstType *from) {
     if (astIsIntType(from) && astIsFloatType(to)) {
         aoStrCatPrintf(buf, "cvtsi2ss %%eax, %%xmm0\n\t");
     } else if (astIsFloatType(from) && astIsFloatType(to)) {
         return;
     } else {
-        asmLoadConvert(buf,to,from);
+        asmLoadConvert(buf, to, from);
     }
 }
 
 static char *asmGetCompartor(long op) {
     switch (op) {
-    case '<': return "setl";
-    case '>': return "setg";
-    case TK_GREATER_EQU: return "setge";
-    case TK_LESS_EQU: return "setle";
+    case '<':
+        return "setl";
+    case '>':
+        return "setg";
+    case TK_GREATER_EQU:
+        return "setge";
+    case TK_LESS_EQU:
+        return "setle";
     default:
-        loggerPanic("Operation: %ld -> %s is not supported for ranges\n",
-                op, astKindToString(op));
+        loggerPanic("Operation: %ld -> %s is not supported for ranges\n", op,
+                    astKindToString(op));
     }
 }
 
@@ -904,34 +1005,36 @@ void asmRangeOperation(Cctrl *cc, aoStr *buf, Ast *ast) {
     aoStr *label_end = astMakeLabel();
 
     aoStrCatPrintf(buf, "# RANGE Start\n\t");
-    asmExpression(cc,buf,ast->left->left);
-    asmPush(buf,REG_RAX);
-    asmExpression(cc,buf,ast->left->right);
-    asmPop(buf,REG_RCX);
+    asmExpression(cc, buf, ast->left->left);
+    asmPush(buf, REG_RAX);
+    asmExpression(cc, buf, ast->left->right);
+    asmPop(buf, REG_RCX);
     aoStrCatPrintf(buf,
-            "cmp    %%rax, %%rcx\n\t"
-            "%-5s   %%al\n\t"
-            "movzb  %%al, %%rax\n\t"
-            "test   %%rax, %%rax\n\t"
-            "movq   $0, %%rax\n\t"
-            "je     %s\n\t", op1, label_end->data);
-    asmExpression(cc,buf,ast->left->right);
-    asmPush(buf,REG_RAX);
-    asmExpression(cc,buf,ast->right);
-    asmPop(buf,REG_RCX);
+                   "cmp    %%rax, %%rcx\n\t"
+                   "%-5s   %%al\n\t"
+                   "movzb  %%al, %%rax\n\t"
+                   "test   %%rax, %%rax\n\t"
+                   "movq   $0, %%rax\n\t"
+                   "je     %s\n\t",
+                   op1, label_end->data);
+    asmExpression(cc, buf, ast->left->right);
+    asmPush(buf, REG_RAX);
+    asmExpression(cc, buf, ast->right);
+    asmPop(buf, REG_RCX);
     aoStrCatPrintf(buf,
-            "cmp    %%rax, %%rcx\n\t"
-            "%-5s   %%al\n\t"
-            "movzb  %%al, %%rax\n\t"
-            "test   %%rax, %%rax\n\t"
-            "movq   $0, %%rax\n\t"
-            "je     %s\n\t"
-            "movq   $1, %%rax\n"
-            "%s:\n\t",op2, label_end->data, label_end->data);
+                   "cmp    %%rax, %%rcx\n\t"
+                   "%-5s   %%al\n\t"
+                   "movzb  %%al, %%rax\n\t"
+                   "test   %%rax, %%rax\n\t"
+                   "movq   $0, %%rax\n\t"
+                   "je     %s\n\t"
+                   "movq   $1, %%rax\n"
+                   "%s:\n\t",
+                   op2, label_end->data, label_end->data);
     aoStrCatPrintf(buf, "# Range END \n\t\n\t");
 }
 
-int asmOpIsCompoundAssign(Ast *ast) {
+int asmOpIsCompoundAssign(const Ast *ast) {
     switch (ast->kind) {
     case '-':
     case '+':
@@ -948,108 +1051,118 @@ int asmOpIsCompoundAssign(Ast *ast) {
 }
 
 int asmShouldReverseMaths(Ast *RHS) {
-    return asmOpIsCompoundAssign(RHS) && 
-        RHS->right && (RHS->right->kind == AST_FUNCALL || 
-         RHS->right->kind == AST_FUNPTR_CALL ||
-         RHS->right->kind == AST_ASM_FUNCALL);
+    return asmOpIsCompoundAssign(RHS) && RHS->right &&
+            (RHS->right->kind == AST_FUNCALL ||
+             RHS->right->kind == AST_FUNPTR_CALL ||
+             RHS->right->kind == AST_ASM_FUNCALL);
 }
 
 void asmBinOpFunctionAssign(Cctrl *cc, aoStr *buf, Ast *fnptr, Ast *fn) {
     (void)cc;
     switch (fn->kind) {
-        case AST_FUNC: {
-            char *normalised = asmNormaliseFunctionName(fn->fname->data);
-            aoStrCatPrintf(buf,
-                    "leaq   %s(%%rip), %%rax\n\t"
-                    "movq    %%rax, %d(%%rbp)\n\t",
-                    normalised,
-                    fnptr->loff);
-            break;
-        }
+    case AST_FUNC: {
+        char *normalised = asmNormaliseFunctionName(fn->fname->data);
+        aoStrCatPrintf(buf,
+                       "leaq   %s(%%rip), %%rax\n\t"
+                       "movq    %%rax, %d(%%rbp)\n\t",
+                       normalised, fnptr->loff);
+        break;
+    }
 
-        case AST_FUNPTR:
-            aoStrCatPrintf(buf,
-                    "movq    %d(%%rbp), %%rax\n\t"
-                    "movq    %%rax, %d(%%rbp)\n\t",
-                    fn->loff, fnptr->loff);
-            break;
+    case AST_FUNPTR:
+        aoStrCatPrintf(buf,
+                       "movq    %d(%%rbp), %%rax\n\t"
+                       "movq    %%rax, %d(%%rbp)\n\t",
+                       fn->loff, fnptr->loff);
+        break;
 
-        case AST_ASM_FUNCDEF:
-        case AST_ASM_FUNC_BIND: {
-            aoStrCatPrintf(buf,
-                    "leaq   %s(%%rip), %%rax\n\t"
-                    "movq    %%rax, %d(%%rbp)\n\t",
-                    fn->asmfname->data,
-                    fnptr->loff);
-            break;
-        }
+    case AST_ASM_FUNCDEF:
+    case AST_ASM_FUNC_BIND: {
+        aoStrCatPrintf(buf,
+                       "leaq   %s(%%rip), %%rax\n\t"
+                       "movq    %%rax, %d(%%rbp)\n\t",
+                       fn->asmfname->data, fnptr->loff);
+        break;
+    }
 
-        default:
-            loggerPanic("Cannot assign: %s to a function pointer type\n",
+    default:
+        loggerPanic("Cannot assign: %s to a function pointer type\n",
                     astKindToString(fn->kind));
     }
 }
 
 void asmBinaryOp(Cctrl *cc, aoStr *buf, Ast *ast) {
     if (ast->kind == '=') {
-        /* If it is compound and the value is being assigned to the return of 
-         * a function we need to perform the integer arithmetic in reversed 
+        /* If it is compound and the value is being assigned to the return of
+         * a function we need to perform the integer arithmetic in reversed
          * order */
         if (asmShouldReverseMaths(ast->right)) {
-            if (ast->type->kind == AST_TYPE_INT) { 
-                asmBinaryOpIntArithmetic(cc,buf,ast->right,
-                        ASM_REVERSE_ARITHMETIC);
+            if (ast->type->kind == AST_TYPE_INT) {
+                asmBinaryOpIntArithmetic(cc, buf, ast->right,
+                                         ASM_REVERSE_ARITHMETIC);
             } else if (ast->type->kind == AST_TYPE_FLOAT) {
-                asmBinaryOpFloatArithmetic(cc,buf,ast->right,
-                        ASM_REVERSE_ARITHMETIC);
+                asmBinaryOpFloatArithmetic(cc, buf, ast->right,
+                                           ASM_REVERSE_ARITHMETIC);
             }
         } else {
-            asmExpression(cc,buf,ast->right);
+            asmExpression(cc, buf, ast->right);
         }
-        asmLoadConvert(buf,ast->type,ast->right->type);
-        asmAssign(cc,buf, ast->left);
+        asmLoadConvert(buf, ast->type, ast->right->type);
+        asmAssign(cc, buf, ast->left);
         return;
     }
 
     if (ast->type->kind == AST_TYPE_POINTER) {
-        asmPointerArithmetic(cc,buf,ast->kind,ast->left,ast->right);
+        asmPointerArithmetic(cc, buf, ast->kind, ast->left, ast->right);
         return;
     }
 
     /* This is pretty loose! */
     if (astIsRangeOperator(ast->kind) && astIsRangeOperator(ast->left->kind)) {
-        asmRangeOperation(cc,buf,ast);
+        asmRangeOperation(cc, buf, ast);
         return;
     }
 
     switch (ast->kind) {
-        case '<': asmCompare(cc,buf,"setl",ast); return;
-        case '>': asmCompare(cc,buf,"setg",ast); return;
-        case TK_EQU_EQU: asmCompare(cc,buf,"sete",ast); return;
-        case TK_GREATER_EQU: asmCompare(cc,buf,"setge",ast); return;
-        case TK_LESS_EQU: asmCompare(cc,buf,"setle",ast); return;
-        case TK_NOT_EQU: asmCompare(cc,buf,"setne",ast); return;
+    case '<':
+        asmCompare(cc, buf, "setl", ast);
+        return;
+    case '>':
+        asmCompare(cc, buf, "setg", ast);
+        return;
+    case TK_EQU_EQU:
+        asmCompare(cc, buf, "sete", ast);
+        return;
+    case TK_GREATER_EQU:
+        asmCompare(cc, buf, "setge", ast);
+        return;
+    case TK_LESS_EQU:
+        asmCompare(cc, buf, "setle", ast);
+        return;
+    case TK_NOT_EQU:
+        asmCompare(cc, buf, "setne", ast);
+        return;
     }
 
     if (ast->type->kind == AST_TYPE_INT || ast->type->kind == AST_TYPE_CHAR) {
-        asmBinaryOpIntArithmetic(cc,buf,ast,ASM_INORDER_ARITHMETIC);
+        asmBinaryOpIntArithmetic(cc, buf, ast, ASM_INORDER_ARITHMETIC);
     } else if (ast->type->kind == AST_TYPE_FLOAT) {
-        asmBinaryOpFloatArithmetic(cc,buf,ast,ASM_INORDER_ARITHMETIC);
+        asmBinaryOpFloatArithmetic(cc, buf, ast, ASM_INORDER_ARITHMETIC);
     } else if (ast->type->kind == AST_TYPE_FUNC) {
         char *fname;
         if (ast->kind == AST_ASM_FUNC_BIND) {
-            fname = strndup(ast->asmfname->data,ast->asmfname->len);
+            fname = strndup(ast->asmfname->data, ast->asmfname->len);
         } else {
             fname = asmNormaliseFunctionName(ast->fname->data);
         }
-        aoStrCatPrintf(buf,"leaq    %s(%%rip), %%rax\n\t",fname);
+        aoStrCatPrintf(buf, "leaq    %s(%%rip), %%rax\n\t", fname);
     } else {
         loggerPanic("Cannot handle>: %s\n", astToString(ast));
     }
 }
 
 void asmPreIncrDecr(Cctrl *cc, aoStr *buf, Ast *ast, char *op) {
-    asmExpression(cc,buf,ast->operand);
+    asmExpression(cc, buf, ast->operand);
     int size = 1;
     if (ast->operand->type->ptr) {
         size = ast->operand->type->ptr->size;
@@ -1058,13 +1171,13 @@ void asmPreIncrDecr(Cctrl *cc, aoStr *buf, Ast *ast, char *op) {
         /* This is essentially pointer juggling like:
          * '*++ptr' or '*--ptr' */
         aoStrCatPrintf(buf, "%s   $%d, %%rax\n\t", op, size);
-        asmAssign(cc,buf,ast->operand);
+        asmAssign(cc, buf, ast->operand);
         if (ast->operand->type->ptr) {
             aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t");
         }
     } else {
         aoStrCatPrintf(buf, "%s   $%d, %%rax\n\t", op, size);
-        asmAssign(cc,buf,ast->operand);
+        asmAssign(cc, buf, ast->operand);
         if (ast->operand->type->ptr) {
             aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t");
         }
@@ -1072,7 +1185,7 @@ void asmPreIncrDecr(Cctrl *cc, aoStr *buf, Ast *ast, char *op) {
 }
 
 void asmIncrDecr(Cctrl *cc, aoStr *buf, Ast *ast, char *op) {
-    asmExpression(cc,buf,ast->operand);
+    asmExpression(cc, buf, ast->operand);
     asmPush(buf, REG_RAX);
     int size = 1;
     if (ast->operand->type->ptr) {
@@ -1083,81 +1196,80 @@ void asmIncrDecr(Cctrl *cc, aoStr *buf, Ast *ast, char *op) {
         /* This is essentially pointer juggling like:
          * '*ptr++' or '*ptr--' */
         aoStrCatPrintf(buf, "%s   $%d, %%rax\n\t", op, size);
-        asmAssign(cc,buf,ast->operand);
+        asmAssign(cc, buf, ast->operand);
     } else {
         aoStrCatPrintf(buf, "%s   $1, %%rax\n\t", op);
-        asmAssign(cc,buf,ast->operand);
+        asmAssign(cc, buf, ast->operand);
     }
 
-    asmPop(buf,REG_RAX);
+    asmPop(buf, REG_RAX);
 }
 
 /* This function is seriouly bjorked */
 void asmAddr(Cctrl *cc, aoStr *buf, Ast *ast) {
-    aoStrCatPrintf(buf, "# ADDR %s START %s \n\t", 
-        astKindToString(ast->operand->kind), 
-        astKindToString(ast->operand->type->kind));
+    aoStrCatPrintf(buf, "# ADDR %s START %s \n\t",
+                   astKindToString(ast->operand->kind),
+                   astKindToString(ast->operand->type->kind));
 
     /* This is gross */
     switch (ast->operand->kind) {
-        case AST_LVAR: {
-            if (ast->operand->type->kind == AST_TYPE_POINTER) {
-                /* XXX: this feels extremely hacky */
-                aoStrCatPrintf(buf, "# ADDR of %s\n\t",
-                        astKindToString(ast->operand->type->ptr->kind));
-                switch (ast->operand->type->ptr->kind) {
-                    case AST_TYPE_ARRAY:
-                    case AST_TYPE_CHAR:
-                    case AST_TYPE_CLASS:
-                        aoStrCatPrintf(buf, "leaq   %d(%%rbp), %%rax\n\t",
-                                ast->operand->loff);
-                        break;
-                    default:
-                        aoStrCatPrintf(buf, "movq   %d(%%rbp), %%rax\n\t",
-                                ast->operand->loff);
-                        break;
-                }
-            } else {
+    case AST_LVAR: {
+        if (ast->operand->type->kind == AST_TYPE_POINTER) {
+            /* XXX: this feels extremely hacky */
+            aoStrCatPrintf(buf, "# ADDR of %s\n\t",
+                           astKindToString(ast->operand->type->ptr->kind));
+            switch (ast->operand->type->ptr->kind) {
+            case AST_TYPE_ARRAY:
+            case AST_TYPE_CHAR:
+            case AST_TYPE_CLASS:
                 aoStrCatPrintf(buf, "leaq   %d(%%rbp), %%rax\n\t",
-                        ast->operand->loff);
-            } 
-            break;
-        }
-        /* XXX: This does not work */
-        case AST_GVAR:
-            aoStrCatPrintf(buf, "leaq   %s(%%rip), %%rax\n\t",
-                    ast->operand->glabel->data);
-            break;
-        case AST_CLASS_REF: {
-            if (ast->operand->operand->kind == AST_LVAR ||
-                ast->operand->operand->kind == AST_DEREF)
-            {
+                               ast->operand->loff);
+                break;
+            default:
                 aoStrCatPrintf(buf, "movq   %d(%%rbp), %%rax\n\t",
-                        ast->cls->cls->operand->loff);
-                aoStrCatPrintf(buf,"addq   $%d, %%rax\n\t",ast->cls->type->offset);
-            } else {
-                loggerPanic("Cannot produce ASM for: %s %s %s %s\n",
-                    astKindToString(ast->operand->operand->kind),
-                    astTypeToString(ast->type),
-                    astTypeToString(ast->operand->type),
-                    astTypeToString(ast->cls->type));
+                               ast->operand->loff);
+                break;
             }
-            break;
+        } else {
+            aoStrCatPrintf(buf, "leaq   %d(%%rbp), %%rax\n\t",
+                           ast->operand->loff);
         }
-        case AST_DEREF: {
-            /* That is the class */
-            Ast *cls = ast->operand;
-            asmExpression(cc,buf,cls);
-            break;
-        }
-        default:
-            loggerPanic("Cannot turn Kind AST:%s %s into assembly\n",
-                    astKindToString(ast->kind),
-                    astToString(ast));
+        break;
     }
-    aoStrCatPrintf(buf, "# ADDR %s END %s \n\t", 
-        astKindToString(ast->operand->kind),
-        astKindToString(ast->operand->type->kind));
+    /* XXX: This does not work */
+    case AST_GVAR:
+        aoStrCatPrintf(buf, "leaq   %s(%%rip), %%rax\n\t",
+                       ast->operand->glabel->data);
+        break;
+    case AST_CLASS_REF: {
+        if (ast->operand->operand->kind == AST_LVAR ||
+            ast->operand->operand->kind == AST_DEREF) {
+            aoStrCatPrintf(buf, "movq   %d(%%rbp), %%rax\n\t",
+                           ast->cls->cls->operand->loff);
+            aoStrCatPrintf(buf, "addq   $%d, %%rax\n\t",
+                           ast->cls->type->offset);
+        } else {
+            loggerPanic("Cannot produce ASM for: %s %s %s %s\n",
+                        astKindToString(ast->operand->operand->kind),
+                        astTypeToString(ast->type),
+                        astTypeToString(ast->operand->type),
+                        astTypeToString(ast->cls->type));
+        }
+        break;
+    }
+    case AST_DEREF: {
+        /* That is the class */
+        Ast *cls = ast->operand;
+        asmExpression(cc, buf, cls);
+        break;
+    }
+    default:
+        loggerPanic("Cannot turn Kind AST:%s %s into assembly\n",
+                    astKindToString(ast->kind), astToString(ast));
+    }
+    aoStrCatPrintf(buf, "# ADDR %s END %s \n\t",
+                   astKindToString(ast->operand->kind),
+                   astKindToString(ast->operand->type->kind));
 }
 
 int asmPlaceArgs(Cctrl *cc, aoStr *buf, List *argv, int reverse) {
@@ -1166,21 +1278,25 @@ int asmPlaceArgs(Cctrl *cc, aoStr *buf, List *argv, int reverse) {
     if (reverse) {
         for (List *it = argv->prev; it != argv; it = it->prev) {
             ast = (Ast *)it->value;
-            asmExpression(cc,buf,ast);
-            if (astIsFloatType(ast->type)) asmPushXMM(buf,0);
-            else asmPush(buf,REG_RAX);
+            asmExpression(cc, buf, ast);
+            if (astIsFloatType(ast->type))
+                asmPushXMM(buf, 0);
+            else
+                asmPush(buf, REG_RAX);
             r += 8;
         }
     } else {
         for (List *it = argv->next; it != argv; it = it->next) {
             ast = (Ast *)it->value;
-            asmExpression(cc,buf,ast);
-            if (astIsFloatType(ast->type)) asmPushXMM(buf,0);
-            else asmPush(buf,REG_RAX);
+            asmExpression(cc, buf, ast);
+            if (astIsFloatType(ast->type))
+                asmPushXMM(buf, 0);
+            else
+                asmPush(buf, REG_RAX);
             r += 8;
         }
     }
-    return align(r,8);
+    return align(r, 8);
 }
 
 void asmPopIntArgs(aoStr *buf, List *argv) {
@@ -1193,7 +1309,7 @@ void asmPopIntArgs(aoStr *buf, List *argv) {
 void asmPopFloatArgs(aoStr *buf, List *argv) {
     int count = listCount(argv);
     for (int i = count - 1; i >= 0; --i) {
-        asmPopXMM(buf,i);
+        asmPopXMM(buf, i);
     }
 }
 
@@ -1202,16 +1318,14 @@ void asmPopFloatArgs(aoStr *buf, List *argv) {
 #define FUN_EXISTS 0x1
 #define FUN_EXTERN 0x2
 #define FUN_VARARG 0x4
-void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
-    int int_cnt,float_cnt,stack_cnt,stackoffset,needs_padding,var_arg_start,argc,
-        flags;
-    List *int_args, *float_args, *stack_args;
-    Ast *funarg; 
-    Ast *tmp, *fun, *arg, *funparam;
+void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, const Ast *funcall) {
+    int float_cnt, stack_cnt, stackoffset;
+    Ast *tmp, *funparam;
 
-    flags = 0;
-    fun = strMapGetLen(cc->global_env,funcall->fname->data,funcall->fname->len);
-    funarg = funparam = NULL;
+    int flags = 0;
+    const Ast *fun = strMapGetLen(cc->global_env, funcall->fname->data,
+                                  funcall->fname->len);
+    Ast *funarg = funparam = NULL;
 
     /* This should exist on the AST */
     if (fun) {
@@ -1224,15 +1338,15 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
         }
     }
 
-    /* Extern functions with variable argument lengths need to be 
+    /* Extern functions with variable argument lengths need to be
      * interoperable with c */
 
-    var_arg_start = -1;
-    argc = 0;
-    if (flags & (FUN_EXISTS|FUN_VARARG) && !(flags & FUN_EXTERN)) {
+    int var_arg_start = -1;
+    int argc = 0;
+    if (flags & (FUN_EXISTS | FUN_VARARG) && !(flags & FUN_EXTERN)) {
         for (ssize_t i = 0; i < fun->params->size; ++i) {
             var_arg_start++;
-            arg = fun->params->entries[i];
+            const Ast *arg = fun->params->entries[i];
             if (arg->kind == AST_VAR_ARGS) {
                 break;
             }
@@ -1240,11 +1354,11 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
         var_arg_start += 1;
     }
 
-    int_cnt = float_cnt = stack_cnt = stackoffset = 0;
-    
-    int_args = listNew();
-    float_args = listNew();
-    stack_args = listNew();
+    int int_cnt = float_cnt = stack_cnt = stackoffset = 0;
+
+    List *int_args = listNew();
+    List *float_args = listNew();
+    List *stack_args = listNew();
 
     funarg = NULL;
     ssize_t i = 0;
@@ -1252,18 +1366,19 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
         /* Handling the case for either more arguments than parameters or
          * more parameters than arguments */
         if (fun && fun->params) {
-            funparam = vecGetInBounds(fun->params,i);
+            funparam = vecGetInBounds(fun->params, i);
         }
-        funarg = vecGetInBounds(funcall->args,i);
+        funarg = vecGetInBounds(funcall->args, i);
         i++;
 
         if (funarg != NULL) {
             tmp = funarg;
             if (tmp->kind == AST_PLACEHOLDER) {
-                loggerDebug("place holder: %s\n",astToString(funparam));
+                loggerDebug("place holder: %s\n", astToString(funparam));
                 tmp = funparam->declinit;
                 if (tmp == NULL) {
-                    loggerPanic("Default parameter not provided for function call: %s()\n",
+                    loggerPanic(
+                            "Default parameter not provided for function call: %s()\n",
                             funcall->fname->data);
                 }
             }
@@ -1280,45 +1395,42 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
             break;
         }
 
-        if (tmp == NULL) break;
+        if (tmp == NULL)
+            break;
 
         /**
          * @SystemV - this below is incompatible
          * our var args are all placed on the stack after 'argc' */
-        if (flags & FUN_VARARG && 
-            !(flags & FUN_EXTERN) && 
-            var_arg_start == argc)
-        {
-            listAppend(stack_args,tmp);
+        if (flags & FUN_VARARG && !(flags & FUN_EXTERN) &&
+            var_arg_start == argc) {
+            listAppend(stack_args, tmp);
             stack_cnt++;
         } else if (astIsFloatType(tmp->type)) {
             argc++;
             if (float_cnt < 8) {
-                listAppend(float_args,tmp);
+                listAppend(float_args, tmp);
                 float_cnt++;
-            }
-            else {
-                listAppend(stack_args,tmp);
+            } else {
+                listAppend(stack_args, tmp);
                 stack_cnt++;
             }
         } else {
             argc++;
             if (int_cnt < 6) {
-                listAppend(int_args,tmp);
+                listAppend(int_args, tmp);
                 int_cnt++;
-            }
-            else {
-                listAppend(stack_args,tmp);
+            } else {
+                listAppend(stack_args, tmp);
                 stack_cnt++;
             }
         }
-        
     }
 
     stack_cnt *= 8;
     aoStrCatPrintf(buf, "# %s(s: %d, i:%d f:%d) sp: %d\n\t",
-            funcall->fname->data,stack_cnt,int_cnt*8,float_cnt*8,stack_pointer);
-    needs_padding = (stack_cnt+stack_pointer) %16;
+                   funcall->fname->data, stack_cnt, int_cnt * 8, float_cnt * 8,
+                   stack_pointer);
+    int needs_padding = (stack_cnt + stack_pointer) % 16;
 
     if (needs_padding) {
         aoStrCatPrintf(buf, "subq   $%d, %%rsp #stack pad\n\t", 8);
@@ -1327,28 +1439,28 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
 
     if (funcall->kind == AST_FUNPTR_CALL) {
         switch (funcall->ref->kind) {
-            case AST_CLASS_REF:
-                asmLoadClassRef(cc,buf,funcall->ref->cls,funcall->ref->type,0);
-                break;
+        case AST_CLASS_REF:
+            asmLoadClassRef(cc, buf, funcall->ref->cls, funcall->ref->type, 0);
+            break;
 
-            case AST_FUNPTR:
-            case AST_LVAR:
-                asmLLoad(buf,funcall->ref->type,funcall->ref->loff);
-                break;
+        case AST_FUNPTR:
+        case AST_LVAR:
+            asmLLoad(buf, funcall->ref->type, funcall->ref->loff);
+            break;
 
-            case AST_GVAR:
-                asmGLoad(buf,funcall->ref->type,funcall->ref->gname,0);
-                break;
+        case AST_GVAR:
+            asmGLoad(buf, funcall->ref->type, funcall->ref->gname, 0);
+            break;
         }
-        aoStrCatPrintf(buf,"movq    %%rax,%%r11\n\t");
+        aoStrCatPrintf(buf, "movq    %%rax,%%r11\n\t");
     }
 
-    stackoffset = asmPlaceArgs(cc,buf,stack_args,1);
-    asmPlaceArgs(cc,buf,int_args,0);
-    asmPlaceArgs(cc,buf,float_args,0);
+    asmPlaceArgs(cc, buf, stack_args, 1);
+    asmPlaceArgs(cc, buf, int_args, 0);
+    asmPlaceArgs(cc, buf, float_args, 0);
 
-    asmPopFloatArgs(buf,float_args);
-    asmPopIntArgs(buf,int_args);
+    asmPopFloatArgs(buf, float_args);
+    asmPopIntArgs(buf, int_args);
 
     if (float_cnt) {
         aoStrCatPrintf(buf, "movl   $%d, %%eax\n\t", float_cnt);
@@ -1376,38 +1488,40 @@ void asmPrepFuncCallArgs(Cctrl *cc, aoStr *buf, Ast *funcall) {
         stack_pointer -= 8;
     }
 
-    listRelease(int_args,NULL);
-    listRelease(float_args,NULL);
-    listRelease(stack_args,NULL);
+    listRelease(int_args, NULL);
+    listRelease(float_args, NULL);
+    listRelease(stack_args, NULL);
 }
 
 /* Function call for ASM, PTR and normal functions */
-void asmFunCall(Cctrl *cc, aoStr *buf, Ast *ast) {
-    asmPrepFuncCallArgs(cc,buf,ast);
+void asmFunCall(Cctrl *cc, aoStr *buf, const Ast *ast) {
+    asmPrepFuncCallArgs(cc, buf, ast);
 }
 
-/* This is also used for initalising classes as they are treated much in the 
+/* This is also used for initalising classes as they are treated much in the
  * same way as arrays */
-void asmArrayInit(Cctrl *cc, aoStr *buf, Ast *ast, AstType *type, int offset) {
+void asmArrayInit(Cctrl *cc, aoStr *buf, const Ast *ast, AstType *type,
+                  int offset) {
     listForEach(ast->arrayinit) {
         Ast *tmp = (Ast *)it->value;
         if (tmp->kind == AST_ARRAY_INIT) {
-            asmArrayInit(cc,buf,tmp,type->ptr,offset);
+            asmArrayInit(cc, buf, tmp, type->ptr, offset);
             offset += type->ptr->size;
             continue;
         }
 
         if (tmp->kind == AST_STRING) {
-            aoStrCatPrintf(buf,"leaq    %s(%%rip), %%rax\n\t",tmp->slabel->data);
-            aoStrCatPrintf(buf,"movq    %%rax, %d(%%rbp)\n\t",offset);
+            aoStrCatPrintf(buf, "leaq    %s(%%rip), %%rax\n\t",
+                           tmp->slabel->data);
+            aoStrCatPrintf(buf, "movq    %%rax, %d(%%rbp)\n\t", offset);
             offset += 8;
         } else {
             asmExpression(cc, buf, tmp);
             if (type->ptr) {
-                asmLSave(buf,type->ptr,offset);
+                asmLSave(buf, type->ptr, offset);
                 offset += type->ptr->size;
             } else {
-                asmLSave(buf,tmp->type,offset);
+                asmLSave(buf, tmp->type, offset);
                 offset += tmp->type->size;
             }
         }
@@ -1419,83 +1533,81 @@ void asmHandleSwitch(Cctrl *cc, aoStr *buf, Ast *ast) {
     PtrVec *cases = ast->cases;
     Ast **jump_table = ast->jump_table_order;
     int jump_table_size = cases->size;
-    Ast *case_ast_min = jump_table[0];
-    Ast *case_ast_max = jump_table[jump_table_size - 1];
+    const Ast *case_ast_min = jump_table[0];
+    const Ast *case_ast_max = jump_table[jump_table_size - 1];
 
     int case_min = case_ast_min->case_begin;
     int case_max = case_ast_max->case_end;
     int case_normalised_end = case_max - case_min;
 
-    /* we need to work off the assumption that RAX is containing the evaluated 
+    /* we need to work off the assumption that RAX is containing the evaluated
      * expression from cond */
-    asmExpression(cc,buf,ast->switch_cond);
+    asmExpression(cc, buf, ast->switch_cond);
 
     aoStr *end_label;
     aoStr *jump_table_start = astMakeLabel();
 
-    if (ast->case_default) end_label = ast->case_default->case_label;
-    else                   end_label = ast->case_end_label;
+    if (ast->case_default)
+        end_label = ast->case_default->case_label;
+    else
+        end_label = ast->case_end_label;
 
     /* Normalise RAX */
     aoStrCatPrintf(buf,
-            "# Switch \n\t"
-            "sub   $%d, %%rax\n\t",case_min);
+                   "# Switch \n\t"
+                   "sub   $%d, %%rax\n\t",
+                   case_min);
 
     /* Preample for jump table */
     if (ast->switch_bounds_checked) {
         aoStrCatPrintf(buf,
-                "# bounds check \n\t"
-                "cmp   $%d, %%rax\n\t"
-                "ja    %s\n\t",
-                case_normalised_end,
-                end_label->data);
+                       "# bounds check \n\t"
+                       "cmp   $%d, %%rax\n\t"
+                       "ja    %s\n\t",
+                       case_normalised_end, end_label->data);
     }
-    aoStrCatPrintf(
-            buf,
-            "leaq  %s(%%rip), %%rdx\n\t"
-            "movl  (%%rdx,%%rax,4), %%eax\n\t"
-            "add   %%rdx, %%rax\n\t"
-            "jmp   *%%rax\n"
-            "\n\t.p2align 2\n"
-            "%s:\n\t"
-            "# Jump Table\n\t",
-            jump_table_start->data, jump_table_start->data);
+    aoStrCatPrintf(buf,
+                   "leaq  %s(%%rip), %%rdx\n\t"
+                   "movl  (%%rdx,%%rax,4), %%eax\n\t"
+                   "add   %%rdx, %%rax\n\t"
+                   "jmp   *%%rax\n"
+                   "\n\t.p2align 2\n"
+                   "%s:\n\t"
+                   "# Jump Table\n\t",
+                   jump_table_start->data, jump_table_start->data);
 
     int cur_case = 0;
     for (int i = 0; i <= case_normalised_end; ++i) {
         Ast *_case = jump_table[cur_case];
-        int case_begin_normalised     = _case->case_begin - case_min;
+        int case_begin_normalised = _case->case_begin - case_min;
         int case_normalised_range_end = _case->case_end - case_min;
-        int diff                      = case_normalised_range_end - case_begin_normalised;
+        int diff = case_normalised_range_end - case_begin_normalised;
 
         /* pad out the table */
         for (; i < case_begin_normalised; ++i) {
-            aoStrCatPrintf(buf, ".long %s-%s\n\t",
-                    end_label->data,
-                    jump_table_start->data);
+            aoStrCatPrintf(buf, ".long %s-%s\n\t", end_label->data,
+                           jump_table_start->data);
         }
 
-        for (int j = case_begin_normalised; j <= case_normalised_range_end; ++j) {
-            aoStrCatPrintf(buf, ".long %s-%s\n\t",
-                    _case->case_label->data,
-                    jump_table_start->data);
+        for (int j = case_begin_normalised; j <= case_normalised_range_end;
+             ++j) {
+            aoStrCatPrintf(buf, ".long %s-%s\n\t", _case->case_label->data,
+                           jump_table_start->data);
         }
 
         i += diff;
         cur_case++;
     }
-    aoStrCatPrintf(buf,".long %s-%s\n\t",
-            end_label->data,
-            jump_table_start->data);
-
+    aoStrCatPrintf(buf, ".long %s-%s\n\t", end_label->data,
+                   jump_table_start->data);
 
     for (int i = 0; i < cases->size; ++i) {
         Ast *_case = cases->entries[i];
-        asmExpression(cc,buf,_case);
+        asmExpression(cc, buf, _case);
     }
 
     if (ast->case_default) {
-        asmExpression(cc,buf,ast->case_default);
+        asmExpression(cc, buf, ast->case_default);
     }
 
     asmRemovePreviousTab(buf);
@@ -1503,7 +1615,7 @@ void asmHandleSwitch(Cctrl *cc, aoStr *buf, Ast *ast) {
 }
 
 void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
-    aoStr *label_begin, *label_end;
+    aoStr *label_end;
 
     switch (ast->kind) {
     case AST_LITERAL: {
@@ -1514,7 +1626,7 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
                 aoStrCatPrintf(buf, "movq   $%lld, %%rax\n\t", ast->i64);
             } else if (!ast->type->issigned) {
                 aoStrCatPrintf(buf, "movq   $%lu, %%rax\n\t",
-                        (unsigned long)ast->i64);
+                               (unsigned long)ast->i64);
             }
             break;
         case AST_TYPE_FLOAT: {
@@ -1527,17 +1639,18 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
                 f64_label = ast->f64_label->data;
                 double f = ast->f64;
                 asmRemovePreviousTab(buf);
-                aoStrCatPrintf(buf, ".data\n %s:\n\t"
-                                    ".quad 0x%lX #%.9f\n"
-                                    ".text\n\t",f64_label,
-                                    ieee754(f),f);
+                aoStrCatPrintf(buf,
+                               ".data\n %s:\n\t"
+                               ".quad 0x%lX #%.9f\n"
+                               ".text\n\t",
+                               f64_label, ieee754(f), f);
             }
             aoStrCatPrintf(buf, "movsd    %s(%%rip), %%xmm0\n\t", f64_label);
             break;
         }
         default:
             loggerPanic("Unknown literal type: %s\n",
-                    astKindToString(ast->kind));
+                        astKindToString(ast->kind));
         }
         break;
     }
@@ -1545,44 +1658,45 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
     case AST_STRING:
         aoStrCatPrintf(buf, "leaq   %s(%%rip), %%rax\n\t", ast->slabel->data);
         break;
-    
+
     case AST_LVAR:
-        asmLLoad(buf,ast->type,ast->loff);
+        asmLLoad(buf, ast->type, ast->loff);
         break;
-    
+
     case AST_GVAR:
-        asmGLoad(buf,ast->type,ast->glabel,0);
+        asmGLoad(buf, ast->type, ast->glabel, 0);
         break;
 
     case AST_FUNPTR_CALL:
     case AST_ASM_FUNCALL:
     case AST_FUNCALL: {
-        asmFunCall(cc,buf,ast);
+        asmFunCall(cc, buf, ast);
         break;
     }
 
     case AST_DEFAULT_PARAM:
-        asmExpression(cc,buf,ast->declvar);
+        asmExpression(cc, buf, ast->declvar);
         break;
-    
+
     case AST_DECL: {
         if (!ast->declinit) {
             return;
         }
 
         if (ast->declinit->kind == AST_ARRAY_INIT) {
-            asmArrayInit(cc,buf,ast->declinit,ast->declvar->type,ast->declvar->loff);
+            asmArrayInit(cc, buf, ast->declinit, ast->declvar->type,
+                         ast->declvar->loff);
         } else if (ast->declvar->type->kind == AST_TYPE_ARRAY) {
             assert(ast->declinit->kind == AST_STRING);
-            asmPlaceString(buf,ast->declinit->sval,ast->declvar->loff);
+            asmPlaceString(buf, ast->declinit->sval, ast->declvar->loff);
         } else if (ast->declinit->kind == AST_STRING) {
             asmGLoad(buf, ast->declinit->type, ast->declinit->slabel, 0);
             asmLSave(buf, ast->declvar->type, ast->declvar->loff);
         } else if (ast->declinit->kind == AST_FUNC) {
-            asmBinOpFunctionAssign(cc,buf,ast->declvar,ast->declinit);
+            asmBinOpFunctionAssign(cc, buf, ast->declvar, ast->declinit);
         } else {
-            asmExpression(cc,buf, ast->declinit);
-            asmCast(buf,ast->declinit->type, ast->declvar->type);
+            asmExpression(cc, buf, ast->declinit);
+            asmCast(buf, ast->declinit->type, ast->declvar->type);
             asmLSave(buf, ast->declvar->type, ast->declvar->loff);
         }
         return;
@@ -1593,89 +1707,94 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
         break;
 
     case AST_ADDR:
-        asmAddr(cc,buf,ast);
+        asmAddr(cc, buf, ast);
         break;
 
     case AST_CAST:
-        asmTypeCast(cc,buf,ast);
+        asmTypeCast(cc, buf, ast);
         break;
 
     case AST_DEREF: {
         assert(ast->operand->type->kind == AST_TYPE_POINTER);
-        asmExpression(cc,buf,ast->operand);
+        asmExpression(cc, buf, ast->operand);
 
-        AstType *op_type =  ast->operand->type;
-        AstType *result = ast->type;
-        char *reg;
-    
+        const AstType *op_type = ast->operand->type;
+        const AstType *result = ast->type;
+
         if (op_type->kind == AST_TYPE_POINTER &&
-                op_type->ptr->kind == AST_TYPE_ARRAY) {
+            op_type->ptr->kind == AST_TYPE_ARRAY) {
             return;
         }
 
+        char *reg = "rcx"; // asmGetIntReg(result,'c');
 
-        reg = "rcx"; // asmGetIntReg(result,'c');
-
-        aoStrCatPrintf(buf, "##__DEREF_START: %s\n\t", astKindToString(result->kind));
+        aoStrCatPrintf(buf, "##__DEREF_START: %s\n\t",
+                       astKindToString(result->kind));
         if (result->size < 4) {
-            aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t"
-                                "movzbl (%%%s), %%eax\n\t"
-                                "movsbl  %%al, %%eax\n\t", reg); 
+            aoStrCatPrintf(buf,
+                           "movq   %%rax, %%rcx\n\t"
+                           "movzbl (%%%s), %%eax\n\t"
+                           "movsbl  %%al, %%eax\n\t",
+                           reg);
         } else {
             if (result->kind == AST_ADDR) {
-                aoStrCatPrintf(buf,"movq   %%%s, %%rax\n\t", reg);
+                aoStrCatPrintf(buf, "movq   %%%s, %%rax\n\t", reg);
             } else if (result->kind == AST_TYPE_CLASS) {
-                aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t"
-                        "leaq (%%%s), %%rax\n\t", reg);
+                aoStrCatPrintf(buf,
+                               "movq   %%rax, %%rcx\n\t"
+                               "leaq (%%%s), %%rax\n\t",
+                               reg);
             } else if (result->kind != AST_TYPE_POINTER) {
-                aoStrCatPrintf(buf,"# deref not ptr start: %s %s\n\t",
-                        astKindToString(result->kind), astKindToString(op_type->kind));
-               // aoStrCatPrintf(buf,"movq   (%%%s), %%rax\n\t", reg);
-               
+                aoStrCatPrintf(buf, "# deref not ptr start: %s %s\n\t",
+                               astKindToString(result->kind),
+                               astKindToString(op_type->kind));
+                // aoStrCatPrintf(buf,"movq   (%%%s), %%rax\n\t", reg);
 
                 if (result->kind == AST_TYPE_FLOAT) {
                     aoStrCatPrintf(buf, "movq   (%%rax), %%xmm0\n\t");
                 } else {
                     // reg = asmGetIntReg(result,'c');
                     char *mov = asmGetPtrMove(result);
-                    aoStrCatPrintf(buf, "movq   %%rax, %%rcx\n\t"
-                                        "%s   (%%%s), %%rax\n\t",mov, reg);
+                    aoStrCatPrintf(buf,
+                                   "movq   %%rax, %%rcx\n\t"
+                                   "%s   (%%%s), %%rax\n\t",
+                                   mov, reg);
                 }
-                aoStrCatPrintf(buf,"# deref not ptr start\n\t");
-            } else if (result->kind == AST_TYPE_POINTER) {
-                reg = asmGetIntReg(result,'a');
+                aoStrCatPrintf(buf, "# deref not ptr start\n\t");
+            } else {
+                reg = asmGetIntReg(result, 'a');
                 char *mov = asmGetMov(result);
                 switch (result->ptr->kind) {
-                    case AST_TYPE_CHAR:
-                        aoStrCatPrintf(buf,"# deref char start\n\t");
-                        aoStrCatPrintf(buf,"%s   (%%%s), %%rax\n\t",mov, reg);
-                        aoStrCatPrintf(buf,"# deref char end\n\t");
-                        break;
-                    case AST_TYPE_INT:
-                        aoStrCatPrintf(buf,"# deref int start\n\t");
-                        aoStrCatPrintf(buf,"leaq   (%%%s), %%rax\n\t", reg);
-                        aoStrCatPrintf(buf,"# deref int end\n\t");
-                        break;
-                    case AST_TYPE_POINTER:
-                        aoStrCatPrintf(buf,"# deref ptr start\n\t");
-                        aoStrCatPrintf(buf,"movq   %%%s, %%rax\n\t", reg);
-                        aoStrCatPrintf(buf,"# deref ptr end\n\t");
-                        break;
-                    /* We want to derefernce a 'U0**' ptr */
-                    case AST_TYPE_VOID:
-                    case AST_TYPE_CLASS:
-                        aoStrCatPrintf(buf,"# deref class start\n\t");
-                        aoStrCatPrintf(buf,"movq   (%%%s), %%rax\n\t", reg);
-                        aoStrCatPrintf(buf,"# deref class end\n\t");
-                        break;
-                    default:
-                        /*XXX: Does dereferencing a class make sense? 
-                         * It seg faults usually */
-                        if (ast->cls->cls->kind == AST_CLASS_REF) {
-                            aoStrCatPrintf(buf,"# problematic class deref\n\t");
-                            aoStrCatPrintf(buf,"movq   (%%%s), %%rax\n\t", reg);
-                        }
-                        break;
+                case AST_TYPE_CHAR:
+                    aoStrCatPrintf(buf, "# deref char start\n\t");
+                    aoStrCatPrintf(buf, "%s   (%%%s), %%rax\n\t", mov, reg);
+                    aoStrCatPrintf(buf, "# deref char end\n\t");
+                    break;
+                case AST_TYPE_INT:
+                    aoStrCatPrintf(buf, "# deref int start\n\t");
+                    aoStrCatPrintf(buf, "leaq   (%%%s), %%rax\n\t", reg);
+                    aoStrCatPrintf(buf, "# deref int end\n\t");
+                    break;
+                case AST_TYPE_POINTER:
+                    aoStrCatPrintf(buf, "# deref ptr start\n\t");
+                    aoStrCatPrintf(buf, "movq   %%%s, %%rax\n\t", reg);
+                    aoStrCatPrintf(buf, "# deref ptr end\n\t");
+                    break;
+                /* We want to derefernce a 'U0**' ptr */
+                case AST_TYPE_VOID:
+                case AST_TYPE_CLASS:
+                    aoStrCatPrintf(buf, "# deref class start\n\t");
+                    aoStrCatPrintf(buf, "movq   (%%%s), %%rax\n\t", reg);
+                    aoStrCatPrintf(buf, "# deref class end\n\t");
+                    break;
+                default:
+                    /*XXX: Does dereferencing a class make sense?
+                     * It seg faults usually */
+                    if (ast->cls->cls->kind == AST_CLASS_REF) {
+                        aoStrCatPrintf(buf, "# problematic class deref\n\t");
+                        aoStrCatPrintf(buf, "movq   (%%%s), %%rax\n\t", reg);
+                    }
+                    break;
                 }
             }
         }
@@ -1684,20 +1803,20 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
     }
 
     case AST_IF: {
-        asmExpression(cc,buf,ast->cond);
-        label_begin = astMakeLabel();
+        asmExpression(cc, buf, ast->cond);
+        const aoStr *label_begin = astMakeLabel();
         aoStrCatPrintf(buf,
-                "test   %%rax, %%rax\n\t"
-                "je     %s\n\t", label_begin->data);
-        asmExpression(cc,buf,ast->then);
+                       "test   %%rax, %%rax\n\t"
+                       "je     %s\n\t",
+                       label_begin->data);
+        asmExpression(cc, buf, ast->then);
         if (ast->els) {
             label_end = astMakeLabel();
             aoStrCatPrintf(buf,
-                    "jmp    %s\n"
-                    "%s:\n\t"
-                    ,label_end->data,
-                    label_begin->data);
-            asmExpression(cc,buf,ast->els);
+                           "jmp    %s\n"
+                           "%s:\n\t",
+                           label_end->data, label_begin->data);
+            asmExpression(cc, buf, ast->els);
             asmRemovePreviousTab(buf);
             aoStrCatPrintf(buf, "%s:\n\t", label_end->data);
         } else {
@@ -1708,8 +1827,8 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
     }
 
     case AST_JUMP:
-         aoStrCatPrintf(buf, "jmp    %s\n\t", ast->jump_label->data);
-         break;
+        aoStrCatPrintf(buf, "jmp    %s\n\t", ast->jump_label->data);
+        break;
 
     case AST_GOTO:
     case AST_BREAK:
@@ -1730,38 +1849,36 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
         asmRemovePreviousTab(buf);
         aoStrCatPrintf(buf, "%s:\n\t", ast->while_begin->data);
         if (ast->whilebody) {
-            asmExpression(cc,buf, ast->whilebody);
+            asmExpression(cc, buf, ast->whilebody);
         }
-        asmExpression(cc,buf,ast->whilecond);
+        asmExpression(cc, buf, ast->whilecond);
         aoStrCatPrintf(buf,
-                "test   %%rax, %%rax\n\t"
-                "je     %s\n\t",
-                ast->while_end->data);
+                       "test   %%rax, %%rax\n\t"
+                       "je     %s\n\t",
+                       ast->while_end->data);
 
         aoStrCatPrintf(buf,
-                "jmp    %s\n"
-                "%s:\n\t"
-                ,ast->while_begin->data,
-                ast->while_end->data);
+                       "jmp    %s\n"
+                       "%s:\n\t",
+                       ast->while_begin->data, ast->while_end->data);
         break;
     }
 
     case AST_WHILE: {
         asmRemovePreviousTab(buf);
         aoStrCatPrintf(buf, "%s:\n\t", ast->while_begin->data);
-        asmExpression(cc,buf,ast->whilecond);
+        asmExpression(cc, buf, ast->whilecond);
         aoStrCatPrintf(buf,
-                "test   %%rax, %%rax\n\t"
-                "je     %s\n\t",
-                ast->while_end->data);
+                       "test   %%rax, %%rax\n\t"
+                       "je     %s\n\t",
+                       ast->while_end->data);
         if (ast->whilebody) {
-            asmExpression(cc,buf, ast->whilebody);
+            asmExpression(cc, buf, ast->whilebody);
         }
         aoStrCatPrintf(buf,
-                "jmp    %s\n"
-                "%s:\n\t"
-                ,ast->while_begin->data,
-                ast->while_end->data);
+                       "jmp    %s\n"
+                       "%s:\n\t",
+                       ast->while_begin->data, ast->while_end->data);
         break;
     }
 
@@ -1771,250 +1888,258 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
             break;
         }
         if (ast->forinit) {
-            asmExpression(cc,buf,ast->forinit);
+            asmExpression(cc, buf, ast->forinit);
         }
 
         asmRemovePreviousTab(buf);
         aoStrCatPrintf(buf, "%s:\n\t", ast->for_begin->data);
 
         if (ast->forcond) {
-            asmExpression(cc,buf,ast->forcond);
+            asmExpression(cc, buf, ast->forcond);
             aoStrCatPrintf(buf,
-                    "test   %%rax, %%rax\n\t"
-                    "je     %s\n\t",
-                    ast->for_end->data);
+                           "test   %%rax, %%rax\n\t"
+                           "je     %s\n\t",
+                           ast->for_end->data);
         }
 
-        asmExpression(cc,buf, ast->forbody);
+        asmExpression(cc, buf, ast->forbody);
 
         /* To help with continue statements */
         asmRemovePreviousTab(buf);
         aoStrCatPrintf(buf, "%s:\n\t", ast->for_middle->data);
 
         if (ast->forstep) {
-            asmExpression(cc,buf,ast->forstep);
+            asmExpression(cc, buf, ast->forstep);
         }
 
         aoStrCatPrintf(buf,
-                "jmp    %s\n"
-                "%s:\n\t"
-                ,ast->for_begin->data,
-                ast->for_end->data);
+                       "jmp    %s\n"
+                       "%s:\n\t",
+                       ast->for_begin->data, ast->for_end->data);
         break;
     }
-    
+
     case AST_RETURN:
         if (ast->retval == NULL) {
             aoStrCatPrintf(buf, "leave\n\tret\n");
             break;
         }
-        asmExpression(cc,buf, ast->retval);
-        asmSaveConvert(buf,ast->type,ast->retval->type);
+        asmExpression(cc, buf, ast->retval);
+        asmSaveConvert(buf, ast->type, ast->retval->type);
         aoStrCatPrintf(buf, "leave\n\tret\n");
         break;
 
     case AST_COMPOUND_STMT:
         listForEach(ast->stms) {
-            asmExpression(cc,buf,(Ast *)it->value);
+            asmExpression(cc, buf, (Ast *)it->value);
         }
         break;
 
     case AST_CLASS_REF:
-        asmLoadClassRef(cc,buf,ast->cls,ast->type,0);
+        asmLoadClassRef(cc, buf, ast->cls, ast->type, 0);
         break;
 
     case AST_DEFAULT:
         asmRemovePreviousTab(buf);
         aoStrCatPrintf(buf, "%s: #default_label \n\t", ast->case_label->data);
         listForEach(ast->case_asts) {
-            asmExpression(cc,buf,(Ast *)it->value);
+            asmExpression(cc, buf, (Ast *)it->value);
         }
         break;
 
     case AST_CASE:
         asmRemovePreviousTab(buf);
 
-        if (listEmpty(ast->case_asts) || ast->case_asts == NULL) return;
+        if (listEmpty(ast->case_asts) || ast->case_asts == NULL)
+            return;
         aoStrCatPrintf(buf, "%s: #case_label \n\t", ast->case_label->data);
 
         listForEach(ast->case_asts) {
-            asmExpression(cc,buf,(Ast *)it->value);
+            asmExpression(cc, buf, (Ast *)it->value);
         }
         break;
 
     case AST_SWITCH:
-        asmHandleSwitch(cc,buf,ast);
+        asmHandleSwitch(cc, buf, ast);
         break;
 
     case TK_PRE_PLUS_PLUS: {
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->operand);
+            asmExpression(cc, buf, ast->operand);
             aoStrCatPrintf(buf,
-                    "movsd   one_dbl(%%rip), %%xmm1\n\t"
-                    "addsd   %%xmm1, %%xmm0\n\t");
-            asmAssign(cc,buf,ast->operand);
+                           "movsd   one_dbl(%%rip), %%xmm1\n\t"
+                           "addsd   %%xmm1, %%xmm0\n\t");
+            asmAssign(cc, buf, ast->operand);
         } else {
-            asmPreIncrDecr(cc,buf,ast,"addq");
+            asmPreIncrDecr(cc, buf, ast, "addq");
         }
         break;
-     }
+    }
 
     case TK_PLUS_PLUS: {
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->operand);
-            asmPushXMM(buf,0);
+            asmExpression(cc, buf, ast->operand);
+            asmPushXMM(buf, 0);
             aoStrCatPrintf(buf,
-                    "movsd   one_dbl(%%rip), %%xmm1\n\t"
-                    "addsd   %%xmm1, %%xmm0\n\t");
-            asmAssign(cc,buf,ast->operand);
-            asmPopXMM(buf,0);
+                           "movsd   one_dbl(%%rip), %%xmm1\n\t"
+                           "addsd   %%xmm1, %%xmm0\n\t");
+            asmAssign(cc, buf, ast->operand);
+            asmPopXMM(buf, 0);
         } else {
-            asmIncrDecr(cc,buf,ast,"addq");
+            asmIncrDecr(cc, buf, ast, "addq");
         }
         break;
     }
 
     case TK_PRE_MINUS_MINUS:
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->operand);
+            asmExpression(cc, buf, ast->operand);
             aoStrCatPrintf(buf,
-                    "movsd   one_dbl(%%rip), %%xmm1\n\t"
-                    "subsd   %%xmm1, %%xmm0\n\t");
-            asmAssign(cc,buf,ast->operand);
+                           "movsd   one_dbl(%%rip), %%xmm1\n\t"
+                           "subsd   %%xmm1, %%xmm0\n\t");
+            asmAssign(cc, buf, ast->operand);
         } else {
-            asmPreIncrDecr(cc,buf,ast,"subq");
+            asmPreIncrDecr(cc, buf, ast, "subq");
         }
         break;
 
     case TK_MINUS_MINUS:
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->operand);
-            asmPushXMM(buf,0);
+            asmExpression(cc, buf, ast->operand);
+            asmPushXMM(buf, 0);
             aoStrCatPrintf(buf,
-                    "movsd   one_dbl(%%rip), %%xmm1\n\t"
-                    "subsd   %%xmm1, %%xmm0\n\t");
-            asmAssign(cc,buf,ast->operand);
-            asmPopXMM(buf,0);
+                           "movsd   one_dbl(%%rip), %%xmm1\n\t"
+                           "subsd   %%xmm1, %%xmm0\n\t");
+            asmAssign(cc, buf, ast->operand);
+            asmPopXMM(buf, 0);
         } else {
-            asmIncrDecr(cc,buf,ast,"subq");
+            asmIncrDecr(cc, buf, ast, "subq");
         }
         break;
 
     case '!': {
-        asmExpression(cc,buf, ast->operand);
+        asmExpression(cc, buf, ast->operand);
         aoStrCatPrintf(buf,
-                "cmp    $0, %%rax\n\t"
-                "sete   %%al\n\t"
-                "movzb  %%al, %%rax\n\t");
+                       "cmp    $0, %%rax\n\t"
+                       "sete   %%al\n\t"
+                       "movzb  %%al, %%rax\n\t");
         break;
     }
 
     case '~': {
-        asmExpression(cc,buf, ast->operand);
+        asmExpression(cc, buf, ast->operand);
         aoStrCatPrintf(buf, "not    %%rax\n\t");
         break;
     }
 
     case TK_OR_OR: {
-        aoStrCat(buf,"# OR OR Start\n\t");
+        aoStrCat(buf, "# OR OR Start\n\t");
         label_end = astMakeLabel();
-        asmExpression(cc,buf,ast->left);
+        asmExpression(cc, buf, ast->left);
 
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->left);
+            asmExpression(cc, buf, ast->left);
             aoStrCatPrintf(buf,
-                    "xorpd   %%xmm1, %%xmm1\n\t"
-                    "ucomisd %%xmm1, %%xmm0\n\t"
-                    "movq    $1, %%rax\n\t"
-                    "jne     %s\n\t", label_end->data);
-            asmExpression(cc,buf,ast->right);
+                           "xorpd   %%xmm1, %%xmm1\n\t"
+                           "ucomisd %%xmm1, %%xmm0\n\t"
+                           "movq    $1, %%rax\n\t"
+                           "jne     %s\n\t",
+                           label_end->data);
+            asmExpression(cc, buf, ast->right);
             aoStrCatPrintf(buf,
-                    "xorpd   %%xmm1, %%xmm1\n\t"
-                    "ucomisd %%xmm1, %%xmm0\n\t"
-                    "movq    $1, %%rax\n\t"
-                    "jne     %s\n\t"
-                    "movq    $0, %%rax\n\t"
-                    "%s:\n\t", label_end->data, label_end->data);
+                           "xorpd   %%xmm1, %%xmm1\n\t"
+                           "ucomisd %%xmm1, %%xmm0\n\t"
+                           "movq    $1, %%rax\n\t"
+                           "jne     %s\n\t"
+                           "movq    $0, %%rax\n\t"
+                           "%s:\n\t",
+                           label_end->data, label_end->data);
         } else {
             aoStrCatPrintf(buf,
-                    "test   %%rax, %%rax\n\t"
-                    "movq   $1, %%rax\n\t"
-                    "jne    %s\n\t", label_end->data);
-            asmExpression(cc,buf,ast->right);
+                           "test   %%rax, %%rax\n\t"
+                           "movq   $1, %%rax\n\t"
+                           "jne    %s\n\t",
+                           label_end->data);
+            asmExpression(cc, buf, ast->right);
             aoStrCatPrintf(buf,
-                    "test   %%rax, %%rax\n\t"
-                    "movq   $1, %%rax\n\t"
-                    "jne    %s\n\t"
-                    "movq   $0, %%rax\n\t"
-                    "%s:\n\t", label_end->data, label_end->data);
+                           "test   %%rax, %%rax\n\t"
+                           "movq   $1, %%rax\n\t"
+                           "jne    %s\n\t"
+                           "movq   $0, %%rax\n\t"
+                           "%s:\n\t",
+                           label_end->data, label_end->data);
         }
-        aoStrCat(buf,"# OR OR End\n\t");
+        aoStrCat(buf, "# OR OR End\n\t");
         break;
     }
 
     case TK_AND_AND: {
-        aoStrCat(buf,"# AND AND Start\n\t");
+        aoStrCat(buf, "# AND AND Start\n\t");
         label_end = astMakeLabel();
 
         if (ast->type->kind == AST_TYPE_FLOAT) {
-            asmExpression(cc,buf,ast->left);
+            asmExpression(cc, buf, ast->left);
             aoStrCatPrintf(buf,
-                    "xorpd   %%xmm1, %%xmm1\n\t"
-                    "ucomisd %%xmm1, %%xmm0\n\t"
-                    "je    %s\n\t", label_end->data);
-            asmExpression(cc,buf,ast->right);
+                           "xorpd   %%xmm1, %%xmm1\n\t"
+                           "ucomisd %%xmm1, %%xmm0\n\t"
+                           "je    %s\n\t",
+                           label_end->data);
+            asmExpression(cc, buf, ast->right);
             aoStrCatPrintf(buf,
-                    "xorpd   %%xmm1, %%xmm1\n\t"
-                    "ucomisd %%xmm1, %%xmm0\n\t"
-                    "movq    $0, %%rax\n\t"
-                    "je     %s\n\t"
-                    "movq    $1, %%rax\n\t"
-                    "%s:\n\t", label_end->data, label_end->data);
+                           "xorpd   %%xmm1, %%xmm1\n\t"
+                           "ucomisd %%xmm1, %%xmm0\n\t"
+                           "movq    $0, %%rax\n\t"
+                           "je     %s\n\t"
+                           "movq    $1, %%rax\n\t"
+                           "%s:\n\t",
+                           label_end->data, label_end->data);
         } else {
-            asmExpression(cc,buf,ast->left);
+            asmExpression(cc, buf, ast->left);
             aoStrCatPrintf(buf,
-                    "test   %%rax, %%rax\n\t"
-                    "movq   $0, %%rax\n\t"
-                    "je    %s\n\t", label_end->data);
-            asmExpression(cc,buf,ast->right);
+                           "test   %%rax, %%rax\n\t"
+                           "movq   $0, %%rax\n\t"
+                           "je    %s\n\t",
+                           label_end->data);
+            asmExpression(cc, buf, ast->right);
             aoStrCatPrintf(buf,
-                    "test   %%rax, %%rax\n\t"
-                    "movq   $0, %%rax\n\t"
-                    "je     %s\n\t"
-                    "movq   $1, %%rax\n\t"
-                    "%s:\n\t", label_end->data, label_end->data);
+                           "test   %%rax, %%rax\n\t"
+                           "movq   $0, %%rax\n\t"
+                           "je     %s\n\t"
+                           "movq   $1, %%rax\n\t"
+                           "%s:\n\t",
+                           label_end->data, label_end->data);
         }
-        aoStrCat(buf,"# AND AND End\n\t");
+        aoStrCat(buf, "# AND AND End\n\t");
         break;
     }
 
     case '-': {
-      if (ast->right == NULL) {
-          asmExpression(cc,buf, ast->left);
-          if (ast->left->type->kind == AST_TYPE_FLOAT) {
-              aoStrCatPrintf(buf,
-                      "movsd   sign_bit(%%rip), %%xmm1\n\t"
-                      "xorpd   %%xmm1, %%xmm0\n\t");
-          } else {
-              aoStrCatPrintf(buf,
-                      "not    %%rax\n\t"
-                      "addq    $1, %%rax\n\t");
-          }
-      } else {
-          asmBinaryOp(cc,buf,ast);
-      }
-      break;
+        if (ast->right == NULL) {
+            asmExpression(cc, buf, ast->left);
+            if (ast->left->type->kind == AST_TYPE_FLOAT) {
+                aoStrCatPrintf(buf,
+                               "movsd   sign_bit(%%rip), %%xmm1\n\t"
+                               "xorpd   %%xmm1, %%xmm0\n\t");
+            } else {
+                aoStrCatPrintf(buf,
+                               "not    %%rax\n\t"
+                               "addq    $1, %%rax\n\t");
+            }
+        } else {
+            asmBinaryOp(cc, buf, ast);
+        }
+        break;
     }
 
     default:
-        asmBinaryOp(cc,buf,ast);
+        asmBinaryOp(cc, buf, ast);
         break;
     }
 }
 
 void asmDataInternal(aoStr *buf, Ast *data) {
     if (data->kind == AST_STRING) {
-        aoStrCatPrintf(buf,".quad %s\n\t",data->slabel->data);
+        aoStrCatPrintf(buf, ".quad %s\n\t", data->slabel->data);
         return;
     }
 
@@ -2029,73 +2154,77 @@ void asmDataInternal(aoStr *buf, Ast *data) {
      * */
     if (data->kind == AST_ARRAY_INIT) {
         listForEach(data->arrayinit) {
-            asmDataInternal(buf,(Ast *)it->value);
+            asmDataInternal(buf, (Ast *)it->value);
         }
         return;
     }
 
     if (data->type->kind == AST_TYPE_FLOAT) {
-        aoStrCatPrintf(buf,".quad 0x%lX #%.9f\n\t",
-                ieee754(data->f64),
-                data->f64);
+        aoStrCatPrintf(buf, ".quad 0x%lX #%.9f\n\t", ieee754(data->f64),
+                       data->f64);
         return;
     }
 
     switch (data->type->size) {
-        case 1: aoStrCatPrintf(buf, ".byte %d\n\t", data->i64); break;
-        case 4: aoStrCatPrintf(buf, ".long %d\n\t", data->i64); break;
-        case 8: aoStrCatPrintf(buf, ".quad %d\n\t", data->i64); break;
-        default:
-            loggerPanic("Cannot create size information for: %s\n",
+    case 1:
+        aoStrCatPrintf(buf, ".byte %d\n\t", data->i64);
+        break;
+    case 4:
+        aoStrCatPrintf(buf, ".long %d\n\t", data->i64);
+        break;
+    case 8:
+        aoStrCatPrintf(buf, ".quad %d\n\t", data->i64);
+        break;
+    default:
+        loggerPanic("Cannot create size information for: %s\n",
                     astToString(data));
     }
 }
 
-void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast* ast) {
+void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast *ast) {
     Ast *declvar = ast->declvar;
     Ast *declinit = ast->declinit;
     aoStr *varname = declvar->gname;
     char *label = asmGetGlabel(declvar);
 
-    if (strMapGetLen(seen_globals,varname->data,varname->len)) {
+    if (strMapGetLen(seen_globals, varname->data, varname->len)) {
         return;
     }
 
-    if (buf->data[buf->len-1] == '\t') {
+    if (buf->data[buf->len - 1] == '\t') {
         buf->len--;
     }
 
-    strMapAdd(seen_globals,varname->data,ast);
+    strMapAdd(seen_globals, varname->data, ast);
 
     if (declinit &&
-        (declinit->kind == AST_ARRAY_INIT || 
-         declinit->kind == AST_LITERAL || declinit->kind == AST_STRING))
-    {
+        (declinit->kind == AST_ARRAY_INIT || declinit->kind == AST_LITERAL ||
+         declinit->kind == AST_STRING)) {
         if (!ast->is_static) {
-            aoStrCatPrintf(buf,".global %s\n",label);
-            aoStrCatPrintf(buf,".data\n");
+            aoStrCatPrintf(buf, ".global %s\n", label);
+            aoStrCatPrintf(buf, ".data\n");
         } else {
-            aoStrCatPrintf(buf,".data\n");
+            aoStrCatPrintf(buf, ".data\n");
         }
         if (declinit->kind == AST_ARRAY_INIT) {
-            Ast *head = (Ast *)declinit->arrayinit->next->value;
+            const Ast *head = (Ast *)declinit->arrayinit->next->value;
             if (head->kind == AST_STRING) {
-                aoStrCatPrintf(buf,".align 4\n");
+                aoStrCatPrintf(buf, ".align 4\n");
             }
         }
 
-        aoStrCatPrintf(buf,"%s:\n\t",label);
+        aoStrCatPrintf(buf, "%s:\n\t", label);
 
         if (declinit->kind == AST_ARRAY_INIT) {
             listForEach(declinit->arrayinit) {
-                asmDataInternal(buf,(Ast *)it->value);
+                asmDataInternal(buf, (Ast *)it->value);
             }
             return;
         } else {
-            asmDataInternal(buf,declinit);
+            asmDataInternal(buf, declinit);
         }
     } else {
-        aoStrCatPrintf(buf,".lcomm %s, %d\n\t",label,declvar->type->size);
+        aoStrCatPrintf(buf, ".lcomm %s, %d\n\t", label, declvar->type->size);
     }
 }
 
@@ -2109,25 +2238,25 @@ void asmDataSection(Cctrl *cc, aoStr *buf) {
         Ast *ast = (Ast *)n->value;
         assert(ast->kind == AST_STRING);
         aoStrCatFmt(buf,
-                "%S:\n\t"
-                ".asciz \"%S\"\n",
-                ast->slabel, ast->sval);
+                    "%S:\n\t"
+                    ".asciz \"%S\"\n",
+                    ast->slabel, ast->sval);
     }
-    aoStrPutChar(buf,'\t');
+    aoStrPutChar(buf, '\t');
     strMapIteratorRelease(it);
-} 
+}
 
 void asmStoreParam(aoStr *buf, int *_ireg, int *_arg, int offset) {
     int arg = *_arg, ireg = *_ireg;
     if (ireg == 6) {
         aoStrCatPrintf(buf,
-                "movq   %d(%%rbp),%%rax\n\t"
-                "movq    %%rax, %d(%%rbp)\n\t",
-                arg++ * 8, -offset);
+                       "movq   %d(%%rbp),%%rax\n\t"
+                       "movq    %%rax, %d(%%rbp)\n\t",
+                       arg++ * 8, -offset);
         *_arg = arg;
     } else {
-        aoStrCatPrintf(buf, "movq   %%%s, %d(%%rbp)\n\t",
-                REGISTERS[ireg++], -offset);
+        aoStrCatPrintf(buf, "movq   %%%s, %d(%%rbp)\n\t", REGISTERS[ireg++],
+                       -offset);
         *_ireg = ireg;
     }
 }
@@ -2135,26 +2264,28 @@ void asmStoreParamFloat(aoStr *buf, int *_freg, int *_arg, int offset) {
     int arg = *_arg, freg = *_freg;
     if (freg == 9) {
         aoStrCatPrintf(buf,
-                "movq   %d(%%rbp),%%rax\n\t"
-                "movq    %%rax, %d(%%rbp)\n\t",
-                arg++ * 8, -offset);
+                       "movq   %d(%%rbp),%%rax\n\t"
+                       "movq    %%rax, %d(%%rbp)\n\t",
+                       arg++ * 8, -offset);
         *_arg = arg;
     } else {
         aoStrCatPrintf(buf, "movq   %%%s, %d(%%rbp)\n\t",
-                FLOAT_REGISTERS[freg++], -offset);
+                       FLOAT_REGISTERS[freg++], -offset);
         *_freg = freg;
     }
 }
 
-void asmGetRegisterCounts(List *params, int *ireg, int *freg) {
+void asmGetRegisterCounts(const List *params, int *ireg, int *freg) {
     listForEach(params) {
-        Ast *param = (Ast *)it->value;
-        if (astIsFloatType(param->type)) (*freg)++;
-        else                             (*ireg)++;
+        const Ast *param = (Ast *)it->value;
+        if (astIsFloatType(param->type))
+            (*freg)++;
+        else
+            (*ireg)++;
     }
 }
 
-int asmFunctionInit(Cctrl *cc, aoStr *buf, Ast *func) {
+int asmFunctionInit(const Cctrl *cc, aoStr *buf, const Ast *func) {
     (void)cc;
     int offset = 0;
     int ireg = 0, freg = 0, locals = 0, arg = 2;
@@ -2162,29 +2293,32 @@ int asmFunctionInit(Cctrl *cc, aoStr *buf, Ast *func) {
 
     char *fname = asmNormaliseFunctionName(func->fname->data);
 
-    aoStrCatPrintf(buf, ".text"            "\n\t"
-                        ".global %s\n"
-                        "%s:\n\t"
-                        "push   %%rbp"       "\n\t"
-                        "movq   %%rsp, %%rbp" "\n\t",
-                        fname,
-                        fname);
+    aoStrCatPrintf(buf,
+                   ".text"
+                   "\n\t"
+                   ".global %s\n"
+                   "%s:\n\t"
+                   "push   %%rbp"
+                   "\n\t"
+                   "movq   %%rsp, %%rbp"
+                   "\n\t",
+                   fname, fname);
 
-    int new_offset = 0, alignment = 0;
+    int new_offset = 0;
     /* Now assign offsets */
     listForEach(func->locals) {
         ast_tmp = (Ast *)it->value;
         /* Calculate how much stackspace is required for locals */
-        alignment = align(ast_tmp->type->size, 8);
+        int alignment = align(ast_tmp->type->size, 8);
         locals += alignment;
         new_offset -= ast_tmp->type->size;
         switch (ast_tmp->kind) {
-            case AST_DEFAULT_PARAM:
-                ast_tmp->declvar->loff = new_offset;
-                break;
-            default:
-                ast_tmp->loff = new_offset;
-                break;
+        case AST_DEFAULT_PARAM:
+            ast_tmp->declvar->loff = new_offset;
+            break;
+        default:
+            ast_tmp->loff = new_offset;
+            break;
         }
     }
 
@@ -2196,7 +2330,8 @@ int asmFunctionInit(Cctrl *cc, aoStr *buf, Ast *func) {
             break;
         case AST_VAR_ARGS:
             locals += align(ast_tmp->argc->type->size, 8);
-            locals += VAR_ARG_MAX*8+212; /* allocate a huge amount off the stack */
+            locals += VAR_ARG_MAX * 8 +
+                    212; /* allocate a huge amount off the stack */
             break;
         default:
             locals += align(ast_tmp->type->size, 8);
@@ -2207,8 +2342,8 @@ int asmFunctionInit(Cctrl *cc, aoStr *buf, Ast *func) {
     int stack_space = 0;
     if (locals) {
         stack_space = align(locals, 16);
-        aoStrCatPrintf(buf, "subq   $%d, %%rsp #STACK LOCAL COUNT %d\n\t", 
-                stack_space, listCount(func->locals));
+        aoStrCatPrintf(buf, "subq   $%d, %%rsp #STACK LOCAL COUNT %d\n\t",
+                       stack_space, listCount(func->locals));
         stack_pointer = stack_space;
     }
 
@@ -2218,50 +2353,50 @@ int asmFunctionInit(Cctrl *cc, aoStr *buf, Ast *func) {
         ast_tmp = vecGet(Ast *, func->params, i);
 
         if (ast_tmp->kind != AST_VAR_ARGS && astIsFloatType(ast_tmp->type)) {
-            asmStoreParamFloat(buf,&freg,&arg,offset);
+            asmStoreParamFloat(buf, &freg, &arg, offset);
         } else {
-            asmStoreParam(buf,&ireg,&arg,offset);
+            asmStoreParam(buf, &ireg, &arg, offset);
         }
         switch (ast_tmp->kind) {
-            case AST_DEFAULT_PARAM:
-                ast_tmp->declvar->loff = -offset;
-                offset -= align(ast_tmp->declvar->type->size, 8);
-                break;
+        case AST_DEFAULT_PARAM:
+            ast_tmp->declvar->loff = -offset;
+            offset -= align(ast_tmp->declvar->type->size, 8);
+            break;
 
-            case AST_VAR_ARGS:
-                ast_tmp->argc->loff = -offset;
-                offset -= align(ast_tmp->argc->type->size, 8);
-                /* XXX: varargs limited to 4 */
-                ast_tmp->argv->loff = align(16,8);
-                for (int i = ireg; i < 6; ++i) {
-                    asmStoreParam(buf,&ireg,&arg,offset);
-                    offset -= 8;
-                }
-                for (int i = freg; i < 8; ++i) {
-                    asmStoreParamFloat(buf,&freg,&arg,offset);
-                    offset -= 8;
-                }
-                break;
+        case AST_VAR_ARGS:
+            ast_tmp->argc->loff = -offset;
+            offset -= align(ast_tmp->argc->type->size, 8);
+            /* XXX: varargs limited to 4 */
+            ast_tmp->argv->loff = align(16, 8);
+            for (int j = ireg; j < 6; ++j) {
+                asmStoreParam(buf, &ireg, &arg, offset);
+                offset -= 8;
+            }
+            for (int j = freg; j < 8; ++j) {
+                asmStoreParamFloat(buf, &freg, &arg, offset);
+                offset -= 8;
+            }
+            break;
 
-            default:
-                ast_tmp->loff = -offset;
-                offset -= align(ast_tmp->type->size, 8);
-                break;
+        default:
+            ast_tmp->loff = -offset;
+            offset -= align(ast_tmp->type->size, 8);
+            break;
         }
     }
-    offset = stack_space;
+
     return stack_space;
 }
 
 void asmFunctionLeave(aoStr *buf) {
-    aoStrCatPrintf(buf,"leave\n\tret\n");
+    aoStrCatPrintf(buf, "leave\n\tret\n");
 }
 
-int asmHasRet(aoStr *buf) {
-    static char *match = "leave\n\tret\n";
+int asmHasRet(const aoStr *buf) {
+    static const char *match = "leave\n\tret\n";
     int len = 11;
-    int curlen = buf->len-1;
-    int j = len-1;
+    int curlen = buf->len - 1;
+    int j = len - 1;
 
     for (int i = 0; i < len; ++i) {
         if (buf->data[curlen] != match[j]) {
@@ -2275,8 +2410,8 @@ int asmHasRet(aoStr *buf) {
 
 void asmFunction(Cctrl *cc, aoStr *buf, Ast *func) {
     assert(func->kind == AST_FUNC);
-    cc->stack_local_space = asmFunctionInit(cc,buf,func);
-    asmExpression(cc,buf,func->body);
+    cc->stack_local_space = asmFunctionInit(cc, buf, func);
+    asmExpression(cc, buf, func->body);
     if (!asmHasRet(buf)) {
         asmFunctionLeave(buf);
     }
@@ -2294,15 +2429,12 @@ void asmPasteAsmBlocks(aoStr *buf, Cctrl *cc) {
 
         while (func_it != asm_block->funcs) {
             asm_func = (Ast *)func_it->value;
-                aoStrCatPrintf(buf, ".global %s\n",
-                         asm_func->asmfname->data);
+            aoStrCatPrintf(buf, ".global %s\n", asm_func->asmfname->data);
 
-                aoStrCatPrintf(buf,"%s:\n",asm_func->asmfname->data);
-                aoStrCatLen(buf,
-                        asm_func->body->asm_stmt->data,
+            aoStrCatPrintf(buf, "%s:\n", asm_func->asmfname->data);
+            aoStrCatLen(buf, asm_func->body->asm_stmt->data,
                         asm_func->body->asm_stmt->len);
-                aoStrPutChar(buf, '\n');
-
+            aoStrPutChar(buf, '\n');
 
             func_it = func_it->next;
         }
@@ -2311,7 +2443,8 @@ void asmPasteAsmBlocks(aoStr *buf, Cctrl *cc) {
 }
 
 void asmInitaliser(Cctrl *cc, aoStr *buf) {
-    if (listEmpty(cc->initalisers)) return;
+    if (listEmpty(cc->initalisers))
+        return;
     char *fname = NULL;
     int locals = 0, stack_space;
 
@@ -2320,15 +2453,19 @@ void asmInitaliser(Cctrl *cc, aoStr *buf) {
 #else
     fname = "main";
 #endif
-    aoStrCatPrintf(buf, ".text"            "\n\t"
-                        ".global %s\n"
-                        "%s:\n\t"
-                        "push   %%rbp"       "\n\t"
-                        "movq   %%rsp, %%rbp" "\n\t",
-                        fname, fname);
+    aoStrCatPrintf(buf,
+                   ".text"
+                   "\n\t"
+                   ".global %s\n"
+                   "%s:\n\t"
+                   "push   %%rbp"
+                   "\n\t"
+                   "movq   %%rsp, %%rbp"
+                   "\n\t",
+                   fname, fname);
     /* Calculate how much stackspace is required for locals */
     listForEach(cc->initaliser_locals) {
-        Ast *ast_tmp = (Ast *)it->value;
+        const Ast *ast_tmp = (Ast *)it->value;
         locals += align(ast_tmp->type->size, 8);
     }
 
@@ -2348,14 +2485,14 @@ void asmInitaliser(Cctrl *cc, aoStr *buf) {
 
     /* This handles command line arguments */
     aoStrCatPrintf(buf,
-            "subq   $%d, %%rsp\n\t"
-            "movq   %%rdi, argc(%%rip)\n\t"
-            "movq   %%rsi, argv(%%rip)\n\t",
-            stack_space);
+                   "subq   $%d, %%rsp\n\t"
+                   "movq   %%rdi, argc(%%rip)\n\t"
+                   "movq   %%rsi, argv(%%rip)\n\t",
+                   stack_space);
     stack_pointer = stack_space;
 
     listForEach(cc->initalisers) {
-        asmExpression(cc,buf,(Ast *)it->value);
+        asmExpression(cc, buf, (Ast *)it->value);
     }
     aoStrCatPrintf(buf, "leave\n\tret\n");
 }
@@ -2364,14 +2501,13 @@ void asmInitaliser(Cctrl *cc, aoStr *buf) {
 aoStr *asmGenerate(Cctrl *cc) {
     Ast *ast;
     StrMap *seen_globals = strMapNew(32);
-    aoStr *asmbuf = aoStrAlloc(1<<10);
- 
+    aoStr *asmbuf = aoStrAlloc(1 << 10);
+
     if (!listEmpty(cc->initalisers)) {
         has_initialisers = 1;
     }
-    asmPasteAsmBlocks(asmbuf,cc);
-    asmDataSection(cc,asmbuf);
-
+    asmPasteAsmBlocks(asmbuf, cc);
+    asmDataSection(cc, asmbuf);
 
     listForEach(cc->ast_list) {
         ast = (Ast *)it->value;
@@ -2380,27 +2516,29 @@ aoStr *asmGenerate(Cctrl *cc) {
             if (ast->flags & AST_FLAG_INLINE) {
                 continue;
             }
-            asmFunction(cc,asmbuf,ast);
+            asmFunction(cc, asmbuf, ast);
         } else if (ast->kind == AST_DECL || ast->kind == AST_GVAR) {
-            asmGlobalVar(seen_globals,asmbuf,ast);
+            asmGlobalVar(seen_globals, asmbuf, ast);
         } else if (ast->kind == AST_ASM_STMT) {
-           // aoStrCatLen(asmbuf, ast->asm_stmt->data, ast->asm_stmt->len);
-           // loggerDebug("%s\n", ast->asm_stmt->data);
-        } else if (ast->kind == AST_ASM_FUNCDEF || ast->kind == AST_ASM_FUNC_BIND || ast->kind == AST_EXTERN_FUNC) {
-           // aoStrCatPrintf(asmbuf, ".text\n\t.global %s\n\t", 
-           //         ast->asmfname->data);
+            // aoStrCatLen(asmbuf, ast->asm_stmt->data, ast->asm_stmt->len);
+            // loggerDebug("%s\n", ast->asm_stmt->data);
+        } else if (ast->kind == AST_ASM_FUNCDEF ||
+                   ast->kind == AST_ASM_FUNC_BIND ||
+                   ast->kind == AST_EXTERN_FUNC) {
+            // aoStrCatPrintf(asmbuf, ".text\n\t.global %s\n\t",
+            //         ast->asmfname->data);
         } else {
             loggerPanic("Cannot handle: %s\n", astToString(ast));
         }
     }
     if (!listEmpty(cc->initalisers)) {
-        asmInitaliser(cc,asmbuf);
+        asmInitaliser(cc, asmbuf);
     }
-    aoStrCatFmt(asmbuf,".LFE0:\n\t");
+    aoStrCatFmt(asmbuf, ".LFE0:\n\t");
 #if IS_LINUX
     aoStrCatFmt(asmbuf, ".section    .note.GNU-stack,\"\",@progbits\n\t");
 #endif
-    aoStrCatFmt(asmbuf,".ident      \"hcc: %s %s %s\"\n",
-            OS_STR, ARCH_STR, cctrlGetVersion());
+    aoStrCatFmt(asmbuf, ".ident      \"hcc: %s %s %s\"\n", OS_STR, ARCH_STR,
+                cctrlGetVersion());
     return asmbuf;
 }


### PR DESCRIPTION
`cppcheck --enable=all --suppress=missingIncludeSystem --check-level=exhaustive ./src/`

- Fixed almost all warnings detected by cppcheck.
- Applied clang-format for consistent code formatting.
- Improved code readability and adherence to project coding style.

No functional changes were made.