### PR TITLE
Fix - revert logger panic on argument count mismatch

### DIFF
--- a/src/x86.c
+++ b/src/x86.c
@@ -1664,8 +1664,6 @@ void asmPrepFuncCallArgs(Cctrl *cc, AoStr *buf, Ast *funcall) {
                     loggerPanic("Default parameter not provided for function call: %s()\n",
                             funcall->fname->data);
                 }
-            } else {
-                loggerPanic("Expected %zu arguments, but got %zu\n", fun->params->size, funcall->args->size);
             }
         } else if (funparam) {
             /* Handling default function parameters, these can only come at
@@ -1675,8 +1673,6 @@ void asmPrepFuncCallArgs(Cctrl *cc, AoStr *buf, Ast *funcall) {
                 tmp = funparam->default_fn->declinit;
             } else if (funparam->kind == AST_DEFAULT_PARAM) {
                 tmp = funparam->declinit;
-            } else {
-                loggerPanic("Expected %zu arguments, but got %zu\n", fun->params->size, funcall->args->size);
             }
         } else {
             break;


### PR DESCRIPTION
Unfortuneatley the panic would be hit on something like `printf(...)` the fix needs to be somewhere in the parser.