### PR TITLE
Fix global variables, allow assembly in a function

### DIFF
--- a/src/aostr.h
+++ b/src/aostr.h
@@ -25,6 +25,7 @@ void aoStrRelease(aoStr *buf);
 
 int aoStrExtendBuffer(aoStr *buf, size_t additional);
 void aoStrToLowerCase(aoStr *buf);
+void aoStrToUpperCase(aoStr *buf);
 void aoStrPutChar(aoStr *buf, char ch);
 void aoStrRepeatChar(aoStr *buf, char ch, int times);
 int aoStrCmp(aoStr *b1, aoStr *b2);
@@ -46,6 +47,7 @@ aoStr *aoStrEncode(aoStr *buf);
 void aoStrArrayRelease(aoStr **arr, int count);
 aoStr **aoStrSplit(char *to_split, char delimiter, int *count);
 char *mprintf(const char *fmt, ...);
+char *mprintFmt(const char *fmt, ...);
 char *mprintVa(const char *fmt, va_list ap, ssize_t *_len);
 aoStr *aoStrError(void);
 aoStr *aoStrIntToHumanReadableBytes(long bytes);

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -137,6 +137,7 @@ Cctrl *cctrlNew(void);
 /* Slimmed down Cctrl, for expanding macros */
 Cctrl *ccMacroProcessor(StrMap *macro_defs);
 Lexeme *cctrlTokenGet(Cctrl *cc);
+Lexeme *cctrlAsmTokenGet(Cctrl *cc);
 Lexeme *cctrlTokenPeek(Cctrl *cc);
 Lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt);
 void cctrlInitMacroProcessor(Cctrl *cc);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -725,7 +725,7 @@ char *lexString(Lexer *l, char terminator, long *_real_len, int *_buffer_len) {
             l->lineno++;
         }
 
-        if (len + 3 >= capacity) {
+        if ((unsigned int)(len + 3) >= capacity) {
             buffer = lexerReAllocBuffer(buffer, len, capacity * 2);
             capacity *= 2;
         }

--- a/src/map.c
+++ b/src/map.c
@@ -742,6 +742,10 @@ void *strMapGetLen(StrMap *map, char *key, long key_len) {
     return NULL;
 }
 
+void *strMapGetAoStr(StrMap *map, aoStr *key) {
+    return strMapGetLen(map,key->data,key->len);
+}
+
 void *strMapGet(StrMap *map, char *key) {
     long key_len = strlen(key);
     return strMapGetLen(map,key,key_len);

--- a/src/map.h
+++ b/src/map.h
@@ -119,6 +119,7 @@ unsigned long roundUpToNextPowerOf2(unsigned long v);
 StrMap *strMapNew(unsigned long capacity);
 StrMap *strMapNewWithParent(unsigned long capacity, StrMap *parent);
 void *strMapGetLen(StrMap *map, char *key, long key_len);
+void *strMapGetAoStr(StrMap *map, aoStr *key);
 void *strMapGet(StrMap *map, char *key);
 int strMapAddLen(StrMap *map, char *key, long key_len, void *value);
 int strMapAdd(StrMap *map, char *key, void *value);

--- a/src/prsasm.h
+++ b/src/prsasm.h
@@ -4,6 +4,6 @@
 #include "ast.h"
 #include "cctrl.h"
 
-Ast *prsAsm(Cctrl *cc);
+Ast *prsAsm(Cctrl *cc, int parse_one);
 
 #endif /* PRS_ASM */

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -20,5 +20,6 @@ AstType *parseFunctionPointerType(Cctrl *cc,
         char **fnptr_name, int *fnptr_name_len, AstType *rettype);
 Ast *findFunctionDecl(Cctrl *cc, char *fname, int len);
 Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right);
+Ast *parseSizeof(Cctrl *cc);
 
 #endif

--- a/src/x86.c
+++ b/src/x86.c
@@ -1557,11 +1557,14 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
 
     case AST_ASM_FUNCALL: {
         if (ast->flags & AST_FLAG_INLINE) {
-            Ast *asm_func_def = strMapGetLen(cc->asm_functions, ast->fname->data, ast->fname->len);
-            if (!asm_func_def) {
-                loggerPanic("Cannot call inline assembly code\n");
-            }
-            aoStrCatFmt(buf, "%S", asm_func_def->body->asm_stmt);
+            asmFunCall(cc,buf,ast);
+            //Ast *asm_func_def = strMapGetLen(cc->asm_functions, ast->fname->data, ast->fname->len);
+            //if (!asm_func_def) {
+            //    loggerPanic("Cannot call inline assembly code\n");
+            //}
+            //astPrint(asm_func_def);
+            //printf("%s\n",asm_func_def->body->asm_stmt->data);
+            //aoStrCatFmt(buf, "%S", asm_func_def->body->asm_stmt);
             break;
         }
     }

--- a/src/x86.c
+++ b/src/x86.c
@@ -2077,6 +2077,7 @@ void asmInitialiseEmptyGlobal(aoStr *buf, Ast *global, int zerofill) {
                 (int)log2((double)size));
     } else {
 #endif
+        (void)zerofill; /* Unused on linux */
         aoStrCatFmt(buf,".globl %S\n\t.comm %S, %i, %u\n\t", label, label,
                         size,
                         roundUpToNextPowerOf2((unsigned long)size));

--- a/src/x86.c
+++ b/src/x86.c
@@ -51,7 +51,7 @@ static int has_initialisers = 0;
 void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast);
 
 #define asmGetGlabel(gvar) \
