### PR TITLE
Chore; ast enums

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -158,24 +158,81 @@ AstType *astTypeCopy(AstType *type) {
     return copy;
 }
 
-Ast *astUnaryOperator(AstType *type, long kind, Ast *operand) {
+Ast *astUnaryOperator(AstType *type, AstUnOp operation, Ast *operand) {
     Ast *ast = astNew();
-    ast->kind = kind;
+    ast->kind = AST_UNOP;
     ast->type = type;
+    if (ast->type == NULL) {
+        loggerWarning("Unary type is being assigned as NULL\n");
+    }
+    ast->unop = operation;
     ast->operand = operand;
     return ast;
 }
 
-Ast *astBinaryOp(long operation, Ast *left, Ast *right, int *_is_err) {
+/* Returns `1` on successful conversion and `0` on failure */
+int astBinOpFromToken(long op, AstBinOp *_result) {
+    switch (op) {
+        case '+': *_result = AST_BIN_OP_ADD;     break;
+        case '-': *_result = AST_BIN_OP_SUB;     break;
+        case '*': *_result = AST_BIN_OP_MUL;     break;
+        case '/': *_result = AST_BIN_OP_DIV;     break;
+        case '%': *_result = AST_BIN_OP_MOD;     break;
+
+        case '=': *_result = AST_BIN_OP_ASSIGN; break;
+        case '<': *_result = AST_BIN_OP_LT;     break;
+        case '>': *_result = AST_BIN_OP_GT;     break;
+        case TK_GREATER_EQU: *_result = AST_BIN_OP_GE;  break;
+        case TK_LESS_EQU: *_result = AST_BIN_OP_GE;  break;
+
+        case TK_EQU_EQU: *_result = AST_BIN_OP_EQ; break;
+        case TK_NOT_EQU: *_result = AST_BIN_OP_NE; break;
+
+        case TK_AND_AND: *_result = AST_BIN_OP_LOG_AND; break;
+        case TK_OR_OR: *_result = AST_BIN_OP_LOG_OR; break;
+
+        case '^': *_result = AST_BIN_OP_BIT_XOR; break;
+        case '&': *_result = AST_BIN_OP_BIT_AND; break;
+        case '|': *_result = AST_BIN_OP_BIT_OR;  break;
+
+        case TK_SHL: *_result = AST_BIN_OP_SHL;  break;
+        case TK_SHR: *_result = AST_BIN_OP_SHR;  break;
+        default:
+            return 0;
+    }
+    return 1;
+}
+
+int astUnaryOpFromToken(long op, AstUnOp *_result) {
+    switch (op) {
+        case TK_PRE_PLUS_PLUS:   *_result = AST_UN_OP_PRE_INC; break;
+        case TK_PRE_MINUS_MINUS: *_result = AST_UN_OP_PRE_DEC; break;
+        case TK_PLUS_PLUS:       *_result = AST_UN_OP_POST_INC; break;
+        case TK_MINUS_MINUS:     *_result = AST_UN_OP_POST_DEC; break;
+        case '+':                *_result = AST_UN_OP_PLUS;    break;
+        case '-':                *_result = AST_UN_OP_MINUS;   break;
+        case '~':                *_result = AST_UN_OP_BIT_NOT; break;
+        case '!':                *_result = AST_UN_OP_LOG_NOT; break;
+        case '&':                *_result = AST_UN_OP_ADDR_OF; break;
+        case '*':                *_result = AST_UN_OP_DEREF;   break;
+        default:                 
+            return 0;
+    }
+    return 1;
+}
+
+Ast *astBinaryOp(AstBinOp operation, Ast *left, Ast *right, int *_is_err) {
     Ast *ast = astNew();
     ast->type = astGetResultType(operation,left->type,right->type);  
 
     if (ast->type == NULL) {
+        loggerWarning("Binary type is being assigned as NULL\n");
         *_is_err = 1;
     }
 
-    ast->kind = operation;
-    if (operation != '=' &&
+    ast->kind = AST_BINOP;
+    ast->binop = operation;
+    if (operation != AST_BIN_OP_ASSIGN &&
             astConvertArray(left->type)->kind != AST_TYPE_POINTER &&
             astConvertArray(right->type)->kind == AST_TYPE_POINTER) {
         ast->left = right;
@@ -718,13 +775,26 @@ int astIsAssignment(long op) {
     }
 }
 
-int astIsValidPointerOp(long op) {
+int astTypeIsPtr(AstType *type) {
+    return type && type->kind == AST_TYPE_POINTER;
+}
+
+int astTypeIsArray(AstType *type) {
+    return type && type->kind == AST_TYPE_ARRAY;
+}
+
+int astIsValidPointerOp(AstBinOp op) {
     switch (op) {
-        case '-': case '+':
-        case '<': case TK_LESS_EQU:
-        case '>': case TK_GREATER_EQU:
-        case TK_EQU_EQU: case TK_NOT_EQU:
-        case TK_OR_OR: case TK_AND_AND:    
+        case AST_BIN_OP_SUB:
+        case AST_BIN_OP_ADD:
+        case AST_BIN_OP_LT:
+        case AST_BIN_OP_LE:
+        case AST_BIN_OP_GT:
+        case AST_BIN_OP_GE:
+        case AST_BIN_OP_EQ:
+        case AST_BIN_OP_NE:
+        case AST_BIN_OP_LOG_OR:
+        case AST_BIN_OP_LOG_AND:
             return 1;
         default:
             return 0;
@@ -740,7 +810,6 @@ int astIsBinCmp(long op) {
     case TK_LESS_EQU:
     case TK_GREATER_EQU:
     case '+':
-    case AST_OP_ADD:
     case '-':
     case '*':
     case '~':
@@ -759,8 +828,24 @@ int astIsBinCmp(long op) {
     }
 }
 
+int astIsUnOp(Ast *ast) {
+    return ast && ast->kind == AST_UNOP;
+}
+
+int astIsBinOp(Ast *ast) {
+    return ast && ast->kind == AST_BINOP;
+}
+
+int astIsAddr(Ast *ast) {
+    return astIsUnOp(ast) && ast->unop == AST_UN_OP_ADDR_OF;
+}
+
+int astIsDeref(Ast *ast) {
+    return astIsUnOp(ast) && ast->unop == AST_UN_OP_DEREF;
+}
+
 /* This is pretty gross to look at but, eliminated recursion */
-AstType *astGetResultType(long op, AstType *a, AstType *b) {
+AstType *astGetResultType(AstBinOp op, AstType *a, AstType *b) {
     AstType *tmp;
     AstType *ptr1, *ptr2;
     ptr1 = astConvertArray(a);
@@ -774,16 +859,19 @@ start_routine:
     }
 
     if (ptr2->kind == AST_TYPE_POINTER || ptr2->kind == AST_TYPE_FUNC) {
-        if (op == '=') {
+        if (op == AST_BIN_OP_ASSIGN) {
             return ptr1;
         }
 
         if (!astIsValidPointerOp(op)) {
             goto error;
         }
-        if (op != '+' && op != '-'
-                && op != TK_EQU_EQU &&
-                op != TK_NOT_EQU && op != TK_OR_OR && op != TK_AND_AND) {
+        if (op != AST_BIN_OP_ADD &&
+            op != AST_BIN_OP_SUB &&
+            op != AST_BIN_OP_EQ &&
+            op != AST_BIN_OP_NE &&
+            op != AST_BIN_OP_LOG_OR &&
+            op != AST_BIN_OP_LOG_AND) {
             goto error;
         }
 
@@ -796,57 +884,62 @@ start_routine:
         }
         /* These are the only arithmetic operators for pointers,
          * the rest are boolean */
-        if (op != '+' && op != '-') {
+        if (op != AST_BIN_OP_ADD && op != AST_BIN_OP_SUB) {
             return ast_uint_type;
         }
         return ptr2;
     }
     switch (ptr1->kind) {
-    case AST_TYPE_VOID:
-        goto error;
-    case AST_TYPE_INT:
-    case AST_TYPE_CHAR:
-        switch (ptr2->kind) {
+        case AST_TYPE_VOID:
+            goto error;
         case AST_TYPE_INT:
         case AST_TYPE_CHAR:
-            return ast_int_type;
+            switch (ptr2->kind) {
+                case AST_TYPE_INT:
+                case AST_TYPE_CHAR:
+                    return ast_int_type;
+                case AST_TYPE_CLASS:
+                    if (ptr2->is_intrinsic) {
+                        return ast_int_type;
+                    } else {
+                        goto error;
+                    }
+                case AST_TYPE_FLOAT:
+                    return ast_float_type;
+                case AST_TYPE_ARRAY:
+                case AST_TYPE_POINTER:
+                    return ptr2;
+                default:
+                    break;
+            }
+        case AST_TYPE_FLOAT:
+            if (ptr2->kind == AST_TYPE_FLOAT) {
+                return ast_float_type;
+            }
+            goto error;
+        case AST_TYPE_ARRAY:
+            if (ptr2->kind != AST_TYPE_ARRAY) {
+                goto error;
+            }
+            ptr1 = ptr1->ptr;
+            ptr2 = ptr2->ptr;
+            goto start_routine;
         case AST_TYPE_CLASS:
-            if (ptr2->is_intrinsic) {
+            if (ptr1->is_intrinsic && ptr2->is_intrinsic) {
+                return ast_int_type;
+            } else if (astIsIntType(ptr1) && ptr2->is_intrinsic) {
+                return ast_int_type;
+            } else if (ptr1->is_intrinsic && astIsIntType(ptr2)) {
                 return ast_int_type;
             } else {
                 goto error;
             }
-        case AST_TYPE_FLOAT:
-            return ast_float_type;
-        case AST_TYPE_ARRAY:
-        case AST_TYPE_POINTER:
-            return ptr2;
-        }
-    case AST_TYPE_FLOAT:
-        if (ptr2->kind == AST_TYPE_FLOAT) {
-            return ast_float_type;
-        }
-        goto error;
-    case AST_TYPE_ARRAY:
-        if (ptr2->kind != AST_TYPE_ARRAY) {
-            goto error;
-        }
-        ptr1 = ptr1->ptr;
-        ptr2 = ptr2->ptr;
-        goto start_routine;
-    case AST_TYPE_CLASS:
-        if (ptr1->is_intrinsic && ptr2->is_intrinsic) {
-            return ast_int_type;
-        } else if (astIsIntType(ptr1) && ptr2->is_intrinsic) {
-            return ast_int_type;
-        } else if (ptr1->is_intrinsic && astIsIntType(ptr2)) {
-            return ast_int_type;
-        } else {
-            goto error;
-        }
+        default:
+            break;
     }
 
 error:
+    loggerWarning("Binop has returned null type\n");
     return NULL;
 }
 
@@ -957,13 +1050,13 @@ void astStringEndStmt(AoStr *str) {
     }
 }
 
-void astUnaryOpToString(AoStr *str, char *op, Ast *ast,int depth) {
+void astUnaryOpToString(AoStr *str, const char *op, Ast *ast,int depth) {
     aoStrCatPrintf(str, "<unary_expr> %s\n", op);
     _astToString(str, ast->operand, depth+1);
     astStringEndStmt(str);
 }
 
-void astBinaryOpToString(AoStr *str, char *op, Ast *ast, int depth) {
+void astBinaryOpToString(AoStr *str, const char *op, Ast *ast, int depth) {
     aoStrCatPrintf(str, "<binary_expr> %s\n", op);
     _astToString(str, ast->left, depth+1);
     astStringEndStmt(str);
@@ -1205,6 +1298,9 @@ static char *astFunctionToStringInternal(Ast *func, AstType *type) {
         case AST_FUN_PROTO:
             strparams = astParamsToString(func->params);
             break;
+        default:
+            loggerPanic("Invalid function kind: %s\n",
+                    astKindToString(func->kind));
     }
 
     if (strparams) {
@@ -1230,7 +1326,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
     List *node;
     char *tmp;
 
-    switch(ast->kind) {
+    switch (ast->kind) {
         case AST_LITERAL: {
             aoStrCatPrintf(str,"<ast_literal> ");
             switch (ast->type->kind) {
@@ -1359,7 +1455,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
                 Ast *tmp = (Ast *)ast->args->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<function_ptr_arg>\n");
-                if (tmp->kind == AST_TYPE_FUNC) {
+                if (tmp->type->kind == AST_TYPE_FUNC) {
                     loggerWarning("%s\n",
                             astTypeToString(((AstType *)tmp)->rettype));
                 }
@@ -1378,7 +1474,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
                 Ast *tmp = (Ast *)ast->args->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<function_arg>\n");
-                if (tmp->kind == AST_TYPE_FUNC) {
+                if (tmp->type->kind == AST_TYPE_FUNC) {
                     loggerDebug("%s\n",
                             astTypeToString(((AstType *)tmp)->rettype));
                 }
@@ -1573,7 +1669,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
 
             /* We only really want to print at the data type we are looking 
              * at, not the whole class */
-            if (field_type && ast->cls->kind == AST_DEREF) {
+            if (field_type && astIsDeref(ast->cls)) {
                 aoStrCatRepeat(str, "  ", depth+1);
 
                 if (!astIsClassPointer(field_type)) {
@@ -1589,10 +1685,10 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
 
                 /* Find the name of the variable that contains this reference */
                 ast_tmp = ast;
-                while (ast_tmp->kind == AST_DEREF ||
+                while (astIsDeref(ast_tmp) ||
                         ast_tmp->kind == AST_CLASS_REF) {
                     field_names[field_name_count++] = ast_tmp->field;
-                    if (ast_tmp->kind != AST_DEREF &&
+                    if (!astIsDeref(ast_tmp) &&
                             ast_tmp->kind != AST_CLASS_REF) {
                         break;
                     }
@@ -1633,18 +1729,6 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             } else {
                 aoStrCatPrintf(str, "<label> %s:\n", ast->sval->data);
             }
-            break;
-
-        case AST_ADDR:
-            aoStrCatPrintf(str, "<addr>\n");
-            _astToString(str,ast->operand,depth+1);
-            astStringEndStmt(str);
-            break;
-
-        case AST_DEREF:
-            aoStrCatPrintf(str, "<deref>\n");
-            _astToString(str,ast->operand,depth+1);
-            //astStringEndStmt(str);
             break;
 
         case AST_CAST:
@@ -1732,118 +1816,156 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             break;
         }
 
-        case TK_PRE_PLUS_PLUS:
-        case TK_PLUS_PLUS:   
-        case TK_PRE_MINUS_MINUS:
-        case TK_MINUS_MINUS:
-            astUnaryOpToString(str, astKindToString(ast->kind),ast,depth);
-            break;
-
-        default: {
-            astBinaryOpToString(str,astKindToString(ast->kind),ast,depth);
+        case AST_BINOP: {
+            const char *bin_op_str = astBinOpKindToString(ast->binop);
+            astBinaryOpToString(str,bin_op_str,ast,depth);
             astStringEndStmt(str);
             break;
         }
+
+        case AST_UNOP: {
+            const char *un_op_str = astUnOpKindToString(ast->unop);
+            astUnaryOpToString(str,un_op_str,ast,depth);
+            break;
+        }
+        
+        case AST_SIZEOF:
+        case AST_PLACEHOLDER:
+        case AST_ASM_FUNCDEF:
+            loggerWarning("Unhandled ast kind: %s\n",
+                    astKindToString(ast->kind));
+            break;
+    }
+}
+
+char *astTypeKindToString(AstTypeKind kind) {
+    switch (kind) {
+        case AST_TYPE_VOID: return "AST_TYPE_VOID";
+        case AST_TYPE_INT: return "AST_TYPE_INT";
+        case AST_TYPE_FLOAT: return "AST_TYPE_FLOAT";
+        case AST_TYPE_CHAR: return "AST_TYPE_CHAR";
+        case AST_TYPE_ARRAY: return "AST_TYPE_ARRAY";
+        case AST_TYPE_POINTER: return "AST_TYPE_POINTER";
+        case AST_TYPE_FUNC: return "AST_TYPE_FUNC";
+        case AST_TYPE_CLASS: return "AST_TYPE_CLASS";
+        case AST_TYPE_VIS_MODIFIER: return "AST_TYPE_VIS_MODIFIER";
+        case AST_TYPE_INLINE: return "AST_TYPE_INLINE";
+        case AST_TYPE_UNION: return "AST_TYPE_UNION";
+        case AST_TYPE_AUTO: return "AST_TYPE_AUTO";
+        default: loggerPanic("Unhandled ast type: %d\n", (AstTypeKind)kind);
     }
 }
 
 /* String representation of the kind of ast we are looking at */
-char *astKindToString(int kind) {
+char *astKindToString(AstKind kind) {
     switch (kind) {
-    /* KIND FOR AST TYPE */
-    case AST_TYPE_VOID:  return "AST_TYPE_VOID";
-    case AST_TYPE_INT:   return "AST_TYPE_INT";
-    case AST_TYPE_FLOAT: return "AST_TYPE_FLOAT";
-    case AST_TYPE_CHAR:  return "AST_TYPE_CHAR";
-    case AST_TYPE_ARRAY: return "AST_TYPE_ARRAY";
-    case AST_TYPE_POINTER: return "->AST_TYPE_POINTER";
-    case AST_TYPE_FUNC:  return "AST_TYPE_FUNC";
-    case AST_TYPE_CLASS: return "AST_TYPE_CLASS";
-    case AST_TYPE_UNION: return "AST_TYPE_UNION";
-    case AST_TYPE_AUTO:  return "AST_TYPE_AUTO";
+        case AST_GVAR:          return "AST_GVAR";
+        case AST_GOTO:          return "AST_GOTO";
+        case AST_LABEL:         return "AST_LABEL";
+        case AST_LVAR:          return "AST_LVAR";
+        case AST_FUNC:          return "AST_FUNC";
+        case AST_DECL:          return "AST_DECL";
+        case AST_STRING:        return "AST_STRING";
+        case AST_FUNCALL:       return "AST_FUNCALL";
+        case AST_LITERAL:       return "AST_LITERAL";
+        case AST_ARRAY_INIT:    return "AST_ARRAY_INIT";
+        case AST_IF:            return "AST_IF";
+        case AST_FOR:           return "AST_FOR";
+        case AST_RETURN:        return "AST_RETURN";
+        case AST_WHILE:         return "AST_WHILE";
+        case AST_CLASS_REF:     return "AST_CLASS_REF";
+        case AST_COMPOUND_STMT: return "AST_COMPOUND_STMT";
+        case AST_ASM_STMT:      return "AST_ASM_STMT";
+        case AST_ASM_FUNC_BIND: return "AST_ASM_FUNC_BIND";
+        case AST_ASM_FUNCALL:   return "AST_ASM_FUNCALL";
+        case AST_FUNPTR:        return "AST_FUNPTR";
+        case AST_FUNPTR_CALL:   return "AST_FUNPTR_CALL";
+        case AST_BREAK:         return "AST_BREAK";
+        case AST_CONTINUE:      return "AST_CONTINUE";
+        case AST_DEFAULT_PARAM: return "AST_DEFAULT_PARAM";
+        case AST_VAR_ARGS:      return "AST_VAR_ARGS";
+        case AST_ASM_FUNCDEF:   return "AST_ASM_FUNCDEF";
+        case AST_CAST:          return "AST_CAST";
+        case AST_FUN_PROTO:     return "AST_FUN_PROTO";
+        case AST_CASE:          return "AST_CASE";
+        case AST_JUMP:          return "AST_JUMP";
+        case AST_EXTERN_FUNC:   return "AST_EXTERN_FUNC";
+        case AST_DO_WHILE:      return "AST_DO_WHILE";
+        case AST_PLACEHOLDER:   return "AST_PLACEHOLDER";
+        case AST_SWITCH:        return "AST_SWITCH";
+        case AST_DEFAULT:       return "AST_DEFAULT";
+        case AST_SIZEOF:        return "AST_SIZEOF";
+        case AST_COMMENT:       return "AST_COMMENT";
+        case AST_BINOP:         return "AST_BINOP";
+        case AST_UNOP:          return "AST_UNOP";
+            break;
+    }
+    loggerPanic("Cannot find kind: %d\n", kind);
+}
 
-    case AST_GVAR:       return "AST_GVAR";
-    case AST_DEREF:      return "AST_DEREF";
-    case AST_ADDR:       return "AST_ADDR";
-    case AST_LVAR:       return "AST_LVAR";
-    case AST_FUNC:       return "AST_FUNC";
-    case AST_FUNPTR:     return "AST_FUNPTR";
-    case AST_EXTERN_FUNC: return "AST_EXTERN_FUNC";
-    case AST_DECL:       return "AST_DECL";
-    case AST_STRING:     return "AST_STRING";
-    case AST_FUNCALL:    return "AST_FUNCALL";
-    case AST_LITERAL:    return "AST_LITERAL";
-    case AST_ARRAY_INIT: return "AST_ARRAY_INIT";
-    case AST_IF:         return "AST_IF";
-    case AST_FOR:        return "AST_FOR";
-    case AST_GOTO:       return "AST_GOTO";
-    case AST_LABEL:      return "AST_LABEL";
-    case AST_RETURN:     return "AST_RETURN";
-    case AST_COMPOUND_STMT: return "AST_COMPOUND_STMT";
-    case AST_CLASS_REF:  return "AST_CLASS_REF";
-    case AST_DEFAULT_PARAM: return "AST_DEFAULT_PARAM";
-    case AST_VAR_ARGS:   return "AST_VAR_ARGS";
-    case AST_CAST:       return "AST_CAST";
-    case AST_JUMP:       return "AST_JUMP";
-    case AST_ASM_FUNC_BIND: return "AST_ASM_FUNC_BIND";
-
-    case AST_SWITCH:        return "AST_SWITCH";
-    case AST_CASE:          return "AST_CASE";
-    case AST_DEFAULT:       return "AST_DEFAULT";
-    case AST_COMMENT:       return "AST_COMMENT";
-    case AST_SIZEOF:        return "AST_SIZEOF";
-
-
-    case TK_AND_AND:         return "&&";
-    case TK_OR_OR:           return "||";
-    case TK_SHL:             return "<<";
-    case TK_SHR:             return ">>";
-    case TK_PLUS_PLUS:       return "++";
-    case TK_PRE_PLUS_PLUS:   return "<p>++";
-    case TK_PRE_MINUS_MINUS: return "<p>--";
-    case TK_MINUS_MINUS:     return "--";
-    case TK_EQU_EQU:         return "==";
-    case TK_NOT_EQU:         return "!=";
-    case TK_LESS_EQU:        return "<=";
-    case TK_GREATER_EQU:     return ">=";
-    case TK_DIV_EQU:         return "/=";
-    case TK_MUL_EQU:         return "*=";
-    case TK_MOD_EQU:         return "%=";
-    case TK_ADD_EQU:         return "+=";
-    case TK_SUB_EQU:         return "-=";
-    case TK_SHL_EQU:         return "<<=";
-    case TK_SHR_EQU:         return ">>=";
-    case TK_AND_EQU:         return "&=";
-    case TK_OR_EQU:          return "|=";
-    case TK_XOR_EQU:         return "^=";
-    case '+':
-    case AST_OP_ADD:     return "+";
-    case '-':            return "-";
-    case '*':            return "*";
-    case '~':            return "~";
-    case '<':            return "<";
-    case '>':            return ">";
-    case '/':            return "/";
-    case '&':            return "&";
-    case '|':            return "|";
-    case '=':            return "=";
-    case '!':            return "!";
-    case '%':            return "%";
-    case '^':            return "^";
-    default:
-        loggerPanic("Cannot find kind: %d\n", kind);
+int astIsRangeOperator(AstBinOp op) {
+    switch (op) {
+        case AST_BIN_OP_GE:
+        case AST_BIN_OP_GT:
+        case AST_BIN_OP_LE:
+        case AST_BIN_OP_LT:
+            return 1;
+        default:
+            return 0;
     }
 }
 
-int astIsRangeOperator(long op) {
+const char *astUnOpKindToString(AstUnOp op) {
     switch (op) {
-    case TK_GREATER_EQU:
-    case TK_LESS_EQU:
-    case '<':
-    case '>':
-        return 1;
-    default:
-        return 0;
+        case AST_UN_OP_POST_INC: return "++";
+        case AST_UN_OP_POST_DEC: return "--";
+        case AST_UN_OP_PRE_INC: return "++";
+        case AST_UN_OP_PRE_DEC: return "--";
+        case AST_UN_OP_PLUS: return "+";
+        case AST_UN_OP_MINUS: return "-";
+        case AST_UN_OP_LOG_NOT: return "!";
+        case AST_UN_OP_BIT_NOT: return "~";
+        case AST_UN_OP_ADDR_OF: return "&";
+        case AST_UN_OP_DEREF: return "*";
+        case AST_UN_OP_SIZEOF: return "sizeof";
+        case AST_UN_OP_ALIGNOF: return "alignof";
+        case AST_UN_OP_CAST: return "cast";
+        default: loggerPanic("Unhandled unary op: %d\n", (AstUnOp)op);
+    }
+}
+
+const char *astBinOpKindToString(AstBinOp op) {
+    switch (op) {
+        case AST_BIN_OP_MUL: return "*";
+        case AST_BIN_OP_DIV: return "/";
+        case AST_BIN_OP_MOD: return "%";
+        case AST_BIN_OP_ADD: return "+";
+        case AST_BIN_OP_SUB: return "-";
+        case AST_BIN_OP_SHL: return "<<";
+        case AST_BIN_OP_SHR: return ">>";
+        case AST_BIN_OP_LT: return "<";
+        case AST_BIN_OP_LE: return "<=";
+        case AST_BIN_OP_GT: return ">";
+        case AST_BIN_OP_GE: return ">=";
+        case AST_BIN_OP_EQ: return "==";
+        case AST_BIN_OP_NE: return "!=";
+        case AST_BIN_OP_BIT_AND: return "&";
+        case AST_BIN_OP_BIT_XOR: return "^";
+        case AST_BIN_OP_BIT_OR: return "|";
+        case AST_BIN_OP_LOG_AND: return "&&";
+        case AST_BIN_OP_LOG_OR: return "||";
+        case AST_BIN_OP_ASSIGN: return "=";
+        case AST_BIN_OP_ADD_ASSIGN: return "+=";
+        case AST_BIN_OP_SUB_ASSIGN: return "-=";
+        case AST_BIN_OP_MUL_ASSIGN: return "*=";
+        case AST_BIN_OP_DIV_ASSIGN: return "/=";
+        case AST_BIN_OP_MOD_ASSIGN: return "%=";
+        case AST_BIN_OP_SHL_ASSIGN: return "<<=";
+        case AST_BIN_OP_SHR_ASSIGN: return ">>=";
+        case AST_BIN_OP_AND_ASSIGN: return "&=";
+        case AST_BIN_OP_XOR_ASSIGN: return "^=";
+        case AST_BIN_OP_OR_ASSIGN:  return "|=";
+        default: loggerPanic("Unhandled binary op: %d\n", (AstBinOp)op);
     }
 }
 
@@ -1880,7 +2002,6 @@ void astBinaryArgToString(AoStr *str, char *op, Ast *ast, unsigned long lexeme_f
 
 /* This can only be used for lvalues */
 static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags) {
-    char *str_op = NULL;
     if (ast == NULL) {
         aoStrCatLen(str, "(null)", 6);
         return;
@@ -2004,30 +2125,6 @@ static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags)
             break;
         }
 
-        case AST_ADDR:
-            aoStrCatPrintf(str, "&");
-            _astLValueToString(str,ast->operand,lexeme_flags);
-            break;
-
-        case AST_DEREF: {
-            if (ast->operand->kind == '+') {
-                Ast *left = ast->operand->left;
-                Ast *right = ast->operand->right;
-                _astLValueToString(str, left, lexeme_flags);
-                aoStrPutChar(str, '[');
-                _astLValueToString(str, right, lexeme_flags);
-                aoStrPutChar(str, ']');
-            } else {
-                /* As `->` is a dereference we need to be able to distinguish 
-                 * between a class dereference and a general pointer dereference */
-                if (ast->deref_symbol != TK_ARROW) {
-                    aoStrCatFmt(str, "*");
-                }
-                _astLValueToString(str, ast->operand, lexeme_flags);
-            }
-            break;
-        }
-
         case AST_CAST: {
             _astLValueToString(str,ast->operand,lexeme_flags);
             char *type = astTypeToString(ast->type);
@@ -2056,7 +2153,6 @@ static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags)
             break;
         }
 
-
         case AST_SIZEOF: {
             char *type_str = astTypeToString(ast->type);
             aoStrCatPrintf(str, "sizeof(%s)",type_str);
@@ -2067,41 +2163,63 @@ static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags)
             aoStrCatPrintf(str, "break;");
             break;
 
-        case TK_PRE_PLUS_PLUS:
-        case TK_PLUS_PLUS:   
-        case TK_PRE_MINUS_MINUS:
-        case TK_MINUS_MINUS:
-        case '~':
-        case '!': {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            astUnaryArgToString(str,str_op,ast,lexeme_flags);
-            break;
-        }
-        case '-': {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            if (ast->right == NULL) {
-                astUnaryArgToString(str,str_op,ast,lexeme_flags);
-            } else {
-                astBinaryArgToString(str,str_op,ast,lexeme_flags);
-            }
-            break;
-        }
-
         case AST_COMMENT: {
             aoStrCatPrintf(str, "%s\n", ast->sval->data);
             break;
         }
 
-
-        default: {
-            str_op = lexemePunctToStringWithFlags(ast->kind,lexeme_flags);
-            astBinaryArgToString(str,str_op,ast,lexeme_flags);
+        case AST_BINOP: {
+            const char *bin_op_str = astBinOpKindToString(ast->binop);
+            _astLValueToString(str, ast->left, lexeme_flags);
+            aoStrCatPrintf(str, " %s ", bin_op_str);
+            _astLValueToString(str, ast->right, lexeme_flags);
             if (ast->left == NULL) {
                 aoStrCatPrintf(str,"%s",
                         lexemePunctToStringWithFlags(';',lexeme_flags));
             }
             break;
         }
+
+        case AST_UNOP: {
+            if (astIsDeref(ast)) {
+                if (ast->operand->kind == AST_BINOP &&
+                        ast->operand->binop == AST_BIN_OP_ADD) {
+                    Ast *left = ast->operand->left;
+                    Ast *right = ast->operand->right;
+                    _astLValueToString(str, left, lexeme_flags);
+                    aoStrPutChar(str, '[');
+                    _astLValueToString(str, right, lexeme_flags);
+                    aoStrPutChar(str, ']');
+                } else {
+                    /* As `->` is a dereference we need to be able to distinguish 
+                     * between a class dereference and a general pointer dereference */
+                    if (ast->deref_symbol != TK_ARROW) {
+                        aoStrCatFmt(str, "*");
+                    }
+                    _astLValueToString(str, ast->operand, lexeme_flags);
+                }
+            } else {
+                const char *un_op_str = astUnOpKindToString(ast->unop);
+                aoStrCatPrintf(str, "%s", un_op_str);
+                _astLValueToString(str, ast->operand,lexeme_flags);
+            }
+            break;
+        }
+
+        case AST_ARRAY_INIT:
+        case AST_IF:
+        case AST_FOR:
+        case AST_WHILE:
+        case AST_COMPOUND_STMT:
+        case AST_ASM_STMT:
+        case AST_CONTINUE:
+        case AST_DEFAULT_PARAM:
+        case AST_ASM_FUNCDEF:
+        case AST_JUMP:
+        case AST_DO_WHILE:
+        case AST_PLACEHOLDER:
+        case AST_SWITCH:
+            break;
     }
 }
 
@@ -2119,7 +2237,7 @@ char *astLValueToString(Ast *ast, unsigned long lexeme_flags) {
 /* Just print out one */
 void astPrint(Ast *ast) {
     char *str = astToString(ast);
-    printf("%s\n", str);
+    fprintf(stderr, "%s\n", str);
 }
 
 void astTypePrint(AstType *type) {
@@ -2151,14 +2269,6 @@ const char *astTypeKindToHumanReadable(AstType *type) {
 
 const char *astKindToHumanReadable(Ast *ast) {
     switch (ast->kind) {
-        case '|': return "bitwise OR";
-        case '&': return "bitwise AND";
-        case '!': return "logical NOT";
-        case '~': return "bitwise NOT";
-        case AST_ADDR: return "address";
-        case AST_DEREF: return "dereference";
-        case TK_PLUS_PLUS: return "increment";
-        case TK_MINUS_MINUS: return "decrement";
         case AST_LITERAL: return "literal";
         case AST_GVAR: return "global variable";
         case AST_GOTO: return "goto statement";
@@ -2195,22 +2305,9 @@ const char *astKindToHumanReadable(Ast *ast) {
         case AST_DEFAULT: return "default statement";
         case AST_SIZEOF: return "size of";
         case AST_COMMENT: return "comment";
-        case TK_AND_AND: return "logical AND";
-        case TK_OR_OR: return "logical OR";
-        case TK_EQU_EQU: return "equality comparison";
-        case TK_NOT_EQU: return "inequality comparison";
-        case TK_LESS_EQU: return "less than or equal comparison";
-        case TK_GREATER_EQU: return "greater than or equal comparison";
-        case TK_SHL: return "left shift";
-        case TK_SHR: return "right shift";
-        case TK_ARROW: return "pointer dereference";
-        case '=': return "assignment";
-        case '>': return "greater than comparison";
-        case '<': return "less than comparison";
-        case '/': return "division";
-        case '+': return "addition";
-        case '*': return "multiplication";
-        case '-': return "subtraction";
+        case AST_PLACEHOLDER: return "placeholder";
+        case AST_BINOP: return "binary op";
+        case AST_UNOP: return "unary op";
         default: return "unknown AST kind";
     }
 }

--- a/src/ast.c
+++ b/src/ast.c
@@ -184,7 +184,7 @@ int astBinOpFromToken(long op, AstBinOp *_result) {
         case '<': *_result = AST_BIN_OP_LT;     break;
         case '>': *_result = AST_BIN_OP_GT;     break;
         case TK_GREATER_EQU: *_result = AST_BIN_OP_GE;  break;
-        case TK_LESS_EQU: *_result = AST_BIN_OP_GE;  break;
+        case TK_LESS_EQU: *_result = AST_BIN_OP_LE;  break;
 
         case TK_EQU_EQU: *_result = AST_BIN_OP_EQ; break;
         case TK_NOT_EQU: *_result = AST_BIN_OP_NE; break;
@@ -1358,7 +1358,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
                 if (!isatty(STDOUT_FILENO)) {
                     aoStrCatPrintf(str, "<const_char> '%s'", buf);
                 } else {
-                    aoStrCatPrintf(str, "\033[0;35m%s\033[0m", buf);
+                    aoStrCatPrintf(str, "<const_char> \033[0;35m'%s'\033[0m", buf);
                 }
                 break;
             }

--- a/src/ast.c
+++ b/src/ast.c
@@ -943,7 +943,7 @@ error:
     return NULL;
 }
 
-AstType *astTypeCheck(AstType *expected, Ast *ast, long op) {
+AstType *astTypeCheck(AstType *expected, Ast *ast, AstBinOp op) {
     if (expected != NULL && ast == NULL) return NULL;
 
     AstType *original_actual = ast->type;
@@ -974,7 +974,7 @@ check_type:
             ret = e;
             goto out;
         } else {
-            if (op != '=') {
+            if (op != AST_BIN_OP_ASSIGN) {
                 ret = e;
             } else if (ast->right != NULL) {
                 if (ast->right->kind == AST_LITERAL && ast->right->i64 == 0) {
@@ -1919,8 +1919,8 @@ const char *astUnOpKindToString(AstUnOp op) {
     switch (op) {
         case AST_UN_OP_POST_INC: return "++";
         case AST_UN_OP_POST_DEC: return "--";
-        case AST_UN_OP_PRE_INC: return "++";
-        case AST_UN_OP_PRE_DEC: return "--";
+        case AST_UN_OP_PRE_INC: return "pre ++";
+        case AST_UN_OP_PRE_DEC: return "pre --";
         case AST_UN_OP_PLUS: return "+";
         case AST_UN_OP_MINUS: return "-";
         case AST_UN_OP_LOG_NOT: return "!";

--- a/src/ast.c
+++ b/src/ast.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <assert.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -341,8 +342,11 @@ Ast *astFunctionDefaultParam(Ast *var, Ast *init) {
     return ast;
 }
 
-Ast *astFunctionPtrCall(AstType *type, char *fname, int len,
-                        Vec *argv, Ast *ref)
+Ast *astFunctionPtrCall(AstType *type,
+                        char *fname,
+                        int len,
+                        Vec *argv,
+                        Ast *ref)
 {
     Ast *ast = astNew();
     ast->type = type;
@@ -747,7 +751,7 @@ AoStr *astNormaliseFunctionName(char *fname) {
         aoStrPutChar(newfn, '_');
     }
 #endif
-    aoStrCatPrintf(newfn,fname);
+    aoStrCatPrintf(newfn, fname);
     /* XXX: Dynamically create main function */
     return newfn;
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -5,61 +5,141 @@
 #include "containers.h"
 #include "list.h"
 
+typedef enum AstUnOp {
+    /* postfix (evaluated after value is yielded) */
+    AST_UN_OP_POST_INC,   /* x++ */
+    AST_UN_OP_POST_DEC,   /* x-- */
+
+    /* prefix (evaluated before value is yielded) */
+    AST_UN_OP_PRE_INC,    /* ++x */
+    AST_UN_OP_PRE_DEC,    /* --x */
+
+    /* arithmetic sign */
+    AST_UN_OP_PLUS,       /* +x */
+    AST_UN_OP_MINUS,      /* -x */
+
+    /* logical & bitwise */
+    AST_UN_OP_LOG_NOT,    /* !x */
+    AST_UN_OP_BIT_NOT,    /* ~x */
+
+    /* pointer & address */
+    AST_UN_OP_ADDR_OF,    /* &x */
+    AST_UN_OP_DEREF,      /* *p */
+
+    AST_UN_OP_SIZEOF,
+    AST_UN_OP_ALIGNOF,
+    AST_UN_OP_CAST
+} AstUnOp;
+
+const char *astUnOpKindToString(AstUnOp op);
+
+typedef enum AstBinOp {
+    /* multiplicative */
+    AST_BIN_OP_MUL,          /* a * b */
+    AST_BIN_OP_DIV,          /* a / b */
+    AST_BIN_OP_MOD,          /* a % b */
+
+    /* additive */
+    AST_BIN_OP_ADD,          /* a + b */
+    AST_BIN_OP_SUB,          /* a - b */
+
+    /* bit-shift */
+    AST_BIN_OP_SHL,          /* a << b */
+    AST_BIN_OP_SHR,          /* a >> b */
+
+    /* relational */
+    AST_BIN_OP_LT,           /* a <  b */
+    AST_BIN_OP_LE,           /* a <= b */
+    AST_BIN_OP_GT,           /* a >  b */
+    AST_BIN_OP_GE,           /* a >= b */
+
+    /* equality */
+    AST_BIN_OP_EQ,           /* a == b */
+    AST_BIN_OP_NE,           /* a != b */
+
+    /* bitwise */
+    AST_BIN_OP_BIT_AND,      /* a &  b */
+    AST_BIN_OP_BIT_XOR,      /* a ^  b */
+    AST_BIN_OP_BIT_OR,       /* a |  b */
+
+    /* logical */
+    AST_BIN_OP_LOG_AND,      /* a && b */
+    AST_BIN_OP_LOG_OR,       /* a || b */
+
+    /* assignment (simple + compound) */
+    AST_BIN_OP_ASSIGN,       /* a  =  b */
+    AST_BIN_OP_ADD_ASSIGN,   /* a += b */
+    AST_BIN_OP_SUB_ASSIGN,   /* a -= b */
+    AST_BIN_OP_MUL_ASSIGN,   /* a *= b */
+    AST_BIN_OP_DIV_ASSIGN,   /* a /= b */
+    AST_BIN_OP_MOD_ASSIGN,   /* a %= b */
+    AST_BIN_OP_SHL_ASSIGN,   /* a <<= b */
+    AST_BIN_OP_SHR_ASSIGN,   /* a >>= b */
+    AST_BIN_OP_AND_ASSIGN,   /* a &= b */
+    AST_BIN_OP_XOR_ASSIGN,   /* a ^= b */
+    AST_BIN_OP_OR_ASSIGN     /* a |= b */
+} AstBinOp;
+
+const char *astBinOpKindToString(AstBinOp op);
+
 /* Relates to the 'kind' property on the AstType struct */
-#define AST_TYPE_VOID         0
-#define AST_TYPE_INT          1
-#define AST_TYPE_FLOAT        2
-#define AST_TYPE_CHAR         3
-#define AST_TYPE_ARRAY        4
-#define AST_TYPE_POINTER      5
-#define AST_TYPE_FUNC         6
-#define AST_TYPE_CLASS        7
-#define AST_TYPE_VIS_MODIFIER 8
-#define AST_TYPE_INLINE       9
-#define AST_TYPE_UNION        10
-#define AST_TYPE_AUTO         11
+typedef enum AstTypeKind {
+    AST_TYPE_VOID         = 0,
+    AST_TYPE_INT          = 1,
+    AST_TYPE_FLOAT        = 2,
+    AST_TYPE_CHAR         = 3,
+    AST_TYPE_ARRAY        = 4,
+    AST_TYPE_POINTER      = 5,
+    AST_TYPE_FUNC         = 6,
+    AST_TYPE_CLASS        = 7,
+    AST_TYPE_VIS_MODIFIER = 8,
+    AST_TYPE_INLINE       = 9,
+    AST_TYPE_UNION        = 10,
+    AST_TYPE_AUTO         = 11
+} AstTypeKind;
 
 /* Relates to the 'kind' property on the Ast struct */
-#define AST_GVAR           256
-#define AST_DEREF          257
-#define AST_GOTO           258
-#define AST_LABEL          259
-#define AST_ADDR           260
-#define AST_LVAR           261
-#define AST_FUNC           262
-#define AST_DECL           263
-#define AST_STRING         264
-#define AST_FUNCALL        265
-#define AST_LITERAL        266
-#define AST_ARRAY_INIT     267
-#define AST_IF             268
-#define AST_FOR            269
-#define AST_RETURN         270
-#define AST_WHILE          271
-#define AST_OP_ADD         272
-#define AST_CLASS_REF      273
-#define AST_COMPOUND_STMT  274
-#define AST_ASM_STMT       275
-#define AST_ASM_FUNC_BIND  276
-#define AST_ASM_FUNCALL    277
-#define AST_FUNPTR         278
-#define AST_FUNPTR_CALL    279
-#define AST_BREAK          280
-#define AST_CONTINUE       281
-#define AST_DEFAULT_PARAM  282
-#define AST_VAR_ARGS       283
-#define AST_ASM_FUNCDEF    284
-#define AST_CAST           285
-#define AST_FUN_PROTO      286
-#define AST_CASE           287
-#define AST_JUMP           288
-#define AST_EXTERN_FUNC    289
-#define AST_DO_WHILE       290
-#define AST_PLACEHOLDER    291
-#define AST_SWITCH         292
-#define AST_DEFAULT        293
-#define AST_SIZEOF         294
-#define AST_COMMENT        295
+typedef enum AstKind {
+    AST_GVAR          = 256,
+    AST_GOTO          = 258,
+    AST_LABEL         = 259,
+    AST_LVAR          = 261,
+    AST_FUNC          = 262,
+    AST_DECL          = 263,
+    AST_STRING        = 264,
+    AST_FUNCALL       = 265,
+    AST_LITERAL       = 266,
+    AST_ARRAY_INIT    = 267,
+    AST_IF            = 268,
+    AST_FOR           = 269,
+    AST_RETURN        = 270,
+    AST_WHILE         = 271,
+    AST_CLASS_REF     = 273,
+    AST_COMPOUND_STMT = 274,
+    AST_ASM_STMT      = 275,
+    AST_ASM_FUNC_BIND = 276,
+    AST_ASM_FUNCALL   = 277,
+    AST_FUNPTR        = 278,
+    AST_FUNPTR_CALL   = 279,
+    AST_BREAK         = 280,
+    AST_CONTINUE      = 281,
+    AST_DEFAULT_PARAM = 282,
+    AST_VAR_ARGS      = 283,
+    AST_ASM_FUNCDEF   = 284,
+    AST_CAST          = 285,
+    AST_FUN_PROTO     = 286,
+    AST_CASE          = 287,
+    AST_JUMP          = 288,
+    AST_EXTERN_FUNC   = 289,
+    AST_DO_WHILE      = 290,
+    AST_PLACEHOLDER   = 291,
+    AST_SWITCH        = 292,
+    AST_DEFAULT       = 293,
+    AST_SIZEOF        = 294,
+    AST_COMMENT       = 295,
+    AST_BINOP         = 296,
+    AST_UNOP          = 297,
+} AstKind;
 
 /* @Cleanup
  * Urgently get rid of this, we do not need `n` ways of setting a label on 
@@ -72,7 +152,7 @@
 typedef struct AstType AstType;
 /* Type of the variable or type of return type of a function */
 typedef struct AstType {
-    int kind;
+    AstTypeKind kind;
     int size;
     int has_var_args;
 
@@ -104,7 +184,7 @@ typedef struct AstType {
 
 typedef struct Ast Ast;
 typedef struct Ast {
-    long kind;
+    AstKind kind;
     unsigned long flags;
     AstType *type;
     int loff;
@@ -160,12 +240,14 @@ typedef struct Ast {
 
         /* Binary operator */
         struct {
+            AstBinOp binop;
             Ast *left;
             Ast *right;
         };
 
         /* Unary operator */
         struct {
+            AstUnOp unop;
             Ast *operand;
         };
 
@@ -318,8 +400,8 @@ Ast *astString(char *str, int len, long real_len);
 Ast *astDecl(Ast *var, Ast *init);
 
 /* Symbol operators i.e: +-*&^><*/
-Ast *astBinaryOp(long operation, Ast *left, Ast *right, int *_is_err);
-Ast *astUnaryOperator(AstType *type, long kind, Ast *operand);
+Ast *astBinaryOp(AstBinOp operation, Ast *left, Ast *right, int *_is_err);
+Ast *astUnaryOperator(AstType *type, AstUnOp operation, Ast *operand);
 
 /* Variable definitions */
 Ast *astLVar(AstType *type, char *name, int len);
@@ -383,32 +465,46 @@ Ast *astClassRef(AstType *type, Ast *cls, char *field_name);
 AstType *astClassType(Map *fields, AoStr *clsname, int size, int is_intrinsic);
 Ast *astCast(Ast *var, AstType *to);
 
-AstType *astGetResultType(long op, AstType *a, AstType *b);
+AstType *astGetResultType(AstBinOp op, AstType *a, AstType *b);
 AstType *astTypeCheck(AstType *expected, Ast *ast, long op);
+
+/* Queries */
+int astIsIntType(AstType *type);
+int astIsFloatType(AstType *type);
+int astTypeIsPtr(AstType *type);
+int astTypeIsArray(AstType *type);
+int astIsVarArg(Ast *ast);
+int astIsRangeOperator(AstBinOp op);
+int astIsBinCmp(long op);
+int astIsAssignment(long op);
+int astIsLabelMatch(Ast *ast, AoStr *goto_label);
+int astIsAddr(Ast *ast);
+int astIsDeref(Ast *ast);
+int astIsUnOp(Ast *ast);
+int astIsBinOp(Ast *ast);
+
 
 AoStr *astMakeLabel(void);
 AoStr *astMakeTmpName(void);
-int astIsIntType(AstType *type);
-int astIsFloatType(AstType *type);
-int astIsVarArg(Ast *ast);
-int astIsRangeOperator(long op);
 Ast *astGlobalCmdArgs(void);
 
 AoStr *astNormaliseFunctionName(char *fname);
-int astIsAssignment(long op);
-int astIsBinCmp(long op);
 Ast *astMakeForeverSentinal(void);
 Ast *astMakeLoopSentinal(void);
 char *astAnnonymousLabel(void);
 
-int astIsLabelMatch(Ast *ast, AoStr *goto_label);
+/* Returns `1` on successful conversion and `0` on failure */
+int astUnaryOpFromToken(long op, AstUnOp *_result);
+/* Returns `1` on successful conversion and `0` on failure */
+int astBinOpFromToken(long op, AstBinOp *_result);
 
 /* For debugging */
 AoStr *astTypeToAoStr(AstType *type);
 char *astTypeToString(AstType *type);
 char *astTypeToColorString(AstType *type);
 AoStr *astTypeToColorAoStr(AstType *type);
-char *astKindToString(int kind);
+char *astKindToString(AstKind kind);
+char *astTypeKindToString(AstTypeKind kind);
 char *astFunctionToString(Ast *func);
 char *astFunctionNameToString(AstType *rettype, char *fname, int len);
 char *astToString(Ast *ast);

--- a/src/ast.h
+++ b/src/ast.h
@@ -432,11 +432,17 @@ Ast *astFunctionCall(AstType *type, char *fname, int len, Vec *argv);
 Ast *astFunction(AstType *rettype, char *fname, int len, Vec *params,
                  Ast *body, List *locals, int has_var_args);
 Ast *astReturn(Ast *retval, AstType *rettype);
-Ast *astFunctionPtr(AstType *type, char *fname, int len, 
+Ast *astFunctionPtr(AstType *type,
+                    char *fname,
+                    int fname_len, 
                     Vec *params);
 
-Ast *astFunctionPtrCall(AstType *type, char *fname, int len,
-                        Vec *argv, Ast *ref);
+Ast *astFunctionPtrCall(AstType *type,
+                        char *fname,
+                        int fname_len,
+                        Vec *argv,
+                        Ast *ref);
+
 Ast *astFunctionDefaultParam(Ast *var, Ast *init);
 Ast *astVarArgs(void);
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -466,7 +466,7 @@ AstType *astClassType(Map *fields, AoStr *clsname, int size, int is_intrinsic);
 Ast *astCast(Ast *var, AstType *to);
 
 AstType *astGetResultType(AstBinOp op, AstType *a, AstType *b);
-AstType *astTypeCheck(AstType *expected, Ast *ast, long op);
+AstType *astTypeCheck(AstType *expected, Ast *ast, AstBinOp op);
 
 /* Queries */
 int astIsIntType(AstType *type);

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -1053,19 +1053,16 @@ static void cfgHandleAstNode(CFGBuilder *builder, Ast *ast) {
         /* Should never hit this */
         case AST_FUNC: break;
 
-        case AST_ADDR:
         case AST_ASM_FUNCDEF:
         case AST_ASM_FUNC_BIND:
         case AST_ASM_STMT:
         case AST_CAST:
         case AST_CLASS_REF:
         case AST_DEFAULT_PARAM:
-        case AST_DEREF:
         case AST_EXTERN_FUNC:
         case AST_FUNPTR:
         case AST_FUN_PROTO:
         case AST_LITERAL:
-        case AST_OP_ADD:
         case AST_PLACEHOLDER:
         case AST_STRING:
         case AST_VAR_ARGS:

--- a/src/containers.c
+++ b/src/containers.c
@@ -154,9 +154,11 @@ void vecInsertAt(Vec *vec, void *value, unsigned long idx) {
     if (vec->size + 1 >= vec->capacity) {
         vecReserve(vec, vec->capacity * 2);
     }
+#ifdef DEBUG
     if (idx >= vec->size) {
-        fprintf(stderr, "Vec - idx %lu is out of range", idx);
+        loggerWarning("Vec - idx %lu is out of range\n", idx);
     }
+#endif
     unsigned long elements_to_move = vec->size - idx;
     memmove(&vec->entries[idx + 1],
             &vec->entries[idx],
@@ -169,7 +171,7 @@ void *vecGetAt(Vec *vec, unsigned long idx) {
     /* Bounds check */
 #ifdef DEBUG
     if (idx >= vec->size) {
-        fprintf(stderr, "Vec - idx %lu is out of range for Vec of size %lu",
+        loggerWarning("Vec - idx %lu is out of range for Vec of size %lu\n",
                 idx, vec->size);
     }
 #endif

--- a/src/containers.h
+++ b/src/containers.h
@@ -34,7 +34,7 @@ struct Vec {
     VecType *type;
 };
 
-#define vecInBounds(vec, idx) ((idx >= 0) && idx < (vec)->size)
+#define vecInBounds(vec, idx) (idx < (vec)->size)
 #define vecGetInBounds(vec, idx) (vecInBounds(vec,idx) ? (vec)->entries[idx] : NULL)
 #define vecEmpty(vec) ((vec)->size == 0)
 #define vecGet(type,vec,idx) ((type)((vec)->entries[idx]))

--- a/src/holyc-lib/json.HC
+++ b/src/holyc-lib/json.HC
@@ -380,7 +380,7 @@ static Bool JsonSetExpectedType(JsonParser *p)
     case 'f': p->type = JSON_PARSER_BOOL; break;
     case '"': p->type = JSON_PARSER_STRING; break;
     default: {
-      if ( ('0'<=peek<='9') || peek == '-' || peek == '+' || peek == '.') {
+      if (('0'<=peek<='9') || peek == '-' || peek == '+' || peek == '.') {
         p->type = JSON_PARSER_NUMERIC;
         break;
       } else {
@@ -908,7 +908,7 @@ U0 JsonPrintError(Json *json)
 {
   U8 *str_error = JsonGetStrerror(json);
   if (str_error) {
-    "%s\n";
+    "%s\n", str_error;
     Free(str_error);
   } else {
     "No errors\n";

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -528,7 +528,7 @@ char *lexemeToString(Lexeme *tok) {
 void lexemePrint(Lexeme *le) {
     if (le) {
         char *str = lexemeToString(le);
-        printf("%ld: %s\n", le->line, str);
+        printf("%d: %s\n", le->line, str);
       //  free(str);
     }
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -528,7 +528,7 @@ char *lexemeToString(Lexeme *tok) {
 void lexemePrint(Lexeme *le) {
     if (le) {
         char *str = lexemeToString(le);
-        printf("%s\n", str);
+        printf("%ld: %s\n", le->line, str);
       //  free(str);
     }
 }
@@ -1067,7 +1067,7 @@ int lex(Lexer *l, Lexeme *le) {
                     lexNextChar(l);
                     if (lexPeekMatch(l, '=')) {
                         lexNextChar(l);
-                        lexemeAssignOp(le,start,2,TK_SHL_EQU,l->lineno);
+                        lexemeAssignOp(le,start,3,TK_SHL_EQU,l->lineno);
                     } else {
                         lexemeAssignOp(le,start,2,TK_SHL,l->lineno);
                     }
@@ -1084,7 +1084,7 @@ int lex(Lexer *l, Lexeme *le) {
                     lexNextChar(l);
                     if (lexPeekMatch(l, '=')) {
                         lexNextChar(l);
-                        lexemeAssignOp(le,start,2,TK_SHR_EQU,l->lineno);
+                        lexemeAssignOp(le,start,3,TK_SHR_EQU,l->lineno);
                     } else {
                         lexemeAssignOp(le,start,2,TK_SHR,l->lineno);
                     }
@@ -1230,17 +1230,20 @@ int lex(Lexer *l, Lexeme *le) {
                 return 1;
             }
 
-            case '~':
-            case '(':
-            case ')':
-            case ',':
-            case ';':
-            case ':':
+            case ':': {
                 if (l->flags & CCF_MULTI_COLON && lexPeekMatch(l,':')) {
                     lexNextChar(l);
                     lexemeAssignOp(le,start,2,TK_DBL_COLON,l->lineno);
                     return 1;
                 }
+                lexemeAssignOp(le,start,1,ch,l->lineno);
+                return 1;
+            }
+            case '~':
+            case '(':
+            case ')':
+            case ',':
+            case ';':
             case '[':
             case ']':
             case '{':

--- a/src/parser.c
+++ b/src/parser.c
@@ -1671,9 +1671,6 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
     Vec *params = parseParams(cc,')',&has_var_args,1);
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {
-#ifdef DEBUG
-        fprintf(stderr, "Parsing function: %.*s\n",len,fname);
-#endif
         return parseFunctionDef(cc,rettype,fname,len,params,has_var_args,is_inline);
     } else {
         if (rettype->kind == AST_TYPE_AUTO) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -52,7 +52,7 @@ Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
 }
 
 void parseTypeCheckClassFieldInitaliser(Cctrl *cc, AstType *cls_field_type, Ast *init) {
-    if (!astTypeCheck(cls_field_type, init, '=')) {
+    if (!astTypeCheck(cls_field_type, init, AST_BIN_OP_ASSIGN)) {
         char *cls_field_str = astTypeToColorString(cls_field_type);
         char *init_field = astTypeToColorString(init->type);
         char *var_string = astLValueToString(init,0);
@@ -566,7 +566,7 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
     }
 
     /* Check what we are trying to assign is valid */
-    AstType *ok = astTypeCheck(var->type,init,'=');
+    AstType *ok = astTypeCheck(var->type,init,AST_BIN_OP_ASSIGN);
     if (!ok) {
         typeCheckWarn(cc,'=',var,init);
     }
@@ -1671,6 +1671,9 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
     Vec *params = parseParams(cc,')',&has_var_args,1);
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {
+#ifdef DEBUG
+        fprintf(stderr, "Parsing function: %.*s\n",len,fname);
+#endif
         return parseFunctionDef(cc,rettype,fname,len,params,has_var_args,is_inline);
     } else {
         if (rettype->kind == AST_TYPE_AUTO) {

--- a/src/parser.c
+++ b/src/parser.c
@@ -36,17 +36,31 @@ static AoStr *getRangeLoopIdx(void) {
 /* Kinda cheating converting it to a string and calling printf */
 Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
     unsigned long ch = (unsigned long)tok->i64;
-    char str[9];
+    char str[16];
     Vec *argv = astVecNew();
     int len = 0;
+    int real_len = 0;
 
     while (ch) {
-        str[len++] = ch & 0xFF;
+        switch (ch & 0xFF) {
+            case '\'': str[len++] = '\\'; str[len++] = '\''; break;
+            case '\\': str[len++] = '\\'; str[len++] = '\\'; break;
+            case '\"': str[len++] = '\''; str[len++] = '\"'; break;
+            case '\b': str[len++] = '\\';  str[len++] = 'b'; break;
+            case '\n': str[len++] = '\\';  str[len++] = 'n'; break;
+            case '\t': str[len++] = '\\';  str[len++] = 't'; break;
+            case '\v': str[len++] = '\\';  str[len++] = 'v'; break;
+            case '\f': str[len++] = '\\';  str[len++] = 'f'; break;
+            case '\r': str[len++] = '\\';  str[len++] = 'r'; break;
+
+            default: str[len++] = ch & 0xFF; break;
+        }
+        real_len++;
         ch = ch >> 8;
     }
 
-    Ast *ast = cctrlGetOrSetString(cc,str,len,len);
-    vecPush(argv,ast);
+    Ast *ast = cctrlGetOrSetString(cc,str,len,real_len);
+    vecPush(argv, ast);
     cctrlTokenExpect(cc,';');
     return astFunctionCall(ast_void_type,"printf",6,argv);
 }

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -85,7 +85,7 @@ AstType *parseFunctionPointerType(Cctrl *cc,
     cctrlTokenExpect(cc,')');
     cctrlTokenExpect(cc,'(');
     Vec *params = parseParams(cc,')',&has_var_args,0);
-    return astMakeFunctionType(rettype,params);
+    return astMakeFunctionType(rettype, params);
 }
 
 Ast *parseFunctionPointer(Cctrl *cc, AstType *rettype) {
@@ -99,15 +99,14 @@ Ast *parseFunctionPointer(Cctrl *cc, AstType *rettype) {
             &fnptr_name_len,
             rettype);
 
-    //Ast *func_def = mapGetLen(cc->global_env, fnptr_name, fnptr_name_len);
-    //if (func_def) {
-        // fnptr_type = astMakePointerType(fnptr_type);
-    //}
+    Vec *params = fnptr_type->params;
+    fnptr_type = astMakePointerType(fnptr_type);
+
     ast = astFunctionPtr(
             fnptr_type,
             fnptr_name,
             fnptr_name_len,
-            fnptr_type->params);
+            params);
     return ast;
 }
 

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -12,6 +12,7 @@
 #include "list.h"
 #include "prsutil.h"
 #include "prslib.h"
+#include "util.h"
 
 static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type);
 Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast);
@@ -42,35 +43,8 @@ AstType *parseReturnAuto(Cctrl *cc, Ast *retval) {
         case AST_FUNPTR_CALL:
         case AST_FUNCALL:
         case AST_FUNPTR:
-        case AST_TYPE_ARRAY:
-        case AST_TYPE_INT:
-        case AST_TYPE_CHAR:
-        case AST_TYPE_FLOAT:
-        case AST_TYPE_POINTER:
-        case AST_TYPE_VOID:
         case AST_LITERAL:
-        case '+':
-        case '-':
-        case '*':
-        case '/':
-        case '<':
-        case '>':
-        case '!':
-        case '&':
-        case '|':
-        case '%':
-        case '$':
-        case '~':
-        case TK_AND_AND:
-        case TK_OR_OR:
-        case TK_EQU_EQU:
-        case TK_NOT_EQU:
-        case TK_LESS_EQU:
-        case TK_GREATER_EQU:
-        case TK_PLUS_PLUS:
-        case TK_MINUS_MINUS:
-        case TK_SHL:
-        case TK_SHR: {
+        case AST_BINOP: {
             return astTypeCopy(retval->type);
         }
         default:
@@ -328,7 +302,7 @@ static AstType *parseArrayDimensionsInternal(Cctrl *cc, AstType *base_type) {
             if (size->kind == AST_LVAR) {
                 dimension = -3;
                 type->clsname = size->lname;
-            } else if (astIsArithmetic(size->kind,0)) {
+            } else if (astIsArithmetic(size,0)) {
                 /* Relent... otherwise this will get far too complicated for a
                  * feature that likely will never be used */
                 Ast *left = size->left;
@@ -447,7 +421,9 @@ Vec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
     tok = cctrlTokenPeek(cc);
 
     while (tok && !tokenPunctIs(tok, terminator)) {
-        if (params && vecGetAt(params, param_idx)) {
+        /* For a function with varadic arguments this will never be in bounds */
+        int is_in_bounds = params && vecInBounds(params, (unsigned long)param_idx);
+        if (is_in_bounds) {
             param = params->entries[param_idx++];
         }
 
@@ -487,7 +463,7 @@ Vec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
                 if ((check = astTypeCheck(param->type,ast,'=')) == NULL) {
                     char *expected = astTypeToColorString(param->type);
                     char *got = astTypeToColorString(ast->type);
-                    cctrlWarning(cc,"Incompatible function argument, expected '%s' got '%s' function '%.*s'",
+                    cctrlWarning(cc,"Incompatible function argument, expected '%s' got '%s'in function '%.*s'",
                             expected,got,len,fname);
                 }
             }
@@ -828,8 +804,9 @@ Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast) {
                 lexemeTypeToString(tok->tk_type),tok->len,tok->start);
     }
     cctrlTokenExpect(cc, ']');
-    Ast *binop = parseCreateBinaryOp(cc,'+', ast, subscript);
-    return astUnaryOperator(binop->type->ptr, AST_DEREF, binop);
+    Ast *binop = parseCreateBinaryOp(cc, AST_BIN_OP_ADD, ast, subscript);
+    //binop->type = ast->type;
+    return astUnaryOperator(binop->type->ptr, AST_UN_OP_DEREF, binop);
 }
 
 Ast *parseGetClassField(Cctrl *cc, Ast *cls) {
@@ -859,8 +836,8 @@ Ast *parseGetClassField(Cctrl *cc, Ast *cls) {
     }
 
     // XXX: This is hacky and only for recusive data types 
-    if (type->fields == NULL && cls->kind == AST_DEREF) {
-        type = cls->cls->type;
+    if (type->fields == NULL && astIsDeref(cls)) {
+        type = cls->operand->type;
     }
     AstType *field = mapGetLen(type->fields, tok->start, tok->len);
     if (!field) {
@@ -868,31 +845,35 @@ Ast *parseGetClassField(Cctrl *cc, Ast *cls) {
         cctrlRaiseException(cc,"Property: %.*s does not exist on class", 
                 tok->len, tok->start);
     }
+
     AoStr *field_name = aoStrDupRaw(tok->start, tok->len);
-    return astClassRef(field, cls, aoStrMove(field_name));
+    Ast *class_ref = astClassRef(field, cls, aoStrMove(field_name));
+    return class_ref;
 }
 
-static int parseCompoundAssign(Lexeme *tok) {
+static int parseCompoundAssign(Lexeme *tok, AstBinOp *_op) {
     if (tok->tk_type != TK_PUNCT) {
         return 0;
     }
 
     switch (tok->i64) {
-        case TK_ADD_EQU: return '+';
-        case TK_SUB_EQU: return '-';
-        case TK_MUL_EQU: return '*';
-        case TK_DIV_EQU: return '/';
-        case TK_MOD_EQU: return '%';
-        case TK_AND_EQU: return '&';
-        case TK_OR_EQU:  return '|';
-        case TK_XOR_EQU: return '^';
-        case TK_SHL_EQU: return TK_SHL;
-        case TK_SHR_EQU: return TK_SHR;
+        case TK_ADD_EQU: *_op = AST_BIN_OP_ADD; return 1;
+        case TK_SUB_EQU: *_op = AST_BIN_OP_SUB; return 1;
+        case TK_MUL_EQU: *_op = AST_BIN_OP_MUL; return 1;
+        case TK_DIV_EQU: *_op = AST_BIN_OP_DIV; return 1;
+        case TK_MOD_EQU: *_op = AST_BIN_OP_MOD; return 1;
+        case TK_AND_EQU: *_op = AST_BIN_OP_BIT_AND; return 1;
+        case TK_OR_EQU:  *_op = AST_BIN_OP_BIT_OR; return 1;
+        case TK_XOR_EQU: *_op = AST_BIN_OP_BIT_XOR; return 1;
+        case TK_SHL_EQU: *_op = AST_BIN_OP_SHL; return 1;
+        case TK_SHR_EQU: *_op = AST_BIN_OP_SHR; return 1;
         default: return 0;
     }
+
+    return 0;
 }
 
-Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right) {
+Ast *parseCreateBinaryOp(Cctrl *cc, AstBinOp operation, Ast *left, Ast *right) {
     int is_err = 0;
     Ast *binop = astBinaryOp(operation,left,right,&is_err);
     if (!is_err) {
@@ -912,7 +893,6 @@ Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right) {
         binop->type = ast_int_type;
     }
     return binop;
-    
 }
 
 Ast *parseExpr(Cctrl *cc, int prec) {
@@ -962,7 +942,12 @@ Ast *parseExpr(Cctrl *cc, int prec) {
                 cctrlRaiseException(cc,"Expected an L-Value however got a %s - `%s`",
                         astKindToHumanReadable(LHS), ast_str);
             }
-            LHS = astUnaryOperator(LHS->type, tok->i64, LHS);
+            AstUnOp op;
+            if (!astUnaryOpFromToken(tok->i64, &op)) {
+                /* This should be impossible to hit as we've already pre-validated */
+                loggerPanic("Invalid token for unary operator; %c\n", (char)tok->i64);
+            }
+            LHS = astUnaryOperator(LHS->type, op, LHS);
             continue;
         }
 
@@ -981,13 +966,14 @@ Ast *parseExpr(Cctrl *cc, int prec) {
                 cctrlRaiseException(cc,"Pointer type expected got `%s` `%s`",
                         astTypeToString(LHS->type), astLValueToString(LHS,0));
             }
-            LHS = astUnaryOperator(LHS->type->ptr, AST_DEREF, LHS);
+            LHS = astUnaryOperator(LHS->type->ptr, AST_UN_OP_DEREF, LHS);
             LHS->deref_symbol = TK_ARROW;
             LHS = parseGetClassField(cc, LHS);
             continue;
         }
 
-        compound_assign = parseCompoundAssign(tok);
+        AstBinOp deconstructed_compound_op;
+        compound_assign = parseCompoundAssign(tok, &deconstructed_compound_op);
         if (tokenPunctIs(tok, '=') || compound_assign) {
             if (!assertLValue(LHS)) {
                 char *ast_str = astLValueToString(LHS,0);
@@ -1018,21 +1004,26 @@ Ast *parseExpr(Cctrl *cc, int prec) {
                                  peek->start);
         }
 
+        /* This de-sugars the compound assign which I think is okay */
         if (compound_assign) {
-            AstType *ok = astTypeCheck(LHS->type,RHS,compound_assign);
+            AstType *ok = astTypeCheck(LHS->type,RHS,deconstructed_compound_op);
             if (!ok) {
-                typeCheckWarn(cc,compound_assign,LHS,RHS);
+                typeCheckWarn(cc,deconstructed_compound_op,LHS,RHS);
             }
-            LHS = parseCreateBinaryOp(cc,'=', LHS, 
-                    parseCreateBinaryOp(cc,compound_assign, LHS, RHS));
+            LHS = parseCreateBinaryOp(cc,AST_BIN_OP_ASSIGN, LHS,
+                    parseCreateBinaryOp(cc, deconstructed_compound_op, LHS, RHS));
         } else {
             if (tok->i64 == '=') {
-                AstType *ok = astTypeCheck(LHS->type,RHS,'=');
+                AstType *ok = astTypeCheck(LHS->type,RHS,AST_BIN_OP_ASSIGN);
                 if (!ok) {
-                    typeCheckWarn(cc,'=',LHS,RHS);
+                    typeCheckWarn(cc,AST_BIN_OP_ASSIGN,LHS,RHS);
                 }
             }
-            LHS = parseCreateBinaryOp(cc,tok->i64,LHS,RHS);
+            AstBinOp binop;
+            if (!astBinOpFromToken(tok->i64,&binop)) {
+                cctrlRaiseException(cc,"Invalid binary operator %c => %d", (char)tok->i64, tok->i64);
+            }
+            LHS = parseCreateBinaryOp(cc,binop,LHS,RHS);
         }
     }
 }
@@ -1137,7 +1128,7 @@ Ast *parsePostFixExpr(Cctrl *cc) {
                                         type_str, 
                                         var_str);
             }
-            ast = astUnaryOperator(ast->type->ptr,AST_DEREF,ast);
+            ast = astUnaryOperator(ast->type->ptr,AST_UN_OP_DEREF,ast);
             ast->deref_symbol = TK_ARROW;
             ast = parseGetClassField(cc,ast);
             continue;
@@ -1151,9 +1142,9 @@ Ast *parsePostFixExpr(Cctrl *cc) {
                         astKindToHumanReadable(ast), ast_str);
             }
             if (tok->i64 == TK_PLUS_PLUS) {
-                return astUnaryOperator(ast->type,TK_PLUS_PLUS,ast);
+                return astUnaryOperator(ast->type,AST_UN_OP_POST_INC,ast);
             } else {
-                return astUnaryOperator(ast->type,TK_MINUS_MINUS,ast);
+                return astUnaryOperator(ast->type,AST_UN_OP_POST_DEC,ast);
             }
         }
 
@@ -1204,19 +1195,10 @@ Ast *parseUnaryExpr(Cctrl *cc) {
     }
 
     if (tok->tk_type == TK_PUNCT) {
-        long unary_op = -1;
-        switch (tok->i64) {
-            case '&': { unary_op = AST_ADDR; break; }
-            case '*': { unary_op = AST_DEREF; break; }
-            case '~': { unary_op = '~'; break; }
-            case '!': { unary_op = '!'; break; }
-            case '-': { unary_op = '-'; break; }
-            case TK_PLUS_PLUS: { unary_op = TK_PRE_PLUS_PLUS; break; }
-            case TK_MINUS_MINUS: { unary_op = TK_PRE_MINUS_MINUS; break; }
-            default: {
-                cctrlTokenRewind(cc);
-                return parsePostFixExpr(cc);
-            }
+        AstUnOp unary_op;
+        if (!astUnaryOpFromToken(tok->i64, &unary_op)) {
+            cctrlTokenRewind(cc);
+            return parsePostFixExpr(cc);
         }
 
         Lexeme *peek = cctrlTokenPeekBy(cc,1);
@@ -1225,29 +1207,36 @@ Ast *parseUnaryExpr(Cctrl *cc) {
 
         /* XXX: This feels wrong but allows things like:
          * !arr[0][1][2] to work properly */
-        if (tokenPunctIs(peek, '[') && !(unary_op == AST_ADDR || unary_op == AST_DEREF)) {
+        if (tokenPunctIs(peek, '[') && !(unary_op == AST_UN_OP_ADDR_OF ||
+                                         unary_op == AST_UN_OP_DEREF)) {
             operand = parseExpr(cc,16);
         } else {
             operand = parseUnaryExpr(cc);
             peek = cctrlTokenPeek(cc);
-            if (tokenPunctIs(peek, '[') && (operand->kind == AST_CLASS_REF || operand->type->kind == AST_TYPE_ARRAY)) {
+            if (tokenPunctIs(peek, '[') && (operand->kind == AST_CLASS_REF ||
+                                            operand->type->kind == AST_TYPE_ARRAY)) {
                 cctrlTokenGet(cc);
                 operand = parseSubscriptExpr(cc, operand);
             }
         }
 
-
-        if (unary_op == AST_ADDR && parseIsFunction(operand)) {
+        if (unary_op == AST_UN_OP_ADDR_OF && parseIsFunction(operand)) {
             return operand;
         }
 
         switch (unary_op) {
-            case AST_ADDR:  type = astMakePointerType(operand->type); break;
-            case AST_DEREF: type = operand->type->ptr; break;
-            case '~':       type = ast_int_type; break;
-            default:        type = operand->type; break;
+            case AST_UN_OP_ADDR_OF: type = astMakePointerType(operand->type); break;
+            case AST_UN_OP_DEREF:   type = operand->type->ptr; break;
+            case AST_UN_OP_BIT_NOT: type = ast_int_type; break;
+            default:                type = operand->type; break;
         }
 
+        if (type == NULL) {
+            printf("ye - %s \n", astUnOpKindToString(unary_op));
+            astPrint(operand);
+            lexemePrint(tok);
+            printf("%s\n", astTypeToString(type));
+        }
         return astUnaryOperator(type, unary_op, operand);
     }
     

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -19,7 +19,7 @@ Ast *parseFunctionPointer(Cctrl *cc, AstType *rettype);
 AstType *parseFunctionPointerType(Cctrl *cc,
         char **fnptr_name, int *fnptr_name_len, AstType *rettype);
 Ast *findFunctionDecl(Cctrl *cc, char *fname, int len);
-Ast *parseCreateBinaryOp(Cctrl *cc, long operation, Ast *left, Ast *right);
+Ast *parseCreateBinaryOp(Cctrl *cc, AstBinOp operation, Ast *left, Ast *right);
 Ast *parseSizeof(Cctrl *cc);
 
 #endif

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -210,9 +210,10 @@ int astCanEval(Ast *ast, int *_ok, int is_float) {
         return 1;
     } else if (ast->kind == AST_LITERAL && (astIsIntType(ast->type) || astIsFloatType(ast->type))) {
         return 1;
+    } else {
+        *_ok = 0;
+        return 0;
     }
-    *_ok = 0;
-    return 0;
 }
 
 double evalFloatExprOrErr(Ast *ast, int *_ok) {

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -22,19 +22,17 @@ int parseIsFunctionCall(Ast *ast);
 AstType *parseGetType(Cctrl *cc, Lexeme *tok);
 int parseIsKeyword(Lexeme *tok, Cctrl *cc);
 double evalFloatExpr(Ast *ast);
-double evalFloatArithmeticOrErr(Ast *ast, int *_ok);
 double evalFloatExprOrErr(Ast *ast, int *_ok);
-double evalOneFloatExprOrErr(Ast *LHS, Ast *RHS, long op, int *_ok);
 long evalIntConstExpr(Ast *ast);
 long evalIntConstExprOrErr(Ast *ast, int *_ok);
-long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, long op, int *_ok);
+long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok);
 long evalIntArithmeticOrErr(Ast *ast, int *_ok);
 int evalClassRef(Ast *ast, int offset);
 int assertLValue(Ast *ast);
 int parseIsFloatOrInt(Ast *ast);
 int parseIsClassOrUnion(int kind);
 int parseIsFunction(Ast *ast);
-int astIsArithmetic(long op, int is_float);
+int astIsArithmetic(Ast *ast, int is_float);
 
 void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags);
 void assertTokenIsTerminatorWithMsg(Cctrl *cc, Lexeme *tok,


### PR DESCRIPTION
- Make the `Ast::kind` and `AstType::kind` enums (easier to keep track of than random ints)
- Modify code to support this
- Also fixes post incrementing pointers and some function pointer oddness