### PR TITLE
chore; normalise types used

### DIFF
--- a/src/aostr.h
+++ b/src/aostr.h
@@ -11,28 +11,30 @@
 #include <stddef.h>
 #include <sys/types.h>
 
+#include "types.h"
+
 typedef struct AoStr {
     char *data;
-    size_t len;
-    size_t capacity;
+    u64 len;
+    u64 capacity;
 } AoStr;
 
-AoStr *aoStrAlloc(size_t capacity);
+AoStr *aoStrAlloc(u64 capacity);
 AoStr *aoStrNew(void);
 void aoStrRelease(AoStr *buf);
 
-int aoStrExtendBuffer(AoStr *buf, size_t additional);
+int aoStrExtendBuffer(AoStr *buf, u64 additional);
 void aoStrToLowerCase(AoStr *buf);
 void aoStrToUpperCase(AoStr *buf);
 void aoStrPutChar(AoStr *buf, char ch);
 void aoStrRepeatChar(AoStr *buf, char ch, int times);
 int aoStrCmp(AoStr *b1, AoStr *b2);
-AoStr *aoStrDupRaw(char *s, size_t len);
+AoStr *aoStrDupRaw(char *s, u64 len);
 AoStr *aoStrDup(AoStr *buf);
 
 char *aoStrMove(AoStr *buf);
 
-void aoStrCatLen(AoStr *buf, const void *d, size_t len);
+void aoStrCatLen(AoStr *buf, const void *d, u64 len);
 void aoStrCatAoStr(AoStr *buf, AoStr *s2);
 void aoStrCat(AoStr *buf, const void *d);
 void aoStrCatRepeat(AoStr *buf, char *str, int times);
@@ -46,13 +48,13 @@ void aoStrArrayRelease(AoStr **arr, int count);
 AoStr **aoStrSplit(char *to_split, char delimiter, int *count);
 char *mprintf(const char *fmt, ...);
 char *mprintFmt(const char *fmt, ...);
-char *mprintVa(const char *fmt, va_list ap, ssize_t *_len);
+char *mprintVa(const char *fmt, va_list ap, s64 *_len);
 AoStr *aoStrError(void);
-AoStr *aoStrIntToHumanReadableBytes(long bytes);
+AoStr *aoStrIntToHumanReadableBytes(s64 bytes);
 
-unsigned long aoStrHashFunction(AoStr *buf);
-unsigned long cstringMurmur(char *data, long len);
-size_t aoStrGetLen(AoStr *buf);
+u64 aoStrHashFunction(AoStr *buf);
+u64 cstringMurmur(char *data, s64 len);
+u64 aoStrGetLen(AoStr *buf);
 AoStr *aoStrIdentity(AoStr *buf);
 int aoStrEq(AoStr *b1, AoStr *b2);
 

--- a/src/arena.c
+++ b/src/arena.c
@@ -5,7 +5,7 @@
 #include "aostr.h"
 #include "arena.h"
 
