### PR TITLE
Fix all compiler warnings, remove string code from mempool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 C_COMPILER     ?= gcc
 BUILD_TYPE     ?= Release
 INSTALL_PREFIX ?= /usr/local
-CFLAGS         ?= "-Wextra -Wall -Wno-implicit-fallthrough"
+CFLAGS         ?= '-Wextra -Wall -Wpedantic -Wno-implicit-fallthrough'
 
 default: all
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -16,7 +16,7 @@ static ArenaBlock *arenaBlockNew(unsigned int capacity) {
 static void arenaBlockRelease(ArenaBlock *block) {
     if (block) {
         /* Need to go to the start address */
-        free(block->mem - block->used);
+        free(((char *)block->mem) - block->used);
         free(block);
     }
 }
@@ -65,17 +65,14 @@ void *arenaAlloc(Arena *arena, unsigned int size) {
             block->next = arena->tail;
             arena->tail = block;
             arena->head = new_block;
-            void *memory = new_block->mem;
-            new_block->used = allocation_size;
-            new_block->mem += allocation_size;
-            return memory;
-        } else {
-            /* The simple path! */
-            void *memory = block->mem;
-            block->used += allocation_size;
-            block->mem += allocation_size;
-            return memory;
+            /* Set block to the new block */
+            block = new_block;
         }
+
+        void *memory = block->mem;
+        block->used += allocation_size;
+        block->mem = ((char *)block->mem) + allocation_size;
+        return memory;
     }
 }
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -1164,7 +1164,6 @@ void _astToString(aoStr *str, Ast *ast, int depth) {
 
     Ast *param;
     List *node;
-    aoStr *escaped;
     char *tmp;
 
     switch(ast->kind) {
@@ -1840,7 +1839,6 @@ static void _astLValueToString(aoStr *str, Ast *ast, unsigned long lexeme_flags)
             break;
 
         case AST_STRING: {
-            aoStr *str_formatted = aoStrNew();
             aoStr *encoded = NULL;
             char *quote = "\"";
             if (lexeme_flags & LEXEME_GRAPH_VIZ_ENCODE_PUNCT) {

--- a/src/transpiler.c
+++ b/src/transpiler.c
@@ -512,7 +512,6 @@ void transpileAstInternal(Ast *ast, TranspileCtx *ctx, ssize_t *indent) {
 
     ssize_t saved_indent = 0;
     List *node;
-    aoStr *escaped;
 
     switch(ast->kind) {
     case AST_LITERAL: {
@@ -1073,7 +1072,6 @@ aoStr *transpileParamsList(PtrVec *params, TranspileCtx *ctx) {
     aoStr *decl = NULL;
     for (int i = 0; i < params->size; ++i) {
         Ast *param = params->entries[i];
-        aoStr *var = transpileLValue(param, ctx);
         if (param->kind == AST_DEFAULT_PARAM) {
             decl = transpileVarDecl(ctx, param->declvar->type,
                     param->declvar->lname->data);


### PR DESCRIPTION
- Fixes compiler warnings
- Changes to the Makefile should help surface more compiler warnings, tempted to put `-Werror`
- Remove string code from `mempool`, it does not need to be isolated from the rest of the project... I don't think unless `aoStr` eventually uses `mempool`