-    gvar->is_static ? gvar->glabel->data : gvar->gname->data
+    gvar->is_static ? gvar->glabel : gvar->gname
 
 uint64_t ieee754(double _f64) {
     if (_f64 == 0.0) return 0;  // Handle zero value explicitly
@@ -286,12 +286,13 @@ void asmGLoad(aoStr *buf, AstType *type, aoStr *label, int offset) {
 
     if (type->kind == AST_TYPE_ARRAY) {
         if (offset) {
-            aoStrCatPrintf(buf, "lea    %s+%d(%%rip), %%rax\n\t",
-                    label->data, offset);
+            aoStrCatFmt(buf, "lea    %S+%d(%%rip), %%rax\n\t", label, offset);
         } else {
-            aoStrCatPrintf(buf, "lea    %s(%%rip), %%rax\n\t",
-                    label->data);
+            aoStrCatFmt(buf, "lea    %S(%%rip), %%rax\n\t", label);
         }
+        return;
+    } else if (type->kind == AST_TYPE_POINTER && type->ptr->kind == AST_TYPE_CHAR) {
+        aoStrCatFmt(buf, "lea    %S(%%rip), %%rax\n\t", label);
         return;
     }
 
@@ -647,8 +648,8 @@ void asmAssign(Cctrl *cc, aoStr *buf, Ast *variable) {
         break;
 
     case AST_GVAR: {
-        char *label = asmGetGlabel(variable);
-        asmGSave(buf,label,variable->type,0);
+        aoStr *label = asmGetGlabel(variable);
+        asmGSave(buf,label->data,variable->type,0);
         break;
     }
     default:
@@ -1554,8 +1555,17 @@ void asmExpression(Cctrl *cc, aoStr *buf, Ast *ast) {
         asmGLoad(buf,ast->type,ast->glabel,0);
         break;
 
+    case AST_ASM_FUNCALL: {
+        if (ast->flags & AST_FLAG_INLINE) {
+            Ast *asm_func_def = strMapGetLen(cc->asm_functions, ast->fname->data, ast->fname->len);
+            if (!asm_func_def) {
+                loggerPanic("Cannot call inline assembly code\n");
+            }
+            aoStrCatFmt(buf, "%S", asm_func_def->body->asm_stmt);
+            break;
+        }
+    }
     case AST_FUNPTR_CALL:
-    case AST_ASM_FUNCALL:
     case AST_FUNCALL: {
         asmFunCall(cc,buf,ast);
         break;
@@ -2051,11 +2061,32 @@ void asmDataInternal(aoStr *buf, Ast *data) {
     }
 }
 
+void asmInitialiseEmptyGlobal(aoStr *buf, Ast *global, int zerofill) {
+    aoStr *label = asmGetGlabel(global);
+    int size = global->type->size;
+
+#if IS_MACOS
+    if (zerofill) {
+        aoStrCatFmt(buf,".globl %S\n\t", label);
+        aoStrCatFmt(buf, ".zerofill __DATA,__common,%S,%i,%i\n\t",
+                label,
+                size,
+                (int)log2((double)size));
+    } else {
+#endif
+        aoStrCatFmt(buf,".globl %S\n\t.comm %S, %i, %u\n\t", label, label,
+                        size,
+                        roundUpToNextPowerOf2((unsigned long)size));
+#if IS_MACOS
+    }
+#endif
+}
+
 void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast* ast) {
     Ast *declvar = ast->declvar;
     Ast *declinit = ast->declinit;
     aoStr *varname = declvar->gname;
-    char *label = asmGetGlabel(declvar);
+    aoStr *label = asmGetGlabel(declvar);
 
     if (strMapGetLen(seen_globals,varname->data,varname->len)) {
         return;
@@ -2071,20 +2102,29 @@ void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast* ast) {
         (declinit->kind == AST_ARRAY_INIT || 
          declinit->kind == AST_LITERAL || declinit->kind == AST_STRING))
     {
-        if (!ast->is_static) {
-            aoStrCatPrintf(buf,".global %s\n",label);
-            aoStrCatPrintf(buf,".data\n");
+        if (declinit->kind == AST_STRING) {
+            aoStrCatFmt(buf,
+                    "%S:\n\t"
+                    ".asciz \"%S\"\n\t",
+                    declvar->gname, declinit->sval);
+            return;
         } else {
-            aoStrCatPrintf(buf,".data\n");
-        }
-        if (declinit->kind == AST_ARRAY_INIT) {
-            Ast *head = (Ast *)declinit->arrayinit->next->value;
-            if (head->kind == AST_STRING) {
-                aoStrCatPrintf(buf,".align 4\n");
+            if (!declvar->is_static) {
+                aoStrCatFmt(buf,".globl %S\n",label);
+                aoStrCatPrintf(buf,".data\n");
+            } else {
+                aoStrCatPrintf(buf,".data\n");
+            }
+            if (declinit->kind == AST_ARRAY_INIT) {
+                Ast *head = (Ast *)declinit->arrayinit->next->value;
+                if (head->kind == AST_STRING) {
+                    aoStrCatPrintf(buf,".align 4\n");
+                }
             }
         }
 
-        aoStrCatPrintf(buf,"%s:\n\t",label);
+
+        aoStrCatFmt(buf,"%S:\n\t",label);
 
         if (declinit->kind == AST_ARRAY_INIT) {
             listForEach(declinit->arrayinit) {
@@ -2095,7 +2135,16 @@ void asmGlobalVar(StrMap *seen_globals, aoStr *buf, Ast* ast) {
             asmDataInternal(buf,declinit);
         }
     } else {
-        aoStrCatPrintf(buf,".lcomm %s, %d\n\t",label,declvar->type->size);
+        if (declvar->is_static) {
+            aoStrCatFmt(buf,".lcomm %S, %i\n\t",label,declvar->type->size);
+        } else {
+            if (label->len == 4 && (!strncmp(label->data, str_lit("argc")) || 
+                        !strncmp(label->data, str_lit("argv")))) {
+                asmInitialiseEmptyGlobal(buf,declvar,0);
+            } else {
+                asmInitialiseEmptyGlobal(buf,declvar,1);
+            }
+        }
     }
 }
 
@@ -2369,6 +2418,7 @@ aoStr *asmGenerate(Cctrl *cc) {
     if (!listEmpty(cc->initalisers)) {
         has_initialisers = 1;
     }
+
     asmPasteAsmBlocks(asmbuf,cc);
     asmDataSection(cc,asmbuf);
 


### PR DESCRIPTION
- Fix for global variables, also usable in assembly routines
- `sizeof(...)` usable in assembly
- Can define assembly in a function, disabled `inline` for these types of functions for the time being as they were very temperamental
```hc
U8 *str = "hello\n";

/* Cannot yet mix C and assembly directly */
U0 Print() {
asm {
   PUSH    RBP
   MOV     RSP, RBP
   LEA     RDI, str[RIP]
   CALL    printf
   LEAVE
   RET
}
}

U0 Main()
{
  Print;
}
```