### PR TITLE
Fix; installing libtos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LIB_SRC        ?= ./src/holyc-lib
 C_COMPILER     ?= gcc
 BUILD_TYPE     ?= debug
 INSTALL_PREFIX ?= /usr/local
-CFLAGS         ?= '-Wextra -Wall -Wpedantic -fsanitize=address'
+CFLAGS         ?= '-Wextra -Wall -Wpedantic'
 
 default: all
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
+TARGET         := hcc
+LIB_SRC        ?= ./src/holyc-lib
 C_COMPILER     ?= gcc
-BUILD_TYPE     ?= Release
+BUILD_TYPE     ?= debug
 INSTALL_PREFIX ?= /usr/local
 CFLAGS         ?= '-Wextra -Wall -Wpedantic'
 
@@ -28,7 +30,9 @@ all:
 		&& $(MAKE) -C ./build -j2
 
 install:
-	$(MAKE) -C ./build install
+	install -c -m 555 $(TARGET) $(INSTALL_PREFIX)/bin
+	cp $(LIB_SRC)/tos.HH $(INSTALL_PREFIX)/include/tos.HH
+	cd $(LIB_SRC) && hcc -lib tos ./all.HC
 
 unit-test:
 	$(MAKE) -C ./build unit-test

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ LIB_SRC        ?= ./src/holyc-lib
 C_COMPILER     ?= gcc
 BUILD_TYPE     ?= debug
 INSTALL_PREFIX ?= /usr/local
-CFLAGS         ?= '-Wextra -Wall -Wpedantic'
+CFLAGS         ?= '-Wextra -Wall -Wpedantic -fsanitize=address'
 
 default: all
 
@@ -30,9 +30,7 @@ all:
 		&& $(MAKE) -C ./build -j2
 
 install:
-	install -c -m 555 $(TARGET) $(INSTALL_PREFIX)/bin
-	cp $(LIB_SRC)/tos.HH $(INSTALL_PREFIX)/include/tos.HH
-	cd $(LIB_SRC) && hcc -lib tos ./all.HC
+	$(MAKE) -C ./build install
 
 unit-test:
 	$(MAKE) -C ./build unit-test

--- a/src/holyc-lib/hashtable.HC
+++ b/src/holyc-lib/hashtable.HC
@@ -69,7 +69,7 @@ public Bool IntMapHas(IntMap *map, I64 key);
 public IntMap *IntMapNew(U64 capacity=1<<8);
 public U0 IntMapSetFreeValue(IntMap *map, U0 (*_free_value)(U0 *value));
 public U0 IntMapRelease(IntMap *map);
-public Bool IntMapResize(IntMap *map, U64 size);
+public Bool IntMapResize(IntMap *map);
 
 U64 IntMapHashFunction(I64 key, U64 mask)
 {
@@ -155,7 +155,7 @@ U0 IntMapRelease(IntMap *map)
   }
 }
 
-public Bool IntMapResize(IntMap *map, U64 size)
+public Bool IntMapResize(IntMap *map)
 {// Resize the hashtable, will return false if OMM
   U64 new_capacity,new_mask,old_mask;
   IntMapNode **new_entries, **old_entries;
@@ -350,7 +350,7 @@ public StrMap *StrMapNew(U64 capacity=1<<8);
 public U0 StrMapSetFreeValue(StrMap *map, U0 (*_free_value)(U0 *value));
 public U0 StrMapSetFreeKey(StrMap *map, U0 (*_free_key)(U0 *key));
 public U0 StrMapRelease(StrMap *map);
-public Bool StrMapResize(StrMap *map, U64 size);
+public Bool StrMapResize(StrMap *map);
 
 StrMap *StrMapNew(U64 capacity)
 {
@@ -441,7 +441,7 @@ U0 StrMapRelease(StrMap *map)
   }
 }
 
-public Bool StrMapResize(StrMap *map, U64 size)
+public Bool StrMapResize(StrMap *map)
 {// Resize the hashtable, will return false if OMM
   U64 new_capacity,new_mask,old_mask;
   StrMapNode **new_entries, **old_entries;

--- a/src/holyc-lib/threads.HC
+++ b/src/holyc-lib/threads.HC
@@ -162,6 +162,7 @@ class ThreadSemaphore
   I32 val;
 }; 
 
+class ThreadWorkerJob;
 class ThreadWorkerJob
 {
   U0 (*callback)(U0 *priv_data, U0 *argv);

--- a/src/holyc-lib/vector.HC
+++ b/src/holyc-lib/vector.HC
@@ -1,5 +1,8 @@
 /* There is a lot of duplication here but it does 'work', generics would clean
  * all of this up... */
+public U0 QSortGeneric(U0 **arr, I64 high, I64 low,
+    I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2));
+
 class IntVec
 {
   I64 size;


### PR DESCRIPTION
The `<Type>MapResize(...)` functions were expecting 2 arguments and only got one which caused the compilation to fail and thus not create `libtos`