-static ArenaBlock *arenaBlockNew(unsigned int capacity) {
+static ArenaBlock *arenaBlockNew(u32 capacity) {
     ArenaBlock *block = (ArenaBlock *)malloc(sizeof(ArenaBlock));
     block->capacity = capacity;
     block->used = 0;
@@ -22,12 +22,12 @@ static void arenaBlockRelease(ArenaBlock *block) {
 }
 
 /* Align to 8 bytes */
-static unsigned int arenaAlignMemorySize(unsigned int size) {
+static u32 arenaAlignMemorySize(u32 size) {
     static const int alignment = 8;
     return (size + (alignment - 1)) & ~(alignment - 1);
 }
 
-void arenaInit(Arena *arena, unsigned int capacity) {
+void arenaInit(Arena *arena, u32 capacity) {
     arena->tail = NULL;
     arena->block_capacity = arenaAlignMemorySize(capacity);
     assert(arena->block_capacity > 0);
@@ -35,15 +35,15 @@ void arenaInit(Arena *arena, unsigned int capacity) {
     arena->head = arenaBlockNew(arena->block_capacity);
 }
 
-Arena *arenaNew(unsigned int capacity) {
+Arena *arenaNew(u32 capacity) {
     Arena *arena = (Arena *)malloc(sizeof(Arena));
     arenaInit(arena, capacity);
     return arena;
 }
 
-void *arenaAlloc(Arena *arena, unsigned int size) {
+void *arenaAlloc(Arena *arena, u32 size) {
     /* Allocate aligned memory only */
-    unsigned int allocation_size = arenaAlignMemorySize(size);
+    u32 allocation_size = arenaAlignMemorySize(size);
     /* Keep a track of how big this is getting */
     arena->used += allocation_size;
     /* If we are allocating something larger than the block allocation_size,
@@ -98,12 +98,12 @@ void arenaRelease(Arena *arena) {
 }
 
 void arenaPrintStats(Arena *arena) {
-    unsigned int total_blocks = 0;
-    unsigned int total_capacity = 0;
-    unsigned int total_used = 0;
-    unsigned int big_allocs = 0;
-    unsigned int total_non_full_blocks = 0;
-    unsigned int total_diff = 0;
+    u32 total_blocks = 0;
+    u32 total_capacity = 0;
+    u32 total_used = 0;
+    u32 big_allocs = 0;
+    u32 total_non_full_blocks = 0;
+    u32 total_diff = 0;
 
     if (arena->head) {
         total_blocks++;
@@ -128,7 +128,7 @@ void arenaPrintStats(Arena *arena) {
         block = block->next;
     }
 
-    unsigned int average_unused_amount = total_diff == 0 || total_non_full_blocks == 0 ? 0 : total_diff / total_non_full_blocks;
+    u32 average_unused_amount = total_diff == 0 || total_non_full_blocks == 0 ? 0 : total_diff / total_non_full_blocks;
 
     AoStr *total_mem = aoStrIntToHumanReadableBytes((long) total_capacity);
     AoStr *total_allocated = aoStrIntToHumanReadableBytes((long)total_used);

--- a/src/arena.h
+++ b/src/arena.h
@@ -1,25 +1,27 @@
 #ifndef MEMORY_ARENA_H__
 #define MEMORY_ARENA_H__
 
+#include "types.h"
+
 typedef struct ArenaBlock ArenaBlock;
 typedef struct ArenaBlock {
-    unsigned int capacity;
-    unsigned int used;
+    u32 capacity;
+    u32 used;
     void *mem;
     ArenaBlock *next; 
 } ArenaBlock; 
 
 typedef struct Arena {
-    unsigned int block_capacity;
-    unsigned int used;
+    u32 block_capacity;
+    u32 used;
     ArenaBlock *head; /* Active block */
     ArenaBlock *tail; /* Used blocks */
 } Arena;
 
-void arenaInit(Arena *arena, unsigned int capacity);
+void arenaInit(Arena *arena, u32 capacity);
 void arenaClear(Arena *arena);
-Arena *arenaNew(unsigned int capacity);
-void *arenaAlloc(Arena *arena, unsigned int size);
+Arena *arenaNew(u32 capacity);
+void *arenaAlloc(Arena *arena, u32 size);
 void arenaRelease(Arena *arena);
 void arenaPrintStats(Arena *arena);
 

--- a/src/ast.c
+++ b/src/ast.c
@@ -172,7 +172,7 @@ Ast *astUnaryOperator(AstType *type, AstUnOp operation, Ast *operand) {
 }
 
 /* Returns `1` on successful conversion and `0` on failure */
-int astBinOpFromToken(long op, AstBinOp *_result) {
+int astBinOpFromToken(s64 op, AstBinOp *_result) {
     switch (op) {
         case '+': *_result = AST_BIN_OP_ADD;     break;
         case '-': *_result = AST_BIN_OP_SUB;     break;
@@ -204,7 +204,7 @@ int astBinOpFromToken(long op, AstBinOp *_result) {
     return 1;
 }
 
-int astUnaryOpFromToken(long op, AstUnOp *_result) {
+int astUnaryOpFromToken(s64 op, AstUnOp *_result) {
     switch (op) {
         case TK_PRE_PLUS_PLUS:   *_result = AST_UN_OP_PRE_INC; break;
         case TK_PRE_MINUS_MINUS: *_result = AST_UN_OP_PRE_DEC; break;
@@ -245,7 +245,7 @@ Ast *astBinaryOp(AstBinOp operation, Ast *left, Ast *right, int *_is_err) {
     return ast;
 }
 
-Ast *astI64Type(long long val) {
+Ast *astI64Type(s64 val) {
     Ast *ast = astNew();
     ast->kind = AST_LITERAL;
     ast->type = ast_int_type;
@@ -253,7 +253,7 @@ Ast *astI64Type(long long val) {
     return ast;
 }
 
-Ast *astCharType(long ch) {
+Ast *astCharType(s64 ch) {
     Ast *ast = astNew();
     ast->kind = AST_LITERAL;
     ast->type = ast_u8_type;
@@ -309,7 +309,7 @@ Ast *astGVar(AstType *type, char *name, int len, int is_static) {
     return ast;
 }
 
-Ast *astString(char *str, int len, long real_len) {
+Ast *astString(char *str, int len, s64 real_len) {
     Ast *ast = astNew();
     ast->kind = AST_STRING;
     if (len == 0) {
@@ -469,7 +469,7 @@ Ast *astSwitch(Ast *cond, Vec *cases, Ast *case_default,
     return ast;
 }
 
-Ast *astCase(AoStr *case_label, long case_begin, long case_end, List *case_asts) {
+Ast *astCase(AoStr *case_label, s64 case_begin, s64 case_end, List *case_asts) {
     Ast *ast = astNew();
     ast->type = ast_int_type;
     ast->kind = AST_CASE;
@@ -756,7 +756,7 @@ AoStr *astNormaliseFunctionName(char *fname) {
     return newfn;
 }
 
-int astIsAssignment(long op) {
+int astIsAssignment(s64 op) {
     switch (op) {
         case '=':
         case TK_SHL_EQU:
@@ -768,7 +768,7 @@ int astIsAssignment(long op) {
         case TK_MUL_EQU:
         case TK_DIV_EQU:
         case TK_MOD_EQU:
-        /* These can be treated as short hand expressions for */
+        /* These can be treated as s16 hand expressions for */
         case TK_PLUS_PLUS:
         case TK_PRE_PLUS_PLUS:
         case TK_MINUS_MINUS:
@@ -805,7 +805,7 @@ int astIsValidPointerOp(AstBinOp op) {
     }
 }
 
-int astIsBinCmp(long op) {
+int astIsBinCmp(s64 op) {
     switch (op) {
     case TK_AND_AND:
     case TK_OR_OR:
@@ -1190,8 +1190,8 @@ AoStr *astTypeToAoStr(AstType *type) {
          *  2) 'SomeType** '
          *              ^--- move cursor here
          * */
-        ssize_t idx = str_type->len - 1;
-        ssize_t end = idx + 1;
+        s64 idx = str_type->len - 1;
+        s64 end = idx + 1;
         /* Move the stars to the end */
         aoStrPutChar(str_type, ' ');
         while (str_type->data[idx] == '*') {
@@ -1217,7 +1217,7 @@ AoStr *astTypeToColorAoStr(AstType *type) {
     AoStr *buf = aoStrNew();
     int star_count = 0;
     if (str->data[str->len-1] == '*') {
-        ssize_t idx = str->len - 1;
+        s64 idx = str->len - 1;
         while (str->data[idx] == '*') {
             idx--;
             star_count++;
@@ -1265,7 +1265,7 @@ static char *astParamsToString(Vec *params) {
         tmp = astTypeToColorString(ast_void_type);
         aoStrCatPrintf(str,"%s",tmp);
     } else {
-        for (unsigned long i = 0; i < params->size; ++i) {
+        for (u64 i = 0; i < params->size; ++i) {
             Ast *param = params->entries[i];
             int is_last = i+1 == params->size;
             if (param->kind == AST_VAR_ARGS) {
@@ -1346,7 +1346,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             }    
             case AST_TYPE_CHAR:  {
                 char buf[9];
-                unsigned long ch = ast->i64;
+                u64 ch = ast->i64;
                 buf[0] = ch & 0xFF;
                 buf[1] = ((unsigned long)ch) >> 8  & 0xFF;
                 buf[2] = ((unsigned long)ch) >> 16 & 0xFF;
@@ -1441,7 +1441,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
         tmp = astFunctionToStringInternal(ast,ast->type);
         aoStrCatPrintf(str, "<asm_function_call> %s\n", tmp);
             depth++;
-            for (unsigned long i = 0; i < ast->args->size; ++i) {
+            for (u64 i = 0; i < ast->args->size; ++i) {
                 Ast *tmp = (Ast *)ast->args->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<asm_function_arg>\n");
@@ -1456,7 +1456,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             aoStrCatPrintf(str, "<function_ptr_call*> %s %s\n", 
                     tmp, ast->fname->data);
             depth++;
-            for (unsigned long i = 0; i < ast->args->size; ++i) {
+            for (u64 i = 0; i < ast->args->size; ++i) {
                 Ast *tmp = (Ast *)ast->args->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<function_ptr_arg>\n");
@@ -1475,7 +1475,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             aoStrCatPrintf(str, "<function_call> %s \n",tmp);
             depth++;
 
-            for (unsigned long i = 0; i < ast->args->size; ++i) {
+            for (u64 i = 0; i < ast->args->size; ++i) {
                 Ast *tmp = (Ast *)ast->args->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<function_arg>\n");
@@ -1494,7 +1494,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             aoStrCatPrintf(str, "<function_ptr*> %s %s\n", tmp,
                     ast->fname->data);
             depth++;
-            for (unsigned long i = 0; i < ast->params->size; ++i) {
+            for (u64 i = 0; i < ast->params->size; ++i) {
                 param = (Ast*)ast->params->entries[i];
                 aoStrCatRepeat(str, "  ", depth);
                 aoStrCatPrintf(str, "<function_ptr_arg>\n");
@@ -1507,7 +1507,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
         case AST_EXTERN_FUNC: {
             tmp = astTypeToString(ast->type);
             aoStrCatPrintf(str, "<extern_function> %s %s\n", tmp, ast->fname->data);
-            for (unsigned long i = 0; i < ast->params->size; ++i) {
+            for (u64 i = 0; i < ast->params->size; ++i) {
                 param = ast->params->entries[i];
                 aoStrCatRepeat(str, "  ", depth+1);
                 aoStrCatPrintf(str, "<extern_function_param>\n");
@@ -1521,7 +1521,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
         case AST_FUN_PROTO: {
             tmp = astTypeToString(ast->type);
             aoStrCatPrintf(str, "<function_proto> %s %s\n", tmp, ast->fname->data);
-            for (unsigned long i = 0; i < ast->params->size; ++i) {
+            for (u64 i = 0; i < ast->params->size; ++i) {
                 param = ast->params->entries[i];
                 aoStrCatRepeat(str, "  ", depth+1);
                 aoStrCatPrintf(str, "<function_proto_param>\n");
@@ -1539,7 +1539,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             } else {
                 aoStrCatPrintf(str, "<function_def> %s\n", tmp);
             }
-            for (unsigned long i = 0; i < ast->params->size; ++i) {
+            for (u64 i = 0; i < ast->params->size; ++i) {
                 param = ast->params->entries[i];
                 aoStrCatRepeat(str, "  ", depth+1);
                 aoStrCatPrintf(str, "<function_param>\n");
@@ -1556,7 +1556,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             aoStrCatPrintf(str, "<asm_function_bind> %s %s %s\n", tmp,
                     ast->asmfname->data,
                     ast->fname->data);
-            for (unsigned long i = 0; i < ast->params->size; ++i) {
+            for (u64 i = 0; i < ast->params->size; ++i) {
                 param = ast->params->entries[i];
                 aoStrCatRepeat(str, "  ", depth+1);
                 aoStrCatPrintf(str, "<asm_function_param>\n");
@@ -1774,7 +1774,7 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             }
 
             _astToString(str,ast->switch_cond,depth+1);
-            for (unsigned long i = 0; i < ast->cases->size; ++i) {
+            for (u64 i = 0; i < ast->cases->size; ++i) {
                 _astToString(str,(Ast *)ast->cases->entries[i],depth+1);
             }
 
@@ -1992,21 +1992,21 @@ AoStr *astToAoStr(Ast *ast) {
 }
 
 /* This can only be used for lvalues */
-static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags);
+static void _astLValueToString(AoStr *str, Ast *ast, u64 lexeme_flags);
 
-void astUnaryArgToString(AoStr *str, char *op, Ast *ast, unsigned long lexeme_flags) {
+void astUnaryArgToString(AoStr *str, char *op, Ast *ast, u64 lexeme_flags) {
     aoStrCatPrintf(str, "%s", op);
     _astLValueToString(str, ast->operand,lexeme_flags);
 }
 
-void astBinaryArgToString(AoStr *str, char *op, Ast *ast, unsigned long lexeme_flags) {
+void astBinaryArgToString(AoStr *str, char *op, Ast *ast, u64 lexeme_flags) {
     _astLValueToString(str, ast->left,lexeme_flags);
     aoStrCatPrintf(str, " %s ", op);
     _astLValueToString(str, ast->right,lexeme_flags);
 }
 
 /* This can only be used for lvalues */
-static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags) {
+static void _astLValueToString(AoStr *str, Ast *ast, u64 lexeme_flags) {
     if (ast == NULL) {
         aoStrCatLen(str, "(null)", 6);
         return;
@@ -2073,7 +2073,7 @@ static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags)
         case AST_FUNPTR_CALL:
         case AST_ASM_FUNCALL: {
             AoStr *internal = aoStrAlloc(256);
-            for (unsigned long i = 0; i < ast->args->size; ++i) {
+            for (u64 i = 0; i < ast->args->size; ++i) {
                 Ast *val = cast(Ast *, ast->args->entries[i]);
                 _astLValueToString(internal,val,lexeme_flags);
                 if (i+1 != ast->args->size) {
@@ -2228,13 +2228,13 @@ static void _astLValueToString(AoStr *str, Ast *ast, unsigned long lexeme_flags)
     }
 }
 
-AoStr *astLValueToAoStr(Ast *ast, unsigned long lexeme_flags) {
+AoStr *astLValueToAoStr(Ast *ast, u64 lexeme_flags) {
     AoStr *str = aoStrNew();
     _astLValueToString(str,ast,lexeme_flags);
     return str;
 }
 
-char *astLValueToString(Ast *ast, unsigned long lexeme_flags) {
+char *astLValueToString(Ast *ast, u64 lexeme_flags) {
     AoStr *str = astLValueToAoStr(ast,lexeme_flags);
     return aoStrMove(str);
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -157,7 +157,7 @@ typedef struct AstType {
     int has_var_args;
 
     /* Alignment of a struct or union */
-    unsigned int alignment;
+    u32 alignment;
 
     /* Value signed or unsigned? */
     int issigned;
@@ -185,14 +185,14 @@ typedef struct AstType {
 typedef struct Ast Ast;
 typedef struct Ast {
     AstKind kind;
-    unsigned long flags;
+    u64 flags;
     AstType *type;
     int loff;
-    long deref_symbol;
+    s64 deref_symbol;
     union {
         struct {
         /* 8, 16, 32, 64 bit number */
-            long long i64;
+            s64 i64;
         };
 
         /* Float & Double */
@@ -211,7 +211,7 @@ typedef struct Ast {
         struct {
             AoStr *sval;
             AoStr *slabel;
-            long real_len;
+            s64 real_len;
         };
 
         /* Local variable */
@@ -335,8 +335,8 @@ typedef struct Ast {
 
         /* For a case */
         struct {
-            long case_begin;
-            long case_end;
+            s64 case_begin;
+            s64 case_end;
             AoStr *case_label;
             /* Scopes ast nodes to the case label... Think this makes sense;
              * in my head it does. As then all the top level case nodes 
@@ -391,10 +391,10 @@ void astMemoryStats(void);
 AstType *astTypeCopy(AstType *type);
 
 /* Literals */
-Ast *astI64Type(long long val);
+Ast *astI64Type(s64 val);
 Ast *astF64Type(double val);
-Ast *astCharType(long ch);
-Ast *astString(char *str, int len, long real_len);
+Ast *astCharType(s64 ch);
+Ast *astString(char *str, int len, s64 real_len);
 
 /* Declarations */
 Ast *astDecl(Ast *var, Ast *init);
@@ -421,7 +421,7 @@ Ast *astDoWhile(Ast *whilecond, Ast *whilebody, AoStr *while_begin,
         AoStr *while_end);
 Ast *astContinue(AoStr *continue_label);
 Ast *astBreak(AoStr *break_label);
-Ast *astCase(AoStr *case_label, long case_begin, long case_end, List *case_asts);
+Ast *astCase(AoStr *case_label, s64 case_begin, s64 case_end, List *case_asts);
 /* Do it with lists, then do it with a vector */
 Ast *astSwitch(Ast *cond, Vec *cases, Ast *case_default,
         AoStr *case_end_label, int switch_bounds_checked);
@@ -481,8 +481,8 @@ int astTypeIsPtr(AstType *type);
 int astTypeIsArray(AstType *type);
 int astIsVarArg(Ast *ast);
 int astIsRangeOperator(AstBinOp op);
-int astIsBinCmp(long op);
-int astIsAssignment(long op);
+int astIsBinCmp(s64 op);
+int astIsAssignment(s64 op);
 int astIsLabelMatch(Ast *ast, AoStr *goto_label);
 int astIsAddr(Ast *ast);
 int astIsDeref(Ast *ast);
@@ -500,9 +500,9 @@ Ast *astMakeLoopSentinal(void);
 char *astAnnonymousLabel(void);
 
 /* Returns `1` on successful conversion and `0` on failure */
-int astUnaryOpFromToken(long op, AstUnOp *_result);
+int astUnaryOpFromToken(s64 op, AstUnOp *_result);
 /* Returns `1` on successful conversion and `0` on failure */
-int astBinOpFromToken(long op, AstBinOp *_result);
+int astBinOpFromToken(s64 op, AstBinOp *_result);
 
 /* For debugging */
 AoStr *astTypeToAoStr(AstType *type);
@@ -515,8 +515,8 @@ char *astFunctionToString(Ast *func);
 char *astFunctionNameToString(AstType *rettype, char *fname, int len);
 char *astToString(Ast *ast);
 AoStr *astToAoStr(Ast *ast);
-char *astLValueToString(Ast *ast, unsigned long lexme_flags);
-AoStr *astLValueToAoStr(Ast *ast, unsigned long lexeme_flags);
+char *astLValueToString(Ast *ast, u64 lexme_flags);
+AoStr *astLValueToAoStr(Ast *ast, u64 lexeme_flags);
 void astPrint(Ast *ast);
 void astTypePrint(AstType *type);
 void astKindPrint(int kind);

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -24,10 +24,10 @@
 #define CCTRL_ERROR 3
 
 typedef struct TokenRingBuffer {
-    ssize_t tail;
-    ssize_t head;
-    ssize_t size;
-    ssize_t capacity;
+    s64 tail;
+    s64 head;
+    s64 size;
+    s64 capacity;
     Lexeme **entries;
 } TokenRingBuffer;
 
@@ -41,7 +41,7 @@ Lexeme *tokenRingBufferPeek(TokenRingBuffer *ring_buffer);
 int tokenRingBufferRewind(TokenRingBuffer *ring_buffer);
 
 typedef struct Cctrl {
-    unsigned long flags;
+    u64 flags;
     /* The global environment for user defined types, functions and global
      * variables */
     Map *global_env;
@@ -121,9 +121,9 @@ typedef struct Cctrl {
     AoStr *tmp_fname;
 
     /* current line number */
-    ssize_t lineno;
+    s64 lineno;
 
-    long stack_local_space;
+    s64 stack_local_space;
 
     /* Is the current type or function static,
      * with functions this has no real difference */
@@ -142,7 +142,7 @@ Lexeme *cctrlTokenPeek(Cctrl *cc);
 Lexeme *cctrlTokenPeekBy(Cctrl *cc, int cnt);
 void cctrlInitMacroProcessor(Cctrl *cc);
 void cctrlTokenRewind(Cctrl *cc);
-void cctrlTokenExpect(Cctrl *cc, long expected);
+void cctrlTokenExpect(Cctrl *cc, s64 expected);
 void cctrlSetCommandLineDefines(Cctrl *cc, List *defines_list);
 
 void cctrlInitParse(Cctrl *cc, Lexer *lexer_);
@@ -157,8 +157,8 @@ __noreturn void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from
 __noreturn void cctrlRaiseException(Cctrl *cc, char *fmt, ...);
 __noreturn void cctrlRaiseSuggestion(Cctrl *cc, char *suggestion, char *fmt, ...);
 __noreturn void cctrlIce(Cctrl *cc, char *fmt, ...);
-Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, long real_len);
-void cctrlRewindUntilPunctMatch(Cctrl *cc, long ch, int *_count);
+Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, s64 real_len);
+void cctrlRewindUntilPunctMatch(Cctrl *cc, s64 ch, int *_count);
 void cctrlRewindUntilStrMatch(Cctrl *cc, char *str, int len, int *_count);
 AoStr *cctrlMessagePrintF(Cctrl *cc, int severity, char *fmt,...);
 

--- a/src/cfg-print.c
+++ b/src/cfg-print.c
@@ -475,7 +475,7 @@ static void cfgCreatePictureUtil(CfgGraphVizBuilder *builder,
 
         case BB_SWITCH: {
             bbPrintf(builder,bb);
-            for (unsigned long i = 0; i < bb->next_blocks->size; ++i) {
+            for (u64 i = 0; i < bb->next_blocks->size; ++i) {
                 BasicBlock *it = vecGet(BasicBlock *,bb->next_blocks,i);
                 cfgCreatePictureUtil(builder,it,seen);
             }
@@ -636,7 +636,7 @@ static void cfgGraphVizAddMappings(CfgGraphVizBuilder *builder, CFG *cfg) {
             }
 
             case BB_SWITCH: {
-                for (unsigned long i = 0; i < cur->next_blocks->size; ++i) {
+                for (u64 i = 0; i < cur->next_blocks->size; ++i) {
                     BasicBlock *bb = vecGet(BasicBlock *,cur->next_blocks,i);
                     aoStrCatPrintf(builder->viz,
                             BB_FMT_BLACK_SOLID,
@@ -662,7 +662,7 @@ static void cfgGraphVizAddMappings(CfgGraphVizBuilder *builder, CFG *cfg) {
                 break;
 
             default:
-                loggerWarning("Unhandled! loopidx=%ld: bb%d %s\n",
+                loggerWarning("Unhandled! loopidx=%llu: bb%d %s\n",
                     it.idx,cur->block_no,bbToString(cur));
         }
     }
@@ -696,7 +696,7 @@ void cfgBuilderWriteToFile(CfgGraphVizBuilder *builder, char *filename) {
                 filename,strerror(errno));
     }
 
-    ssize_t written = write(fd, cfg_string->data, cfg_string->len);
+    s64 written = write(fd, cfg_string->data, cfg_string->len);
     if (written != (ssize_t)cfg_string->len) {
         loggerPanic("Failed to write CFG '%s'\n", filename);
     }
@@ -718,7 +718,7 @@ void cfgsToFile(Vec *cfgs, char *filename) {
     cfgGraphVizBuilderInit(&builder);
 
     aoStrCat(builder.viz,"digraph user_program {\n ");
-    for (unsigned long i = 0; i < cfgs->size; ++i) {
+    for (u64 i = 0; i < cfgs->size; ++i) {
         cfgCreateGraphViz(&builder,(CFG *)cfgs->entries[i]);
     }
     aoStrCatPrintf(builder.viz, "} // ending graph\n");

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -212,7 +212,7 @@ void cfgPrintAstArray(BasicBlock *bb) {
     if (bb->ast_array->size == 0) {
         printf("(null)\n");
     } else {
-        for (unsigned long i = 0; i < bb->ast_array->size; ++i) {
+        for (u64 i = 0; i < bb->ast_array->size; ++i) {
             printf("%lu: \n", i);
             astPrint(bb->ast_array->entries[i]);
         }
@@ -220,7 +220,7 @@ void cfgPrintAstArray(BasicBlock *bb) {
 }
 #endif
 
-char *bbFlagsToString(unsigned int flags) {
+char *bbFlagsToString(u32 flags) {
     if (!flags) return mprintf("(NO_FLAGS)");
     AoStr *str = aoStrNew();
     int has_flag = 0;
@@ -347,7 +347,7 @@ void bbPrint(BasicBlock *bb) {
     char *bb_str = bbToString(bb);
     AoStr *str = aoStrDupRaw((char*)bb_str, strlen(bb_str)); 
     aoStrPutChar(str,'\n');
-    for (unsigned long i = 0; i < bb->ast_array->size; ++i) {
+    for (u64 i = 0; i < bb->ast_array->size; ++i) {
         char *ast_str = astLValueToString(bb->ast_array->entries[i],0);
         aoStrCat(str,ast_str);
         aoStrPutChar(str,'\n');
@@ -358,7 +358,7 @@ void bbPrint(BasicBlock *bb) {
 
 static BasicBlock *cfgBuilderAllocBasicBlock(CFGBuilder *builder,
                                              int type,
-                                             unsigned int flags)
+                                             u32 flags)
 {
     BasicBlock *bb = (BasicBlock *)memPoolAlloc(builder->block_pool, sizeof(BasicBlock));
 
@@ -389,7 +389,7 @@ static CFG *cfgNew(AoStr *fname, BasicBlock *head_block) {
  * can be used i.e there are no asts in the array. 
  * Other times we need to allocate a new block */
 static BasicBlock *cfgSelectOrCreateBlock(CFGBuilder *builder, int type,
-        unsigned int flags)
+        u32 flags)
 {
     BasicBlock *bb = NULL;
     if (bbAstCount(builder->bb) == 0 && !bbIsLoopControl(builder->bb)) {
@@ -897,7 +897,7 @@ static void cfgHandleSwitch(CFGBuilder *builder, Ast *ast) {
     builder->flags |= CFG_BUILDER_FLAG_IN_SWITCH;
 
     /* ??? - This has the potential to be a crazy loop */
-    for (unsigned long i = 0; i < ast->cases->size; ++i) {
+    for (u64 i = 0; i < ast->cases->size; ++i) {
         cfgBuilderSetBlock(builder,bb_switch);
         Ast *_case = (Ast *)ast->cases->entries[i];
         cfgHandleCase(builder,bb_end,_case);
@@ -937,7 +937,7 @@ static void cfgLinkLeaves(Map *map, BasicBlock *bb, BasicBlock *dest) {
         mapAdd(map,(void *)(long)bb->block_no,NULL);
         switch (bb->type) {
             case BB_SWITCH:
-                for (unsigned long i = 0; i < bb->next_blocks->size; ++i) {
+                for (u64 i = 0; i < bb->next_blocks->size; ++i) {
                     cfgLinkLeaves(map,bb->next_blocks->entries[i],dest);
                 }
                 /* FALLTHROUGH */
@@ -978,7 +978,7 @@ static BasicBlock *cfgMergeBranches(CFGBuilder *builder, BasicBlock *pre,
  * @DataFlow Jamesbarford 2024/08/28
  * TODO: This function should be the one responsible for converting the ast 
  * into IR and adding what a block defines or modifies which will make liveness
- * analysis easier along with dataflow.
+ * analysis easier as64 with dataflow.
  * */
 static void cfgHandleAstNode(CFGBuilder *builder, Ast *ast) {
     assert(ast != NULL);
@@ -1140,7 +1140,7 @@ static void cfgRelocateGoto(CFGBuilder *builder, BasicBlock *bb_goto,
 
         /* We need to get the statements that happened before the 
          * label */
-        for (unsigned long i = 0; i < dest_ast_array->size; ++i) {
+        for (u64 i = 0; i < dest_ast_array->size; ++i) {
             Ast *needle = dest_ast_array->entries[i];
             if (needle->kind == AST_LABEL && aoStrCmp(goto_label,
                         astHackedGetLabel(needle))) {
@@ -1159,7 +1159,7 @@ static void cfgRelocateGoto(CFGBuilder *builder, BasicBlock *bb_goto,
         dest_ast_array->size -= ast_move_cnt;
 
         /* Remove asts that no longer exist in the block */
-        for (unsigned long i = 0; i < dest_ast_array->size; ++i) {
+        for (u64 i = 0; i < dest_ast_array->size; ++i) {
             dest_ast_array->entries[i] = dest_ast_array->entries[ast_move_cnt+i];
         }
 
@@ -1215,7 +1215,7 @@ static void cfgAdjacencyPrintBlock(BasicBlock *bb, int is_parent) {
 }
 
 BasicBlock *cfgVecFindBlock(Vec *vec, int block_no, int *_idx) {
-    for (unsigned long i = 0; i < vec->size; ++i) {
+    for (u64 i = 0; i < vec->size; ++i) {
         BasicBlock *bb = vecGet(BasicBlock *,vec,i);
         if (bb->block_no == block_no) {
             *_idx = i;
@@ -1412,7 +1412,7 @@ static void cfgRelinkSwitch(CFG *cfg, BasicBlock *bb_switch) {
         Vec *blocks = bb_switch->next_blocks;
         /* Recurse through the graph linking all leaf nodes to the destination 
          * node, this is fairly expensive. */
-        for (unsigned long i = 0; i < blocks->size; ++i) {
+        for (u64 i = 0; i < blocks->size; ++i) {
             BasicBlock *bb_case = vecGet(BasicBlock *,blocks,i);
             cfgLinkLeaves(cache,bb_case,dest);
         }
@@ -1427,7 +1427,7 @@ static void cfgRelinkSwitch(CFG *cfg, BasicBlock *bb_switch) {
 
 static Set *cfgCreateSwitchAdjacencyList(CFG *cfg, BasicBlock *bb) {
     Set *iset = setNew(16, &set_int_type);
-    for (unsigned long i = 0; i < bb->next_blocks->size; ++i) {
+    for (u64 i = 0; i < bb->next_blocks->size; ++i) {
         BasicBlock *bb_case = (BasicBlock *)bb->next_blocks->entries[i];
         setAdd(iset,(void *)(long)bb_case->block_no);
         bbAddPrev(bb_case,bb);
@@ -1710,7 +1710,7 @@ void cfgRemoveUnreachableNodes(CFG *cfg) {
     }
 
     for (int i = 0; i < id_cnt; ++i) {
-        long block_no = (long)ids[i];
+        s64 block_no = (long)ids[i];
         mapRemove(cfg->graph,(void *)block_no);
         mapRemove(cfg->no_to_block,(void *)block_no);
     }
@@ -1733,7 +1733,7 @@ static void cfgConstructFunction(CFGBuilder *builder, List *stmts) {
         BasicBlock *bb_dest = NULL;
         Ast *ast = NULL; 
 
-        for (unsigned long i = 0; i < bb_goto->ast_array->size; ++i) {
+        for (u64 i = 0; i < bb_goto->ast_array->size; ++i) {
             ast = (Ast *)bb_goto->ast_array->entries[i];
             if (ast->kind == AST_GOTO || ast->kind == AST_JUMP) {
                 break;
@@ -1845,7 +1845,7 @@ static void _bbFindAllLoopNodes(BasicBlock *loop_head,
             break;
 
         case BB_SWITCH: {
-            for (unsigned long i = 0; i < bb->next_blocks->size; ++i) {
+            for (u64 i = 0; i < bb->next_blocks->size; ++i) {
                 BasicBlock *it = vecGet(BasicBlock *,bb->next_blocks,i);
                 _bbFindAllLoopNodes(loop_head,it,nodes,loop_cnt);
             }
@@ -1898,7 +1898,7 @@ void cfgExplore(CFG *cfg, Set *seen, int block_no) {
     SetIter it;
     setIterInit(iset, &it);
     while (setIterNext(&it)) {
-        long next_block_no = (long)it.value;
+        s64 next_block_no = (long)it.value;
         BasicBlock *bb = mapGet(cfg->no_to_block,(void *)(long)next_block_no);
         cfgExplore(cfg,seen,bb->block_no);
     }

--- a/src/cfg.h
+++ b/src/cfg.h
@@ -5,6 +5,7 @@
 #include "cctrl.h"
 #include "containers.h"
 #include "mempool.h"
+#include "types.h"
 
 enum bbType {
     BB_GARBAGE       = -1,
@@ -56,7 +57,7 @@ typedef struct BasicBlock {
     int type;
     /* For denoting a loop head / end, not a big fan of having flags AND 
      * a type field but I presently can't think of a better way for loops. */
-    unsigned int flags;
+    u32 flags;
     int block_no;
     int visited;
 
@@ -99,7 +100,7 @@ typedef struct CFG {
 typedef struct CFGBuilder {
     int bb_count;
     int bb_block_no;
-    unsigned long flags;
+    u64 flags;
     Cctrl *cc;
     CFG *cfg;
     MemPool *block_pool;
@@ -117,7 +118,7 @@ typedef struct CFGBuilder {
 BasicBlock *bbNew(int type);
 BasicBlock *bbAddNext(BasicBlock *cur, int type, BasicBlock *next);
 char *bbTypeToString(int type);
-char *bbFlagsToString(unsigned int flags);
+char *bbFlagsToString(u32 flags);
 char *bbPreviousBlockNumbersToString(BasicBlock *bb);
 int bbPrevHas(BasicBlock *bb, int block_no);
 BasicBlock *cfgGet(CFG *cfg, int block_no);

--- a/src/cli.c
+++ b/src/cli.c
@@ -94,12 +94,12 @@ static CliParser parsers[] = {
     {str_lit("--terry"),    0, CLI_TERRY, "--terry", "Information about Terry A. Davis", &cliParseNop},
 };
 
-static size_t longestCommand(void) {
+static u64 longestCommand(void) {
     int commands_len = (int)(sizeof(parsers)/sizeof(parsers[0]));
-    size_t max_len = 0;
+    u64 max_len = 0;
     for (int i = 0; i < commands_len; ++i) {
         CliParser *parser = &parsers[i];
-        size_t len = strlen(parser->optname);
+        u64 len = strlen(parser->optname);
         if (len > max_len) {
             max_len = len;
         }
@@ -126,7 +126,7 @@ const char *getBuildModeStr(void) {
 /* For creating error messages that can't take advantage of the nicer cctrl one */
 __noreturn void cliPanicGeneric(const char *const_msg, const char *fmt, va_list ap) {
     char buffer[BUFSIZ];
-    size_t len = vsnprintf(buffer, sizeof(buffer), fmt, ap);
+    u64 len = vsnprintf(buffer, sizeof(buffer), fmt, ap);
     buffer[len] = '\0';
     if (const_msg) {
         if (is_terminal) {
@@ -197,7 +197,7 @@ __noreturn void cliNoInputFiles(void) {
 
 __noreturn void cliPrintUsage(void) {
     int commands_len = (int)(sizeof(parsers)/sizeof(parsers[0]));
-    size_t longest = longestCommand() + 4;
+    u64 longest = longestCommand() + 4;
     AoStr *buffer = aoStrNew();
 
     if (is_terminal) {
@@ -231,7 +231,7 @@ __noreturn void cliPrintUsage(void) {
 
         /* Making the spacing uniform */
         if (parser->optlen < longest) {
-            for (size_t optlen = parser->optlen; optlen < longest; ++optlen) {
+            for (u64 optlen = parser->optlen; optlen < longest; ++optlen) {
                 aoStrPutChar(buffer, ' '); 
             }
         }
@@ -243,7 +243,7 @@ __noreturn void cliPrintUsage(void) {
     exit(EXIT_SUCCESS);
 }
 
-CliParser *cliParserFind(char *arg, size_t arg_len) {
+CliParser *cliParserFind(char *arg, u64 arg_len) {
     int len = (int)(sizeof(parsers)/sizeof(parsers[0]));
 
     for (int i = 0; i < len; ++i) {
@@ -277,7 +277,7 @@ enum CliFileType {
     HC_ASSEMBLY,
 };
 
-enum CliFileType cliGetFileType(char *filename, size_t filename_len) {
+enum CliFileType cliGetFileType(char *filename, u64 filename_len) {
     char *end = &filename[filename_len-1];
     if (tolower(*end) == 'c' && tolower(*(end-1)) == 'h' && *(end-2) == '.') {
         return HC_SOURCE;
@@ -290,7 +290,7 @@ enum CliFileType cliGetFileType(char *filename, size_t filename_len) {
     }
 }
 
-void getASMFileName(CliArgs *args, enum CliFileType file_type, char *filename, size_t filename_len) {
+void getASMFileName(CliArgs *args, enum CliFileType file_type, char *filename, u64 filename_len) {
     switch (file_type) {
         case HC_INVALID:
             cliPanic("Unknown file extension, file must end with .HC, .HH or .s case insensitive. Got: %s\n", filename);
@@ -338,7 +338,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
 
     for (int i = 0; i < argc; i++) {
         char *arg = argv[i];
-        size_t arg_len = strlen(arg);
+        u64 arg_len = strlen(arg);
         char *next_arg = i + 1 < argc ? argv[i+1] : NULL;
         char *arg_to_parse = NULL;
 

--- a/src/cli.h
+++ b/src/cli.h
@@ -45,7 +45,7 @@ typedef struct CliValue {
 
 typedef struct CliParser {
     char *optname;
-    size_t optlen;
+    u64 optlen;
     int arg_count;
     enum CliArgType arg_type; 
     char *usage;

--- a/src/containers.h
+++ b/src/containers.h
@@ -2,6 +2,7 @@
 #define CONTAINERS_H__
 
 #include "aostr.h"
+#include "types.h"
 
 #define MAP_LOAD 0.60
 
@@ -28,8 +29,8 @@ struct VecType {
 
 /* For pointers */
 struct Vec {
-    unsigned long size;
-    unsigned long capacity;
+    u64 size;
+    u64 capacity;
     void **entries;
     VecType *type;
 };
@@ -42,14 +43,14 @@ struct Vec {
 
 Vec *vecNew(VecType *type);
 Vec *vecNewFrom(VecType *type, ...);
-void vecReserve(Vec *vec, unsigned long capacity);
+void vecReserve(Vec *vec, u64 capacity);
 void vecPush(Vec *vec, void *value);
-void vecPushInt(Vec *vec, unsigned long value);
+void vecPushInt(Vec *vec, u64 value);
 void *vecPop(Vec *vec, int *_ok);
 int vecRemove(Vec *vec, void *value);
-int vecRemoveAt(Vec *vec, unsigned long idx);
-void vecInsertAt(Vec *vec, void *value, unsigned long idx);
-void *vecGetAt(Vec *vec, unsigned long idx);
+int vecRemoveAt(Vec *vec, u64 idx);
+void vecInsertAt(Vec *vec, void *value, u64 idx);
+void *vecGetAt(Vec *vec, u64 idx);
 int vecHas(Vec *vec, void *needle);
 void vecRelease(Vec *vec);
 void vecClear(Vec *vec);
@@ -73,8 +74,8 @@ typedef struct MapType MapType;
 #define MAP_FLAG_DELETED (1<<2)
 
 typedef int (mapKeyMatch)(void *v1, void *v2);
-typedef unsigned long (mapKeyHash)(void *value);
-typedef long (mapKeyLen)(void *value);
+typedef u64 (mapKeyHash)(void *value);
+typedef s64 (mapKeyLen)(void *value);
 typedef AoStr *(mapKeyToString)(void *value);
 typedef AoStr *(mapValueToString)(void *value);
 typedef void (mapValueRelease)(void *value);
@@ -93,17 +94,17 @@ struct MapType {
 };
 
 struct MapNode {
-    unsigned int flags;
+    u32 flags;
     void *key;
     void *value;
-    long key_len;
+    s64 key_len;
 };
 
 struct Map {
-    unsigned long size;
-    unsigned long capacity;
-    unsigned long mask;
-    unsigned long threashold;
+    u64 size;
+    u64 capacity;
+    u64 mask;
+    u64 threashold;
     MapNode *entries;
     Vec *indexes;
     MapType *type;
@@ -112,7 +113,7 @@ struct Map {
      * immediately followed by a `mapGet(...)` so we cache the key on
      * `mapHas(...)` */
     void *cached_key;
-    unsigned long cached_idx;
+    u64 cached_idx;
 };
 
 #define mapSetValueToString(map, func) ((map)->type->value_to_string = (func))
@@ -123,21 +124,21 @@ struct Map {
 struct MapIter {
     Map *map;
     MapNode *node;
-    unsigned long idx;
-    unsigned long vecidx;
+    u64 idx;
+    u64 vecidx;
 };
 
-Map *mapNew(unsigned long capacity, MapType *type);
-Map *mapNewWithParent(Map *parent, unsigned long capacity, MapType *type);
+Map *mapNew(u64 capacity, MapType *type);
+Map *mapNewWithParent(Map *parent, u64 capacity, MapType *type);
 int mapAdd(Map *map, void *key, void *value);
 int mapAddOrErr(Map *map, void *key, void *value);
-int mapAddLen(Map *map, char *key, long key_len, void *value);
+int mapAddLen(Map *map, char *key, s64 key_len, void *value);
 void mapRemove(Map *map, void *key);
 int mapHas(Map *map, void *key);
 int mapHasAll(Map *map, ...);
 void *mapGet(Map *map, void *key);
-void *mapGetLen(Map *map, char *key, long len);
-void *mapGetAt(Map *map, unsigned long index);
+void *mapGetLen(Map *map, char *key, s64 len);
+void *mapGetAt(Map *map, u64 index);
 void mapClear(Map *map);
 void mapRelease(Map *map);
 MapIter *mapIterNew(Map *map);
@@ -151,17 +152,17 @@ void mapMerge(Map *map1, Map *map2);
 void mapPrintStats(Map *map);
 
 int mapIntKeyMatch(void *a, void *b);
-long mapIntKeyLen(void *key);
-unsigned long mapIntKeyHash(void *key);
+s64 mapIntKeyLen(void *key);
+u64 mapIntKeyHash(void *key);
 AoStr *mapIntToString(void *key);
 int mapAoStrKeyMatch(void *s1, void *s2);
-long mapAoStrLen(void *s);
+s64 mapAoStrLen(void *s);
 AoStr *mapAoStrToString(void *s);
 void mapAoStrRelease(void *s);
-unsigned long mapCStringHashLen(void *str, long len);
-unsigned long mapCStringHash(void *str);
+u64 mapCStringHashLen(void *str, s64 len);
+u64 mapCStringHash(void *str);
 int mapCStringEq(void *s1, void *s2);
-long mapCStringLen(void *s);
+s64 mapCStringLen(void *s);
 AoStr *mapCStringToString(void *s);
 
 extern MapType map_cstring_cstring_type;
@@ -176,10 +177,10 @@ typedef struct SetType SetType;
 typedef struct SetNode SetNode;
 
 typedef int (setValueMatch)(void *v1, void *v2);
-typedef unsigned long (setValueHash)(void *value);
+typedef u64 (setValueHash)(void *value);
 typedef AoStr *(setValueToString)(void *value);
 typedef void (setValueRelease)(void *value);
-typedef long (setKeyLen)(void *key);
+typedef s64 (setKeyLen)(void *key);
 
 struct SetType {
     setValueMatch *match;
@@ -193,17 +194,17 @@ struct SetType {
 struct SetNode {
     int occupied;
     void *key;
-    long key_len;
+    s64 key_len;
 };
 
 extern SetType set_aostr_type;
 extern SetType set_int_type;
 
 struct Set {
-    unsigned long size;
-    unsigned long capacity;
-    unsigned long mask;
-    unsigned long threashold;
+    u64 size;
+    u64 capacity;
+    u64 mask;
+    u64 threashold;
     SetNode *entries;
     Vec *indexes;
     SetType *type;
@@ -220,19 +221,19 @@ struct SetIter {
     /* Set being iterated over */
     Set *set;
     /* The user facing index which the size relative to the size of the Set */
-    unsigned long idx;
+    u64 idx;
     /* The internal index into the vector of indexes */
-    unsigned long vecidx;
+    u64 vecidx;
     /* Current value being pointed to */
     void *value;
 };
 
-Set *setNew(unsigned long capacity, SetType *type);
+Set *setNew(u64 capacity, SetType *type);
 int setAdd(Set *set, void *key);
 void *setRemove(Set *set, void *key);
 int setHas(Set *set, void *key);
-int setHasLen(Set *set, char *key, long len);
-void *setGetAt(Set *set, long index);
+int setHasLen(Set *set, char *key, s64 len);
+void *setGetAt(Set *set, s64 index);
 void setClear(Set *set);
 void setRelease(Set *set);
 SetIter *setIterNew(Set *set);
@@ -257,5 +258,5 @@ extern SetType set_cstring_type;
 /* `Set<char *>` the set owns the `char *`*/
 extern SetType set_cstring_owned_type;
 
-unsigned long roundUpToNextPowerOf2(unsigned long v);
+u64 roundUpToNextPowerOf2(u64 v);
 #endif

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -143,7 +143,7 @@ typedef struct Lexeme {
     char *start;
     int ishex;
     union {
-        long i64;
+        s64 i64;
         double f64;
     };
 } Lexeme;
@@ -161,8 +161,8 @@ typedef struct Lexer {
     char *start;
     char cur_ch;
     char *cur_str;
-    long cur_strlen;
-    long cur_i64;
+    s64 cur_strlen;
+    s64 cur_i64;
     double cur_f64;
     int lineno;
     int flags;
@@ -181,7 +181,7 @@ void lexemeMemoryInit(void);
 void lexemeMemoryRelease(void);
 void lexemeMemoryStats(void);
 
-Lexeme *lexemeTokNew(char *start, int len, int line, long ch);
+Lexeme *lexemeTokNew(char *start, int len, int line, s64 ch);
 Lexeme *lexemeNew(char *start, int len);
 Lexeme *lexemeSentinal(void);
 void lexSetBuiltinRoot(Lexer *l, char *root);
@@ -191,18 +191,18 @@ int lex(Lexer *l, Lexeme *le);
 Lexeme *lexToken(Map *macro_defs, Lexer *l);
 void lexemePrint(Lexeme *le);
 char *lexemeTypeToString(int tk_type);
-char *lexemePunctToString(long op);
-char *lexemePunctToStringWithFlags(long op, unsigned long flags);
-char *lexemePunctToEncodedString(long op);
+char *lexemePunctToString(s64 op);
+char *lexemePunctToStringWithFlags(s64 op, u64 flags);
+char *lexemePunctToEncodedString(s64 op);
 char *lexemeToString(Lexeme *tok);
 AoStr *lexemeToAoStr(Lexeme *tok);
 void lexReleaseAllFiles(Lexer *l);
-int tokenPunctIs(Lexeme *tok, long ch);
+int tokenPunctIs(Lexeme *tok, s64 ch);
 int tokenIdentIs(Lexeme *tok, char *ident, int len);
 void lexemeFree(void *_le);
-char *lexerReportLine(Lexer *l, ssize_t lineno);
+char *lexerReportLine(Lexer *l, s64 lineno);
 int lexemeEq(Lexeme *l1, Lexeme *l2);
-char *lexReadfile(char *path, ssize_t *_len);
+char *lexReadfile(char *path, s64 *_len);
 
 
 #endif // !LEXER_H

--- a/src/main.c
+++ b/src/main.c
@@ -18,6 +18,7 @@
 #include "list.h"
 #include "memory.h"
 #include "transpiler.h"
+#include "types.h"
 #include "util.h"
 
 int is_terminal;
@@ -119,8 +120,8 @@ int hccLibInit(hccLib *lib, CliArgs *args, char *name) {
 
 int writeAsmToTmp(AoStr *asmbuf) {
     int fd;
-    ssize_t written = 0;
-    size_t towrite = 0;
+    s64 written = 0;
+    u64 towrite = 0;
     char *ptr;
     ptr = asmbuf->data;
 
@@ -159,7 +160,7 @@ void emitFile(AoStr *asmbuf, CliArgs *args) {
         safeSystem(cmd->data);
     } else if (args->asm_outfile && args->assemble_only) {
         int fd;
-        unsigned long flags = O_CREAT|O_RDWR|O_TRUNC;
+        u64 flags = O_CREAT|O_RDWR|O_TRUNC;
 
         if (args->to_stdout) {
             fd = STDOUT_FILENO;
@@ -172,10 +173,10 @@ void emitFile(AoStr *asmbuf, CliArgs *args) {
             loggerPanic("Failed to open '%s' - %s\n",
                 args->asm_outfile, strerror(errno));
         }
-        ssize_t written = write(fd,asmbuf->data,asmbuf->len);
-        if (written != (ssize_t)asmbuf->len) {
-            loggerPanic("Failed to write data expected %ld got %ld\n",
-                    (ssize_t)asmbuf->len, written);
+        s64 written = write(fd,asmbuf->data,asmbuf->len);
+        if (written != (s64)asmbuf->len) {
+            loggerPanic("Failed to write data expected %lld got %lld\n",
+                    (s64)asmbuf->len, written);
         }
         close(fd);
     } else if (args->emit_dylib) {
@@ -237,7 +238,7 @@ void assemble(CliArgs *args) {
     AoStr *run_cmd = aoStrNew();
 
     if (args->run) {
-        ssize_t len = 0;
+        s64 len = 0;
         char *buffer = lexReadfile(args->infile,&len);
         AoStr asm_buf = {
             .data = buffer,

--- a/src/memory.c
+++ b/src/memory.c
@@ -15,7 +15,7 @@
 static Arena global_memory_arena;
 static int global_memory_arena_init = 0;
 
-void *xmalloc(size_t size) {
+void *xmalloc(u64 size) {
     void *ptr = (void *)malloc(size);
     if (!ptr) {
         loggerPanic("OOM: %s\n", aoStrError()->data);
@@ -27,14 +27,14 @@ void xfree(void *ptr) {
     if (ptr) free(ptr);
 }
 
-void globalArenaInit(unsigned int capcity) {
+void globalArenaInit(u32 capcity) {
     if (!global_memory_arena_init) {
         arenaInit(&global_memory_arena, capcity);
         global_memory_arena_init = 1;
     }
 }
 
-void *globalArenaAllocate(unsigned int size) {
+void *globalArenaAllocate(u32 size) {
     return (void *)arenaAlloc(&global_memory_arena, size);
 }
 

--- a/src/memory.h
+++ b/src/memory.h
@@ -1,11 +1,11 @@
 #ifndef MEMORY_H__
 #define MEMORY_H__
 
-void *xmalloc(size_t size);
+void *xmalloc(u64 size);
 void xfree(void *ptr);
 
-void globalArenaInit(unsigned int capacity);
-void *globalArenaAllocate(unsigned int size);
+void globalArenaInit(u32 capacity);
+void *globalArenaAllocate(u32 size);
 void globalArenaRelease(void);
 void globalArenaPrintStats(void);
 

--- a/src/mempool.h
+++ b/src/mempool.h
@@ -2,6 +2,7 @@
 #define MEMPOOL_H__
 
 #include <pthread.h>
+#include "types.h"
 
 typedef enum {
     MEMPOOL_OK = 0,                          
@@ -15,28 +16,28 @@ typedef void memPoolDeallocate(void *owner, void *ptr);
 
 typedef struct MemChunk MemChunk;
 typedef struct MemChunk {
-    unsigned int segment_id; /* Which segment this block belongs to */
-    unsigned int size;       /* How big this chunk is */
+    u32 segment_id; /* Which segment this block belongs to */
+    u32 size;       /* How big this chunk is */
     MemChunk *next;          /* Next bump */
     char free;               /* Is this block free? */
 } __attribute__((aligned(8))) MemChunk;
 
 typedef struct MemSegment {
-    unsigned int id;        /* Id of this segment */
+    u32 id;        /* Id of this segment */
     MemChunk *list;         /* The memory list, which is an offset to the
                              * buffer */
 
     void *buffer;           /* The memory for this segment */
-    unsigned int allocated; /* How much memory has been allocated */
+    u32 allocated; /* How much memory has been allocated */
 } MemSegment;
 
 typedef struct MemPool {
     MemSegment **segments;         /* Segments array */
-    unsigned int segments_array_capacity; /* The capacity of the segments array */
+    u32 segments_array_capacity; /* The capacity of the segments array */
 
-    unsigned int segment_count;    /* How many segments we have */
+    u32 segment_count;    /* How many segments we have */
 
-    unsigned int segment_capacity; /* The size in bytes of a segment. Cannot
+    u32 segment_capacity; /* The size in bytes of a segment. Cannot
                                     * allocate anything bigger than this */
 
     pthread_mutex_t mutex;         /* Lock for the pool to allow for multi
@@ -56,10 +57,10 @@ char *memChunkToString(MemChunk *chunk);
 char *memPoolToString(MemPool *pool);
 char *memSegmentToString(MemSegment *segment);
 
-MemPool *memPoolNew(unsigned int bytes);
-void memPoolInit(MemPool *pool, unsigned int bytes);
-void *memPoolAlloc(MemPool *pool, unsigned int size);
-void *memPoolTryAlloc(MemPool *pool, unsigned int size);
+MemPool *memPoolNew(u32 bytes);
+void memPoolInit(MemPool *pool, u32 bytes);
+void *memPoolAlloc(MemPool *pool, u32 size);
+void *memPoolTryAlloc(MemPool *pool, u32 size);
 void memPoolSetDeallocate(MemPool *pool, memPoolDeallocate *deallocate);
 void memPoolRelease(MemPool *pool, char free_pool);
 void memPoolFree(MemPool *pool, void *ptr);
@@ -67,7 +68,7 @@ void memPoolFree(MemPool *pool, void *ptr);
 typedef struct MemPoolIterator {
     MemPool *pool;
     MemChunk *chunk;
-    unsigned int segment_id;
+    u32 segment_id;
 } MemPoolIterator;
 
 MemPoolIterator *memPoolIteratorNew(MemPool *pool);

--- a/src/parser.c
+++ b/src/parser.c
@@ -21,7 +21,7 @@
 Ast *parseStatement(Cctrl *cc);
 Ast *parseIfStatement(Cctrl *cc);
 Ast *parseForStatement(Cctrl *cc);
-Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, long terminator_flags);
+Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, s64 terminator_flags);
 Ast *parseDecl(Cctrl *cc);
 Ast *parseDeclOrStatement(Cctrl *cc);
 Ast *parseCompoundStatement(Cctrl *cc);
@@ -35,7 +35,7 @@ static AoStr *getRangeLoopIdx(void) {
 
 /* Kinda cheating converting it to a string and calling printf */
 Ast *parseFloatingCharConst(Cctrl *cc, Lexeme *tok) {
-    unsigned long ch = (unsigned long)tok->i64;
+    u64 ch = (unsigned long)tok->i64;
     char str[16];
     Vec *argv = astVecNew();
     int len = 0;
@@ -90,7 +90,7 @@ Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
     }
 
     initlist = listNew();
-    unsigned long i = 0;
+    u64 i = 0;
     Map *cls_fields = NULL;
     if (type->kind == AST_TYPE_CLASS) {
         cls_fields = type->fields;
@@ -128,7 +128,7 @@ Ast *parseDeclArrayInitInt(Cctrl *cc, AstType *type) {
                             astTypeToString(type));
                 }
 
-                unsigned long cls_field_idx = (unsigned long)cls_fields->indexes->entries[i];
+                u64 cls_field_idx = (unsigned long)cls_fields->indexes->entries[i];
                 MapNode *entry = &cls_fields->entries[cls_field_idx];
                 AstType *cls_field_type = entry->value;
                 parseTypeCheckClassFieldInitaliser(cc,cls_field_type,init);
@@ -180,9 +180,9 @@ ClsField *clsFieldNew(AstType *type, AoStr *field_name) {
 }
 
 List *parseClassOrUnionFields(Cctrl *cc, AoStr *name,
-        unsigned int (*computeSize)(List *), unsigned int *_size)
+        u32 (*computeSize)(List *), u32 *_size)
 {
-    unsigned int size;
+    u32 size;
     char *fnptr_name;
     int fnptr_name_len;
     Lexeme *tok, *tok_name;
@@ -295,7 +295,7 @@ List *parseClassOrUnionFields(Cctrl *cc, AoStr *name,
     return fields_list;
 }
 
-unsigned int CalcUnionSize(List *fields) {
+u32 CalcUnionSize(List *fields) {
     int max = 0;
     AstType *type;
     listForEach(fields) {
@@ -308,9 +308,9 @@ unsigned int CalcUnionSize(List *fields) {
     return max;
 }
 
-unsigned int CalcClassSize(List *fields) {
-    unsigned int offset = 0;
-    unsigned int size = 0;
+u32 CalcClassSize(List *fields) {
+    u32 offset = 0;
+    u32 size = 0;
     listForEach(fields) {
         ClsField *cls_field = (ClsField *)it->value;
         AstType *type = cls_field->type;
@@ -450,12 +450,12 @@ Map *parseUnionOffsets(Cctrl *cc, int *real_size, List *fields) {
 
 AstType *parseClassOrUnion(Cctrl *cc, Map *env,
         int is_class,
-        unsigned int (*computeSize)(List *),
+        u32 (*computeSize)(List *),
         int is_intrinsic)
 {
     AoStr *tag = NULL;
     int aligned_size = 0;
-    unsigned int class_size;
+    u32 class_size;
     Lexeme *tok = cctrlTokenGet(cc);
     AstType *prev = NULL, *ref = NULL, *base_class = NULL;
     List *fields = NULL;
@@ -536,7 +536,7 @@ AstType *parseUnionDef(Cctrl *cc) {
     return _union;
 }
 
-Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
+Ast *parseVariableAssignment(Cctrl *cc, Ast *var, s64 terminator_flags) {
     Ast *init;
     int len;
     Lexeme *peek = cctrlTokenPeek(cc);
@@ -598,7 +598,7 @@ Ast *parseVariableAssignment(Cctrl *cc, Ast *var, long terminator_flags) {
     return astDecl(var,init);
 }
 
-Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, long terminator_flags) {
+Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, s64 terminator_flags) {
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok,'=')) {
         return parseVariableAssignment(cc,var,terminator_flags);

--- a/src/parser.h
+++ b/src/parser.h
@@ -16,6 +16,6 @@
 
 void parseToAst(Cctrl *cc);
 Ast *parseStatement(Cctrl *cc);
-long evalIntConstExpr(Ast *ast);
+s64 evalIntConstExpr(Ast *ast);
 
 #endif // !PARSER_H

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -117,7 +117,7 @@ void prsAsmLabel(Cctrl *cc, AoStr *buf) {
         cctrlRaiseException(cc,": Labels must be: '@@<int>'");
     }
     
-    long label_num = tok->i64;
+    s64 label_num = tok->i64;
     Lexeme *next = cctrlTokenPeek(cc);
     AoStr *label = aoStrDup(cc->tmp_asm_fname);
     aoStrToLowerCase(label);
@@ -192,7 +192,7 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
             case TK_KEYWORD: {
                 if (tok->i64 == KW_SIZEOF) {
                     Ast *sizeof_ast = parseSizeof(cc);
-                    unsigned long size = (unsigned long)sizeof_ast->i64;
+                    u64 size = (unsigned long)sizeof_ast->i64;
                     switch (count) {
                         case 1:
                             count++;

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -118,7 +118,7 @@ Ast *parseDefaultFunctionParam(Cctrl *cc, Ast *var) {
     return astFunctionDefaultParam(var,init);
 }
 
-Vec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store) {
+Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
     Vec *params = astVecNew();
 
     Lexeme *tok, *pname;
@@ -409,7 +409,7 @@ Ast *findFunctionDecl(Cctrl *cc, char *fname, int len) {
     return NULL;
 }
 
-Vec *parseArgv(Cctrl *cc, Ast *decl, long terminator, char *fname, int len) {
+Vec *parseArgv(Cctrl *cc, Ast *decl, s64 terminator, char *fname, int len) {
     List *var_args = NULL;
     Ast *ast, *param = NULL;
     AstType *check;
@@ -535,7 +535,7 @@ Ast *parseInlineFunctionCall(Cctrl *cc, Ast *fn, Vec *argv) {
 }
 
 /* Read function arguments for a function being called */
-Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, long terminator) {
+Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, s64 terminator) {
     AstType *rettype = NULL;
     Ast *maybe_fn = findFunctionDecl(cc,fname,len);
     Vec *argv = parseArgv(cc,maybe_fn,terminator,fname,len);
@@ -706,7 +706,7 @@ static Ast *parsePrimary(Cctrl *cc) {
         }
         return ast;
     case TK_STR: {
-        long real_len = 0;
+        s64 real_len = 0;
         AoStr *str = aoStrNew();
         cctrlTokenRewind(cc);
         /* Concatinate adjacent strings together */
@@ -1072,7 +1072,7 @@ Ast *parseSizeof(Cctrl *cc) {
 
     /* If we have a string we want the _true_ length of it which as the string
      * is escaped needs to be calculated manually. */
-    long size = 0; 
+    s64 size = 0; 
     if (ast && ast->kind == AST_STRING) {
         size = ast->real_len;
     } else {

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -5,8 +5,8 @@
 
 Ast *parseUnaryExpr(Cctrl *cc);
 Ast *parseExpr(Cctrl *cc, int prec);
-Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, long terminator);
-Vec *parseParams(Cctrl *cc, long terminator, int *has_var_args, int store);
+Ast *parseFunctionArguments(Cctrl *cc, char *fname, int len, s64 terminator);
+Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store);
 void parseDeclInternal(Cctrl *cc, Lexeme **tok, AstType **type);
 void parseAssignAuto(Cctrl *cc, Ast *ast);
 AstType *parseReturnAuto(Cctrl *cc, Ast *retval);

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -46,36 +46,36 @@ int parseIsFunctionCall(Ast *ast) {
            ast->kind == AST_ASM_FUNCALL);
 }
 
-void assertIsFloat(Ast *ast, long lineno) {
+void assertIsFloat(Ast *ast, s64 lineno) {
     if (ast && !astIsFloatType(ast->type)) {
-        loggerPanic("line %ld: Expected float type got %s\n",
+        loggerPanic("line %lld: Expected float type got %s\n",
                 lineno,astTypeToString(ast->type));
     }
 }
 
-void assertIsInt(Ast *ast, long lineno) {
+void assertIsInt(Ast *ast, s64 lineno) {
     if (ast && !astIsIntType(ast->type)) {
-        loggerPanic("line %ld: Expected int type got %s\n",
+        loggerPanic("line %lld: Expected int type got %s\n",
                 lineno, astTypeToString(ast->type));
     }
 }
 
-void assertIsFloatOrInt(Ast *ast, long lineno) {
+void assertIsFloatOrInt(Ast *ast, s64 lineno) {
     if (!parseIsFloatOrInt(ast)) {
-        loggerPanic("line %ld: Expected float got %s\n",
+        loggerPanic("line %lld: Expected float got %s\n",
                 lineno, astTypeToString(ast->type));
     }
 }
 
-void assertIsPointer(Ast *ast, long lineno) {
+void assertIsPointer(Ast *ast, s64 lineno) {
     if (!ast || ast->type->kind != AST_TYPE_POINTER) {
-        loggerPanic("line %ld: Expected float got %s\n",
+        loggerPanic("line %lld: Expected float got %s\n",
                 lineno,astTypeToString(ast->type));
     }
 }
 
 char *assertionTerminatorMessage(Cctrl *cc, Lexeme *tok,
-                                 long terminator_flags)
+                                 s64 terminator_flags)
 {
     if ((terminator_flags & PUNCT_TERM_SEMI) &&
         (terminator_flags & PUNCT_TERM_COMMA)) {
@@ -94,7 +94,7 @@ char *assertionTerminatorMessage(Cctrl *cc, Lexeme *tok,
 
 /* Check if one of the characters matches and the flag wants that character to
  * terminate */
-void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags) {
+void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, s64 terminator_flags) {
     if (tok == NULL) {
         cctrlRaiseException(cc,"NULL token passed to assertTokenIsTerminator");
     }
@@ -109,7 +109,7 @@ void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags) {
     AoStr *info_msg = NULL;
     Lexeme *next = cctrlTokenPeek(cc);
     if (tok->line != next->line) {
-        ssize_t next = cc->lineno+1;
+        s64 next = cc->lineno+1;
         while (cc->lineno <= next) {
             cctrlTokenGet(cc);
         }
@@ -133,7 +133,7 @@ void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags) {
 }
 
 void assertTokenIsTerminatorWithMsg(Cctrl *cc, Lexeme *tok,
-                                    long terminator_flags,
+                                    s64 terminator_flags,
                                     const char *fmt, ...)
 {
     if ((tok->i64 == ';' && (terminator_flags & PUNCT_TERM_SEMI)) ||
@@ -264,7 +264,7 @@ double evalFloatExpr(Ast *ast) {
     return result;
 }
 
-long evalIntArithmeticOrErr(Ast *ast, int *_ok) {
+s64 evalIntArithmeticOrErr(Ast *ast, int *_ok) {
 #define eval evalIntArithmeticOrErr
     if (!astCanEval(ast,_ok,0)) {
         *_ok = 0;
@@ -309,11 +309,11 @@ long evalIntArithmeticOrErr(Ast *ast, int *_ok) {
 #undef eval
 }
 
-long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok) {
+s64 evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok) {
     if (LHS->kind == AST_LITERAL && RHS->kind == AST_LITERAL) {
-        ssize_t left =  astIsIntType(LHS->type) ? LHS->i64 : (ssize_t)LHS->f64;
-        ssize_t right = astIsIntType(RHS->type) ? RHS->i64 : (ssize_t)LHS->f64;
-        ssize_t result = 0;
+        s64 left =  astIsIntType(LHS->type) ? LHS->i64 : (ssize_t)LHS->f64;
+        s64 right = astIsIntType(RHS->type) ? RHS->i64 : (ssize_t)LHS->f64;
+        s64 result = 0;
         switch (op) {
             case AST_BIN_OP_ADD:  result = left + right; break;
             case AST_BIN_OP_SUB:  result = left - right; break;
@@ -336,7 +336,7 @@ long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok) {
     return 0;
 }
 
-long evalIntConstExprOrErr(Ast *ast, int *_ok) {
+s64 evalIntConstExprOrErr(Ast *ast, int *_ok) {
     switch (ast->kind) {
         case AST_LITERAL: {
             if (astIsIntType(ast->type)) {
@@ -438,9 +438,9 @@ long evalIntConstExprOrErr(Ast *ast, int *_ok) {
     return 0;
 }
 
-long evalIntConstExpr(Ast *ast) {
+s64 evalIntConstExpr(Ast *ast) {
     int ok = 1;
-    ssize_t res = evalIntConstExprOrErr(ast,&ok);
+    s64 res = evalIntConstExprOrErr(ast,&ok);
     if (!ok) {
         loggerPanic("Expected integer expression: %s\n", astToString(ast));
     }
@@ -464,23 +464,23 @@ int assertLValue(Ast *ast) {
 }
 
 void assertUniqueSwitchCaseLabels(Vec *case_vector, Ast *case_) {
-    for (unsigned long i = 0; i < case_vector->size; ++i) {
+    for (u64 i = 0; i < case_vector->size; ++i) {
         Ast *cur = case_vector->entries[i];
         if (case_->case_end < cur->case_begin ||
             cur->case_begin < case_->case_begin) {
             continue;
         }
         if (case_->case_begin == cur->case_end) {
-            for (unsigned long j = 0; j < case_vector->size; ++j) {
+            for (u64 j = 0; j < case_vector->size; ++j) {
                 astPrint(case_vector->entries[i]);
             }
-            loggerPanic("Duplicate case value: %ld\n",case_->case_begin);
+            loggerPanic("Duplicate case value: %lld\n",case_->case_begin);
         }
-        loggerPanic("Duplicate case value: %ld\n",case_->case_begin);
+        loggerPanic("Duplicate case value: %lld\n",case_->case_begin);
     }
 }
 
-void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual) {
+void typeCheckWarn(Cctrl *cc, s64 op, Ast *expected, Ast *actual) {
     AoStr *expected_type = astTypeToColorAoStr(expected->type);
     AoStr *actual_type = astTypeToColorAoStr(actual->type);
     char *actual_str = astToString(actual);

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -23,10 +23,10 @@ AstType *parseGetType(Cctrl *cc, Lexeme *tok);
 int parseIsKeyword(Lexeme *tok, Cctrl *cc);
 double evalFloatExpr(Ast *ast);
 double evalFloatExprOrErr(Ast *ast, int *_ok);
-long evalIntConstExpr(Ast *ast);
-long evalIntConstExprOrErr(Ast *ast, int *_ok);
-long evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok);
-long evalIntArithmeticOrErr(Ast *ast, int *_ok);
+s64 evalIntConstExpr(Ast *ast);
+s64 evalIntConstExprOrErr(Ast *ast, int *_ok);
+s64 evalOneIntExprOrErr(Ast *LHS, Ast *RHS, AstBinOp op, int *_ok);
+s64 evalIntArithmeticOrErr(Ast *ast, int *_ok);
 int evalClassRef(Ast *ast, int offset);
 int assertLValue(Ast *ast);
 int parseIsFloatOrInt(Ast *ast);
@@ -34,16 +34,16 @@ int parseIsClassOrUnion(int kind);
 int parseIsFunction(Ast *ast);
 int astIsArithmetic(Ast *ast, int is_float);
 
-void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, long terminator_flags);
+void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, s64 terminator_flags);
 void assertTokenIsTerminatorWithMsg(Cctrl *cc, Lexeme *tok,
-        long terminator_flags, const char *fmt, ...);
+        s64 terminator_flags, const char *fmt, ...);
 void assertUniqueSwitchCaseLabels(Vec *case_vector, Ast *case_);
-void assertIsFloatOrInt(Ast *ast, long lineno);
-void assertIsInt(Ast *ast, long lineno);
-void assertIsFloat(Ast *ast, long lineno);
-void assertIsPointer(Ast *ast, long lineno);
+void assertIsFloatOrInt(Ast *ast, s64 lineno);
+void assertIsInt(Ast *ast, s64 lineno);
+void assertIsFloat(Ast *ast, s64 lineno);
+void assertIsPointer(Ast *ast, s64 lineno);
 
-void typeCheckWarn(Cctrl *cc, long op, Ast *expected, Ast *actual);
+void typeCheckWarn(Cctrl *cc, s64 op, Ast *expected, Ast *actual);
 void typeCheckReturnTypeWarn(Cctrl *cc, Ast *maybe_func, 
                              AstType *check, Ast *retval);
 #endif // PRS_UTIL

--- a/src/types.h
+++ b/src/types.h
@@ -1,0 +1,42 @@
+#ifndef TYPES_H__
+#define TYPES_H__
+
+#include <stdint.h>
+#include <limits.h>
+#include <float.h>
+
+/* Make sane types */
+
+#define I8_MAX  INT8_MAX
+#define U8_MAX  UINT8_MAX
+#define I16_MAX INT16_MAX
+#define U16_MAX UINT16_MAX
+#define I32_MAX INT32_MAX
+#define U32_MAX UINT32_MAX
+#define I64_MAX INT64_MAX
+#define U64_MAX UINT64_MAX
+#define F32_MAX FLT_MAX
+#define F64_MAX DBL_MAX
+
+/* Signed 8 bit integer */
+typedef int8_t     s8;
+/* Unsigned 8 bit integer */
+typedef uint8_t    u8;
+/* Signed 16 bit integer */
+typedef int16_t   s16;
+/* Unsigned 16 bit integer */
+typedef uint16_t  u16;
+/* Signed 32 bit integer */
+typedef int32_t   s32;
+/* Unsigned 32 bit integer */
+typedef uint32_t  u32;
+/* Signed 64 bit integer */
+typedef int64_t   s64;
+/* Unsigned 64 bit integer */
+typedef uint64_t  u64;
+/* 32 bit float */
+typedef float     f32;
+/* 64 bit float */
+typedef double    f64;
+
+#endif

--- a/src/x86.c
+++ b/src/x86.c
@@ -56,13 +56,13 @@ uint64_t ieee754(double _f64) {
     if (_f64 == 0.0) return 0;  // Handle zero value explicitly
 
     // Calculate exponent and adjust fraction
-    long double base2_exp = floorl(log2l(fabs(_f64)));
-    long double exponet2_removed = ldexpl(_f64, -base2_exp - 1);
+    double base2_exp = floorl(log2l(fabs(_f64)));
+    double exponet2_removed = ldexpl(_f64, -base2_exp - 1);
 
     // Initialize fraction and calculate it bit by bit
     uint64_t fraction = 0;
-    long double digit = 0.5;  // Start with 1/2
-    for (long i = 0; i != 53; i++) {
+    double digit = 0.5;  // Start with 1/2
+    for (s64 i = 0; i != 53; i++) {
         if (exponet2_removed >= digit) {
             exponet2_removed -= digit;
             fraction |= 1ULL << (52 - i);
@@ -878,7 +878,7 @@ void asmBinaryOpIntArithmetic(Cctrl *cc, AoStr *buf, Ast *ast, int reverse) {
 
     /* @BROKEN; SEE COMMENT ABOVE ^^^
     int ok = 1;
-    ssize_t result = evalIntArithmeticOrErr(ast,&ok);
+    s64 result = evalIntArithmeticOrErr(ast,&ok);
     if (!ok) {
         ok = 1;
         result = evalOneIntExprOrErr(LHS,RHS,ast->binop,&ok);
@@ -1616,7 +1616,7 @@ void asmPrepFuncCallArgs(Cctrl *cc, AoStr *buf, Ast *funcall) {
     var_arg_start = -1;
     argc = 0;
     if (flags & (FUN_EXISTS|FUN_VARARG) && !(flags & FUN_EXTERN)) {
-        for (unsigned long i = 0; i < fun->params->size; ++i) {
+        for (u64 i = 0; i < fun->params->size; ++i) {
             var_arg_start++;
             arg = fun->params->entries[i];
             if (arg->kind == AST_VAR_ARGS) {
@@ -1633,7 +1633,7 @@ void asmPrepFuncCallArgs(Cctrl *cc, AoStr *buf, Ast *funcall) {
     stack_args = listNew();
 
     funarg = NULL;
-    ssize_t i = 0;
+    s64 i = 0;
     while (1) {
         /* Handling the case for either more arguments than parameters or
          * more parameters than arguments */
@@ -1818,7 +1818,7 @@ void asmHandleSwitch(Cctrl *cc, AoStr *buf, Ast *ast) {
     /* create jump table */
     Vec *cases = ast->cases;
     Ast **jump_table = ast->jump_table_order;
-    unsigned long jump_table_size = cases->size;
+    u64 jump_table_size = cases->size;
     Ast *case_ast_min = jump_table[0];
     Ast *case_ast_max = jump_table[jump_table_size - 1];
 
@@ -1870,13 +1870,13 @@ void asmHandleSwitch(Cctrl *cc, AoStr *buf, Ast *ast) {
 
         /* pad out the table */
         for (; i < case_begin_normalised; ++i) {
-            aoStrCatPrintf(buf, ".long %s-%s\n\t",
+            aoStrCatPrintf(buf, ".s64 %s-%s\n\t",
                     end_label->data,
                     jump_table_start->data);
         }
 
         for (int j = case_begin_normalised; j <= case_normalised_range_end; ++j) {
-            aoStrCatPrintf(buf, ".long %s-%s\n\t",
+            aoStrCatPrintf(buf, ".s64 %s-%s\n\t",
                     _case->case_label->data,
                     jump_table_start->data);
         }
@@ -1884,12 +1884,12 @@ void asmHandleSwitch(Cctrl *cc, AoStr *buf, Ast *ast) {
         i += diff;
         cur_case++;
     }
-    aoStrCatPrintf(buf,".long %s-%s\n\t",
+    aoStrCatPrintf(buf,".s64 %s-%s\n\t",
             end_label->data,
             jump_table_start->data);
 
 
-    for (unsigned long i = 0; i < cases->size; ++i) {
+    for (u64 i = 0; i < cases->size; ++i) {
         Ast *_case = cases->entries[i];
         asmExpression(cc,buf,_case);
     }
@@ -2212,7 +2212,7 @@ void asmDataInternal(AoStr *buf, Ast *data) {
 
     switch (data->type->size) {
         case 1: aoStrCatPrintf(buf, ".byte %d\n\t", data->i64); break;
-        case 4: aoStrCatPrintf(buf, ".long %d\n\t", data->i64); break;
+        case 4: aoStrCatPrintf(buf, ".s64 %d\n\t", data->i64); break;
         case 8: aoStrCatPrintf(buf, ".quad %d\n\t", data->i64); break;
         default:
             loggerPanic("Cannot create size information for: %s\n",
@@ -2398,7 +2398,7 @@ int asmFunctionInit(Cctrl *cc, AoStr *buf, Ast *func) {
         }
     }
 
-    for (unsigned long i = 0; i < func->params->size; ++i) {
+    for (u64 i = 0; i < func->params->size; ++i) {
         ast_tmp = vecGet(Ast *, func->params, i);
         switch (ast_tmp->kind) {
         case AST_DEFAULT_PARAM:
@@ -2424,7 +2424,7 @@ int asmFunctionInit(Cctrl *cc, AoStr *buf, Ast *func) {
 
     /* We can use register arguments */
     offset = stack_space;
-    for (unsigned long i = 0; i < func->params->size; ++i) {
+    for (u64 i = 0; i < func->params->size; ++i) {
         ast_tmp = vecGet(Ast *, func->params, i);
 
         if (ast_tmp->kind != AST_VAR_ARGS && astIsFloatType(ast_tmp->type)) {


### PR DESCRIPTION
Use; `i8`, `u8`, `s16`, `u16`, `s32`, `u32`, `s64`, `u64` which are aliases from `stdint.h`