### PR TITLE
Use `arg` variable instead of `value.str` for setting `args->clibs`

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -393,7 +393,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
             case CLI_TRANSPILE:          args->transpile = 1; break;
             case CLI_TO_STDOUT:          args->to_stdout = 1; break;
             case CLI_OUTPUT_FILENAME:    args->output_filename = mprintf("%s", value.str); break;
-            case CLI_CLIBS:              args->clibs = mprintf("%s", value.str); break;
+            case CLI_CLIBS:              args->clibs = mprintf("%s", arg); break;
             case CLI_DEFINES_LIST: {
                 /* @Leak who owns this memory? This list or the macro_defs hashtable
                  * on Cctrl? */


### PR DESCRIPTION
`cliParseNop` doesn't put `rawarg` into `CliValue.str`, and with it being empty, the library flags do not get appended to the build command.

For whatever reason though, this change makes the compiler SIGABRT, returning `double free or corruption (!prev)` happening when freeing an arena block and I don't know enough about region-based memory managment to fix it. It does produce a working executable though.

Might also be a good idea to rename it to `-cflags=` instead of `-clibs=` for general usage, though that's just a suggestion.