### PR TITLE
fix - get git hash when compiling with cmake

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,14 @@ if (HCC_LINK_SQLITE3)
     add_compile_definitions(HCC_LINK_SQLITE3)
 endif()
 
+execute_process(
+  COMMAND git rev-parse main
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE HCC_GIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+add_compile_definitions(HCC_GIT_HASH="${HCC_GIT_HASH}")
 
 # Optionally, add more flags or options depending on the build type
 # For example, optimization flags for Release builds:

--- a/src/main.c
+++ b/src/main.c
@@ -289,8 +289,8 @@ int main(int argc, char **argv) {
     CliArgs args;
     cliArgsInit(&args);
     /* now parse cli options */
-    cliParseArgs(&args,argc,argv);
     args.install_dir = INSTALL_PREFIX;
+    cliParseArgs(&args,argc,argv);
 
     if (args.assemble) {
         assemble(&args);


### PR DESCRIPTION
- Get the git hash when building with CMake as opposed to at runtime

closes #168