### PR TITLE
Feat: syntax highlighting for nano, VS Code, Emacs; update Vim config

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ main(void)
 }
 ```
 
+## Editor Support
+Syntax highlighting configurations are available in `src/syntax-highlighting/`:
+
+| Editor | File | Installation |
+|--------|------|-------------|
+| **Vim** | `hc.vim` | Copy to `~/.vim/syntax/hc.vim` and add `autocmd BufRead,BufNewFile *.HC,*.HH set syntax=hc` to `~/.vimrc` |
+| **nano** | `holyc.nanorc` | Copy to `~/.nano/` and add `include "~/.nano/holyc.nanorc"` to `~/.nanorc` |
+| **VS Code / Sublime Text** | `holyc.tmLanguage.json` | Place in a VS Code extension under `syntaxes/` or use a TextMate bundle for Sublime Text |
+| **Emacs** | `holyc-mode.el` | Add to your `load-path` and `(require 'holyc-mode)` in your init file |
+
+All configurations highlight HolyC types, keywords, preprocessor directives, strings, comments, numeric literals and inline assembly blocks. Files with `.HC` and `.HH` extensions are automatically recognized.
+
 ## Bugs
 Please open an issue on [github](https://github.com/Jamesbarford/holyc-lang/issues)
 

--- a/README.md
+++ b/README.md
@@ -262,6 +262,18 @@ main(void)
 }
 ```
 
+## Editor Support
+Syntax highlighting configurations are available in `src/syntax-highlighting/`:
+
+| Editor | File | Installation |
+|--------|------|-------------|
+| Vim | `hc.vim` | Copy to `~/.vim/syntax/hc.vim`, then add `autocmd BufRead,BufNewFile *.HC,*.HH set syntax=hc` to `~/.vimrc` |
+| nano | `holyc.nanorc` | Copy to `~/.nano/`, then add `include "~/.nano/holyc.nanorc"` to `~/.nanorc` |
+| VS Code / Sublime Text | `holyc.tmLanguage.json` | Place in a VS Code extension under `syntaxes/` or use a TextMate bundle for Sublime Text |
+| Emacs | `holyc-mode.el` | Add to your `load-path`, then `(require 'holyc-mode)` in your init file |
+
+All configurations recognize `.HC` and `.HH` extensions and cover the current HolyC keyword set including `try`/`catch`/`throw` and the `reg`/`noreg` register hints.
+
 ## Bugs
 Please open an issue on [github](https://github.com/Jamesbarford/holyc-lang/issues)
 

--- a/src/syntax-highlighting/hc.vim
+++ b/src/syntax-highlighting/hc.vim
@@ -9,11 +9,12 @@ syn keyword cRepeat   while for do
 syn keyword cConstant NULL FALSE TRUE EXIT_FAIL EXIT_OK I64_MIN I64_MAX U64_MAX U8_MAX I8_MAX I8_MIN STDOUT STDERR __BUFSIZ__ STDIN
 syn keyword cOperator public private sizeof
 syn clear cStatement
-syn keyword cCast cast
+syn keyword cCast cast bitcast
 syn keyword cKeyword return continue break goto
 syn keyword cClass class
 
 syn match cAsmKeyword "\<\asm\>"
+syn keyword cAsmKeyword _extern
 hi def link cAsmKeyword Keyword
 hi def link cKeyword Keyword
 hi def link cCast Statement

--- a/src/syntax-highlighting/hc.vim
+++ b/src/syntax-highlighting/hc.vim
@@ -4,19 +4,17 @@ set syntax=c
 
 syn keyword cTypeUnhighlighted bool char short int float double unsigned signed const void
 
-syn keyword cType     _extern extern inline static U0 Bool I8 U8 I16 U16 I32 U32 I64 U64 F64 auto atomic
+syn keyword cType     _extern extern inline static U0 Bool I8 U8 I16 U16 I32 U32 I64 U64 F64 auto atomic reg noreg
 syn keyword cRepeat   while for do
 syn keyword cConstant NULL FALSE TRUE EXIT_FAIL EXIT_OK I64_MIN I64_MAX U64_MAX U8_MAX I8_MAX I8_MIN STDOUT STDERR __BUFSIZ__ STDIN
 syn keyword cOperator public private sizeof
 syn clear cStatement
-syn keyword cCast cast
-syn keyword cKeyword return continue break goto
+syn keyword cKeyword return continue break goto try catch throw
 syn keyword cClass class
 
 syn match cAsmKeyword "\<\asm\>"
 hi def link cAsmKeyword Keyword
 hi def link cKeyword Keyword
-hi def link cCast Statement
 hi def link cClass cTypedef
 
 " this is a bit iffy

--- a/src/syntax-highlighting/holyc-mode.el
+++ b/src/syntax-highlighting/holyc-mode.el
@@ -1,0 +1,80 @@
+;;; holyc-mode.el --- Major mode for HolyC programming language -*- lexical-binding: t; -*-
+
+;; Author: HolyC-Lang Contributors
+;; URL: https://github.com/Jamesbarford/holyc-lang
+;; Version: 1.0
+;; Keywords: languages, holyc
+;; Package-Requires: ((emacs "24.3"))
+
+;;; Commentary:
+
+;; Major mode for editing HolyC source files (.HC, .HH).
+;; Derived from cc-mode (C mode) for indentation and basic syntax support.
+;; Adds HolyC-specific keywords, types, and constants.
+
+;;; Code:
+
+(require 'cc-mode)
+
+(defvar holyc-mode-syntax-table
+  (let ((table (make-syntax-table c-mode-syntax-table)))
+    table)
+  "Syntax table for `holyc-mode'.")
+
+(defvar holyc-types
+  '("U0" "Bool" "I8" "U8" "I16" "U16" "I32" "U32" "I64" "U64" "F64"
+    "auto" "atomic")
+  "HolyC type keywords.")
+
+(defvar holyc-keywords
+  '("cast" "bitcast" "sizeof"
+    "class" "union" "public" "private"
+    "extern" "_extern" "inline" "static" "volatile"
+    "asm")
+  "HolyC-specific keywords not covered by cc-mode.")
+
+(defvar holyc-constants
+  '("NULL" "TRUE" "FALSE"
+    "EXIT_OK" "EXIT_FAIL"
+    "I64_MIN" "I64_MAX" "U64_MAX" "U8_MAX" "I8_MAX" "I8_MIN"
+    "STDOUT" "STDERR" "STDIN" "__BUFSIZ__"
+    "DT_REG" "DT_DIR")
+  "HolyC constants.")
+
+(defvar holyc-preprocessor-keywords
+  '("define" "ifdef" "ifndef" "endif" "elif" "elifdef" "undef" "defined")
+  "HolyC preprocessor keywords (without # prefix).")
+
+(defvar holyc-font-lock-keywords
+  (let ((types-regexp (regexp-opt holyc-types 'words))
+        (keywords-regexp (regexp-opt holyc-keywords 'words))
+        (constants-regexp (regexp-opt holyc-constants 'words))
+        (preproc-regexp (regexp-opt holyc-preprocessor-keywords 'words)))
+    `((,types-regexp . font-lock-type-face)
+      (,keywords-regexp . font-lock-keyword-face)
+      (,constants-regexp . font-lock-constant-face)
+      (,preproc-regexp . font-lock-preprocessor-face)))
+  "Font-lock keywords for `holyc-mode'.")
+
+;;;###autoload
+(define-derived-mode holyc-mode c-mode "HolyC"
+  "Major mode for editing HolyC source code.
+Derived from C mode for indentation and basic syntax support.
+Adds HolyC-specific keywords, types, and constants."
+  :syntax-table holyc-mode-syntax-table
+  (font-lock-add-keywords nil holyc-font-lock-keywords)
+  (setq-local comment-start "// ")
+  (setq-local comment-end ""))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.HC\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.HH\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.hc\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.hh\\'" . holyc-mode))
+
+(provide 'holyc-mode)
+
+;;; holyc-mode.el ends here

--- a/src/syntax-highlighting/holyc-mode.el
+++ b/src/syntax-highlighting/holyc-mode.el
@@ -1,0 +1,81 @@
+;;; holyc-mode.el --- Major mode for HolyC programming language -*- lexical-binding: t; -*-
+
+;; Author: HolyC-Lang Contributors
+;; URL: https://github.com/Jamesbarford/holyc-lang
+;; Version: 1.0
+;; Keywords: languages, holyc
+;; Package-Requires: ((emacs "24.3"))
+
+;;; Commentary:
+
+;; Major mode for editing HolyC source files (.HC, .HH).
+;; Derived from cc-mode (C mode) for indentation and basic syntax support.
+;; Adds HolyC-specific keywords, types, and constants.
+
+;;; Code:
+
+(require 'cc-mode)
+
+(defvar holyc-mode-syntax-table
+  (let ((table (make-syntax-table c-mode-syntax-table)))
+    table)
+  "Syntax table for `holyc-mode'.")
+
+(defvar holyc-types
+  '("U0" "Bool" "I8" "U8" "I16" "U16" "I32" "U32" "I64" "U64" "F64"
+    "auto" "atomic" "reg" "noreg")
+  "HolyC type keywords.")
+
+(defvar holyc-keywords
+  '("sizeof"
+    "try" "catch" "throw"
+    "class" "union" "public" "private"
+    "extern" "_extern" "inline" "static" "volatile"
+    "asm")
+  "HolyC-specific keywords not covered by cc-mode.")
+
+(defvar holyc-constants
+  '("NULL" "TRUE" "FALSE"
+    "EXIT_OK" "EXIT_FAIL"
+    "I64_MIN" "I64_MAX" "U64_MAX" "U8_MAX" "I8_MAX" "I8_MIN"
+    "STDOUT" "STDERR" "STDIN" "__BUFSIZ__"
+    "DT_REG" "DT_DIR")
+  "HolyC constants.")
+
+(defvar holyc-preprocessor-keywords
+  '("define" "ifdef" "ifndef" "endif" "elif" "elifdef" "undef" "defined")
+  "HolyC preprocessor keywords (without # prefix).")
+
+(defvar holyc-font-lock-keywords
+  (let ((types-regexp (regexp-opt holyc-types 'words))
+        (keywords-regexp (regexp-opt holyc-keywords 'words))
+        (constants-regexp (regexp-opt holyc-constants 'words))
+        (preproc-regexp (regexp-opt holyc-preprocessor-keywords 'words)))
+    `((,types-regexp . font-lock-type-face)
+      (,keywords-regexp . font-lock-keyword-face)
+      (,constants-regexp . font-lock-constant-face)
+      (,preproc-regexp . font-lock-preprocessor-face)))
+  "Font-lock keywords for `holyc-mode'.")
+
+;;;###autoload
+(define-derived-mode holyc-mode c-mode "HolyC"
+  "Major mode for editing HolyC source code.
+Derived from C mode for indentation and basic syntax support.
+Adds HolyC-specific keywords, types, and constants."
+  :syntax-table holyc-mode-syntax-table
+  (font-lock-add-keywords nil holyc-font-lock-keywords)
+  (setq-local comment-start "// ")
+  (setq-local comment-end ""))
+
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.HC\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.HH\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.hc\\'" . holyc-mode))
+;;;###autoload
+(add-to-list 'auto-mode-alist '("\\.hh\\'" . holyc-mode))
+
+(provide 'holyc-mode)
+
+;;; holyc-mode.el ends here

--- a/src/syntax-highlighting/holyc.nanorc
+++ b/src/syntax-highlighting/holyc.nanorc
@@ -1,0 +1,43 @@
+## HolyC syntax highlighting for GNU nano
+## Save to ~/.nano/ or /usr/share/nano/ and add: include "holyc.nanorc" to ~/.nanorc
+
+syntax "holyc" "\.HC$" "\.HH$" "\.hc$" "\.hh$"
+
+## Types
+color green "\b(U0|Bool|I8|U8|I16|U16|I32|U32|I64|U64|F64|auto|atomic)\b"
+
+## Keywords — control flow
+color brightyellow "\b(if|else|for|while|do|switch|case|default|return|break|continue|goto)\b"
+
+## Keywords — declaration and storage
+color brightyellow "\b(class|union|public|private|extern|_extern|inline|static|volatile)\b"
+
+## Keywords — operators
+color brightyellow "\b(cast|bitcast|sizeof)\b"
+
+## Preprocessor directives
+color brightcyan "^[[:space:]]*#[[:space:]]*(include|define|ifdef|ifndef|endif|elif|elifdef|undef|error|if|else)"
+
+## Constants
+color brightmagenta "\b(NULL|TRUE|FALSE|EXIT_OK|EXIT_FAIL|I64_MIN|I64_MAX|U64_MAX|U8_MAX|I8_MAX|I8_MIN|STDOUT|STDERR|STDIN|__BUFSIZ__|DT_REG|DT_DIR)\b"
+
+## Numeric literals — hex
+color brightblue "\b0[xX][0-9a-fA-F]+\b"
+
+## Numeric literals — decimal and float
+color brightblue "\b[0-9]+(\.[0-9]+)?\b"
+
+## String literals
+color brightyellow ""([^"\\]|\\.)*""
+
+## Character literals
+color brightyellow "'([^'\\]|\\.)*'"
+
+## Assembly block keyword
+color brightred "\basm\b"
+
+## Line comments
+color brightblack "//.*$"
+
+## Block comments
+color brightblack start="/\*" end="\*/"

--- a/src/syntax-highlighting/holyc.nanorc
+++ b/src/syntax-highlighting/holyc.nanorc
@@ -1,0 +1,43 @@
+## HolyC syntax highlighting for GNU nano
+## Save to ~/.nano/ or /usr/share/nano/ and add: include "holyc.nanorc" to ~/.nanorc
+
+syntax "holyc" "\.HC$" "\.HH$" "\.hc$" "\.hh$"
+
+## Types
+color green "\b(U0|Bool|I8|U8|I16|U16|I32|U32|I64|U64|F64|auto|atomic|reg|noreg)\b"
+
+## Keywords — control flow
+color brightyellow "\b(if|else|for|while|do|switch|case|default|return|break|continue|goto|try|catch|throw)\b"
+
+## Keywords — declaration and storage
+color brightyellow "\b(class|union|public|private|extern|_extern|inline|static|volatile)\b"
+
+## Keywords — operators
+color brightyellow "\bsizeof\b"
+
+## Preprocessor directives
+color brightcyan "^[[:space:]]*#[[:space:]]*(include|define|ifdef|ifndef|endif|elif|elifdef|undef|error|if|else)"
+
+## Constants
+color brightmagenta "\b(NULL|TRUE|FALSE|EXIT_OK|EXIT_FAIL|I64_MIN|I64_MAX|U64_MAX|U8_MAX|I8_MAX|I8_MIN|STDOUT|STDERR|STDIN|__BUFSIZ__|DT_REG|DT_DIR)\b"
+
+## Numeric literals — hex
+color brightblue "\b0[xX][0-9a-fA-F]+\b"
+
+## Numeric literals — decimal and float
+color brightblue "\b[0-9]+(\.[0-9]+)?\b"
+
+## String literals
+color brightyellow ""([^"\\]|\\.)*""
+
+## Character literals
+color brightyellow "'([^'\\]|\\.)*'"
+
+## Assembly block keyword
+color brightred "\basm\b"
+
+## Line comments
+color brightblack "//.*$"
+
+## Block comments
+color brightblack start="/\*" end="\*/"

--- a/src/syntax-highlighting/holyc.tmLanguage.json
+++ b/src/syntax-highlighting/holyc.tmLanguage.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "HolyC",
+  "scopeName": "source.holyc",
+  "fileTypes": ["HC", "HH", "hc", "hh"],
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#preprocessor" },
+    { "include": "#strings" },
+    { "include": "#characters" },
+    { "include": "#asm-block" },
+    { "include": "#numbers" },
+    { "include": "#types" },
+    { "include": "#constants" },
+    { "include": "#cast-operators" },
+    { "include": "#control-keywords" },
+    { "include": "#declaration-keywords" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.holyc",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.block.holyc",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "preprocessor": {
+      "patterns": [
+        {
+          "name": "keyword.other.preprocessor.include.holyc",
+          "match": "^\\s*#\\s*include\\b"
+        },
+        {
+          "name": "keyword.other.preprocessor.holyc",
+          "match": "^\\s*#\\s*(define|ifdef|ifndef|endif|elif|elifdef|undef|error|if|else)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.holyc",
+          "begin": "\"",
+          "end": "\"",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.holyc" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.holyc" } },
+          "patterns": [
+            {
+              "name": "constant.character.escape.holyc",
+              "match": "\\\\."
+            },
+            {
+              "name": "constant.other.placeholder.holyc",
+              "match": "%[-+' #0*]*(\\d+|\\*)?(\\.\\d+|\\.\\*)?[hlLjzt]*(d|i|u|o|x|X|f|F|e|E|g|G|c|s|p|n|%)"
+            }
+          ]
+        }
+      ]
+    },
+    "characters": {
+      "patterns": [
+        {
+          "name": "string.quoted.single.holyc",
+          "match": "'([^'\\\\]|\\\\.)'"
+        }
+      ]
+    },
+    "asm-block": {
+      "patterns": [
+        {
+          "name": "meta.asm.holyc",
+          "begin": "\\basm\\s*\\{",
+          "end": "\\}",
+          "beginCaptures": { "0": { "name": "keyword.other.asm.holyc" } },
+          "endCaptures": { "0": { "name": "keyword.other.asm.holyc" } },
+          "patterns": [
+            { "include": "#comments" },
+            {
+              "name": "entity.name.function.asm.holyc",
+              "match": "^\\s*\\w+::"
+            },
+            {
+              "name": "constant.other.asm.label.holyc",
+              "match": "@@\\d+"
+            },
+            {
+              "name": "keyword.operator.asm.holyc",
+              "match": "\\b(MOV|PUSH|POP|LEA|TEST|CLD|REP|LOD|STOSB|DEC|RET|CMP|INC|SCASB|XCHG|CLI|BT|PAUSE|JMP|JZ|JNZ|JE|JNE|JB|JBE|JA|JAE|CALL|ADD|SUB|XOR|OR|AND|MUL|NOT|MOD|DIV|SHL|SHR)\\w*\\b"
+            },
+            {
+              "name": "variable.other.register.asm.holyc",
+              "match": "\\b(RAX|RBX|RCX|RDX|RSI|RDI|RBP|RSP|R[89]|R1[0-5]|EAX|EBX|ECX|EDX|AL|BL|CL|DL)\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.holyc",
+          "match": "\\b0[xX][0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.float.holyc",
+          "match": "\\b[0-9]+\\.[0-9]+\\b"
+        },
+        {
+          "name": "constant.numeric.integer.holyc",
+          "match": "\\b[0-9]+\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "storage.type.holyc",
+          "match": "\\b(U0|Bool|I8|U8|I16|U16|I32|U32|I64|U64|F64|auto|atomic)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.holyc",
+          "match": "\\b(NULL|TRUE|FALSE|EXIT_OK|EXIT_FAIL|I64_MIN|I64_MAX|U64_MAX|U8_MAX|I8_MAX|I8_MIN|STDOUT|STDERR|STDIN|__BUFSIZ__|DT_REG|DT_DIR)\\b"
+        }
+      ]
+    },
+    "cast-operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.cast.holyc",
+          "match": "\\b(cast|bitcast|sizeof)\\b"
+        }
+      ]
+    },
+    "control-keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.holyc",
+          "match": "\\b(if|else|for|while|do|switch|case|default|return|break|continue|goto)\\b"
+        }
+      ]
+    },
+    "declaration-keywords": {
+      "patterns": [
+        {
+          "name": "storage.modifier.holyc",
+          "match": "\\b(class|union|public|private|extern|_extern|inline|static|volatile)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.other.asm.holyc",
+          "match": "\\basm\\b"
+        }
+      ]
+    }
+  }
+}

--- a/src/syntax-highlighting/holyc.tmLanguage.json
+++ b/src/syntax-highlighting/holyc.tmLanguage.json
@@ -1,0 +1,170 @@
+{
+  "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+  "name": "HolyC",
+  "scopeName": "source.holyc",
+  "fileTypes": ["HC", "HH", "hc", "hh"],
+  "patterns": [
+    { "include": "#comments" },
+    { "include": "#preprocessor" },
+    { "include": "#strings" },
+    { "include": "#characters" },
+    { "include": "#asm-block" },
+    { "include": "#numbers" },
+    { "include": "#types" },
+    { "include": "#constants" },
+    { "include": "#cast-operators" },
+    { "include": "#control-keywords" },
+    { "include": "#declaration-keywords" },
+    { "include": "#operators" }
+  ],
+  "repository": {
+    "comments": {
+      "patterns": [
+        {
+          "name": "comment.line.double-slash.holyc",
+          "match": "//.*$"
+        },
+        {
+          "name": "comment.block.holyc",
+          "begin": "/\\*",
+          "end": "\\*/"
+        }
+      ]
+    },
+    "preprocessor": {
+      "patterns": [
+        {
+          "name": "keyword.other.preprocessor.include.holyc",
+          "match": "^\\s*#\\s*include\\b"
+        },
+        {
+          "name": "keyword.other.preprocessor.holyc",
+          "match": "^\\s*#\\s*(define|ifdef|ifndef|endif|elif|elifdef|undef|error|if|else)\\b"
+        }
+      ]
+    },
+    "strings": {
+      "patterns": [
+        {
+          "name": "string.quoted.double.holyc",
+          "begin": "\"",
+          "end": "\"",
+          "beginCaptures": { "0": { "name": "punctuation.definition.string.begin.holyc" } },
+          "endCaptures": { "0": { "name": "punctuation.definition.string.end.holyc" } },
+          "patterns": [
+            {
+              "name": "constant.character.escape.holyc",
+              "match": "\\\\."
+            },
+            {
+              "name": "constant.other.placeholder.holyc",
+              "match": "%[-+' #0*]*(\\d+|\\*)?(\\.\\d+|\\.\\*)?[hlLjzt]*(d|i|u|o|x|X|f|F|e|E|g|G|c|s|p|n|%)"
+            }
+          ]
+        }
+      ]
+    },
+    "characters": {
+      "patterns": [
+        {
+          "name": "string.quoted.single.holyc",
+          "match": "'([^'\\\\]|\\\\.)'"
+        }
+      ]
+    },
+    "asm-block": {
+      "patterns": [
+        {
+          "name": "meta.asm.holyc",
+          "begin": "\\basm\\s*\\{",
+          "end": "\\}",
+          "beginCaptures": { "0": { "name": "keyword.other.asm.holyc" } },
+          "endCaptures": { "0": { "name": "keyword.other.asm.holyc" } },
+          "patterns": [
+            { "include": "#comments" },
+            {
+              "name": "entity.name.function.asm.holyc",
+              "match": "^\\s*\\w+::"
+            },
+            {
+              "name": "constant.other.asm.label.holyc",
+              "match": "@@\\d+"
+            },
+            {
+              "name": "keyword.operator.asm.holyc",
+              "match": "\\b(MOV|PUSH|POP|LEA|TEST|CLD|REP|LOD|STOSB|DEC|RET|CMP|INC|SCASB|XCHG|CLI|BT|PAUSE|JMP|JZ|JNZ|JE|JNE|JB|JBE|JA|JAE|CALL|ADD|SUB|XOR|OR|AND|MUL|NOT|MOD|DIV|SHL|SHR)\\w*\\b"
+            },
+            {
+              "name": "variable.other.register.asm.holyc",
+              "match": "\\b(RAX|RBX|RCX|RDX|RSI|RDI|RBP|RSP|R[89]|R1[0-5]|EAX|EBX|ECX|EDX|AL|BL|CL|DL)\\b"
+            }
+          ]
+        }
+      ]
+    },
+    "numbers": {
+      "patterns": [
+        {
+          "name": "constant.numeric.hex.holyc",
+          "match": "\\b0[xX][0-9a-fA-F]+\\b"
+        },
+        {
+          "name": "constant.numeric.float.holyc",
+          "match": "\\b[0-9]+\\.[0-9]+\\b"
+        },
+        {
+          "name": "constant.numeric.integer.holyc",
+          "match": "\\b[0-9]+\\b"
+        }
+      ]
+    },
+    "types": {
+      "patterns": [
+        {
+          "name": "storage.type.holyc",
+          "match": "\\b(U0|Bool|I8|U8|I16|U16|I32|U32|I64|U64|F64|auto|atomic|reg|noreg)\\b"
+        }
+      ]
+    },
+    "constants": {
+      "patterns": [
+        {
+          "name": "constant.language.holyc",
+          "match": "\\b(NULL|TRUE|FALSE|EXIT_OK|EXIT_FAIL|I64_MIN|I64_MAX|U64_MAX|U8_MAX|I8_MAX|I8_MIN|STDOUT|STDERR|STDIN|__BUFSIZ__|DT_REG|DT_DIR)\\b"
+        }
+      ]
+    },
+    "cast-operators": {
+      "patterns": [
+        {
+          "name": "keyword.operator.sizeof.holyc",
+          "match": "\\bsizeof\\b"
+        }
+      ]
+    },
+    "control-keywords": {
+      "patterns": [
+        {
+          "name": "keyword.control.holyc",
+          "match": "\\b(if|else|for|while|do|switch|case|default|return|break|continue|goto|try|catch|throw)\\b"
+        }
+      ]
+    },
+    "declaration-keywords": {
+      "patterns": [
+        {
+          "name": "storage.modifier.holyc",
+          "match": "\\b(class|union|public|private|extern|_extern|inline|static|volatile)\\b"
+        }
+      ]
+    },
+    "operators": {
+      "patterns": [
+        {
+          "name": "keyword.other.asm.holyc",
+          "match": "\\basm\\b"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- `holyc.nanorc` (new) — GNU nano
- `holyc.tmLanguage.json` (new) — VS Code / Sublime Text (TextMate grammar)
- `holyc-mode.el` (new) — Emacs major mode derived from `cc-mode`
- `hc.vim` — drop the removed `cast` keyword, add `try`/`catch`/`throw` and the `reg`/`noreg` register hints
- `README.md` — Editor Support section

All four configs recognize `.HC`/`.HH` (and lowercase) and reflect the current keyword set on beta-v0.0.12.