### PR TITLE
Fix; for default function parameters

### DIFF
--- a/src/ast.h
+++ b/src/ast.h
@@ -216,6 +216,7 @@ typedef struct Ast {
 
         /* Local variable */
         struct {
+            u32 lvar_id;
             AoStr *lname;
         };
 
@@ -497,7 +498,9 @@ Ast *astGlobalCmdArgs(void);
 AoStr *astNormaliseFunctionName(char *fname);
 Ast *astMakeForeverSentinal(void);
 Ast *astMakeLoopSentinal(void);
+Ast *astMakePlaceHolder(void);
 char *astAnnonymousLabel(void);
+void astResetLVarId(void);
 
 /* Returns `1` on successful conversion and `0` on failure */
 int astUnaryOpFromToken(s64 op, AstUnOp *_result);

--- a/src/parser.c
+++ b/src/parser.c
@@ -1682,6 +1682,9 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
     cc->localenv = cctrlCreateAstMap(cc->localenv);
     cc->tmp_locals = listNew();
 
+    /* Reset the unique id counter otherwise we get ridiculous numbers */
+    astResetLVarId();
+
     Vec *params = parseParams(cc,')',&has_var_args,1);
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -433,13 +433,19 @@ Vec *parseArgv(Cctrl *cc, Ast *decl, s64 terminator, char *fname, int len) {
         }
 
         if (tokenPunctIs(tok, ',')) {
+            ast = NULL;
             if (param && param->kind == AST_DEFAULT_PARAM) {
                 ast = param->declinit;
-                vecPush(argv_vec, ast);
-            } else {
-                vecPush(argv_vec, NULL);
+            } else if (param && param->kind == AST_FUNPTR) {
+                if (param->default_fn != NULL) {
+                    ast = param->default_fn->declinit;
+                }
+            }
+            if (ast == NULL) {
+                ast = astMakePlaceHolder();
             }
 
+            vecPush(argv_vec, ast);
             cctrlTokenGet(cc);
             tok = cctrlTokenPeek(cc);
             continue;

--- a/src/x86.c
+++ b/src/x86.c
@@ -1870,13 +1870,13 @@ void asmHandleSwitch(Cctrl *cc, AoStr *buf, Ast *ast) {
 
         /* pad out the table */
         for (; i < case_begin_normalised; ++i) {
-            aoStrCatPrintf(buf, ".s64 %s-%s\n\t",
+            aoStrCatPrintf(buf, ".long %s-%s\n\t",
                     end_label->data,
                     jump_table_start->data);
         }
 
         for (int j = case_begin_normalised; j <= case_normalised_range_end; ++j) {
-            aoStrCatPrintf(buf, ".s64 %s-%s\n\t",
+            aoStrCatPrintf(buf, ".long %s-%s\n\t",
                     _case->case_label->data,
                     jump_table_start->data);
         }
@@ -1884,7 +1884,7 @@ void asmHandleSwitch(Cctrl *cc, AoStr *buf, Ast *ast) {
         i += diff;
         cur_case++;
     }
-    aoStrCatPrintf(buf,".s64 %s-%s\n\t",
+    aoStrCatPrintf(buf,".long %s-%s\n\t",
             end_label->data,
             jump_table_start->data);
 
@@ -2212,7 +2212,7 @@ void asmDataInternal(AoStr *buf, Ast *data) {
 
     switch (data->type->size) {
         case 1: aoStrCatPrintf(buf, ".byte %d\n\t", data->i64); break;
-        case 4: aoStrCatPrintf(buf, ".s64 %d\n\t", data->i64); break;
+        case 4: aoStrCatPrintf(buf, ".long %d\n\t", data->i64); break;
         case 8: aoStrCatPrintf(buf, ".quad %d\n\t", data->i64); break;
         default:
             loggerPanic("Cannot create size information for: %s\n",


### PR DESCRIPTION
Adding `NULL` as parameter would cause trying to print the ast to explode.
- Fix for the `sed` replace of long breaking the x64 codegen
- Also assign unique id's to lvars