### PR TITLE
Feat: add ternary operator (? :) support

### DIFF
--- a/src/ast.c
+++ b/src/ast.c
@@ -429,6 +429,16 @@ Ast *astIf(Ast *cond, Ast *then, Ast *els) {
     return ast;
 }
 
+Ast *astTernary(AstType *type, Ast *cond, Ast *then, Ast *els) {
+    Ast *ast = astNew();
+    ast->type = type;
+    ast->kind = AST_TERNARY;
+    ast->cond = cond;
+    ast->then = then;
+    ast->els = els;
+    return ast;
+}
+
 /* Sort the cases from low to high */
 static void astJumpTableSort(Ast **cases, int high, int low) {
     if (low < high) {
@@ -1856,6 +1866,17 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             break;
         }
 
+        case AST_TERNARY: {
+            aoStrCatPrintf(str, "(");
+            _astToString(str, ast->cond, depth);
+            aoStrCatPrintf(str, " ? ");
+            _astToString(str, ast->then, depth);
+            aoStrCatPrintf(str, " : ");
+            _astToString(str, ast->els, depth);
+            aoStrCatPrintf(str, ")");
+            break;
+        }
+
         case AST_PLACEHOLDER: {
             aoStrCatPrintf(str, "<placeholder>\n");
             break;
@@ -1929,6 +1950,7 @@ char *astKindToString(AstKind kind) {
         case AST_COMMENT:       return "AST_COMMENT";
         case AST_BINOP:         return "AST_BINOP";
         case AST_UNOP:          return "AST_UNOP";
+        case AST_TERNARY:       return "AST_TERNARY";
             break;
     }
     loggerPanic("Cannot find kind: %d\n", kind);
@@ -2339,6 +2361,7 @@ const char *astKindToHumanReadable(Ast *ast) {
         case AST_PLACEHOLDER: return "placeholder";
         case AST_BINOP: return "binary op";
         case AST_UNOP: return "unary op";
+        case AST_TERNARY: return "ternary expression";
         default: return "unknown AST kind";
     }
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -139,6 +139,7 @@ typedef enum AstKind {
     AST_COMMENT       = 295,
     AST_BINOP         = 296,
     AST_UNOP          = 297,
+    AST_TERNARY       = 298,
 } AstKind;
 
 /* @Cleanup
@@ -472,6 +473,7 @@ AstType *astConvertArray(AstType *ast_type);
 Ast *astClassRef(AstType *type, Ast *cls, char *field_name);
 AstType *astClassType(Map *fields, AoStr *clsname, int size, int is_intrinsic);
 Ast *astCast(Ast *var, AstType *to);
+Ast *astTernary(AstType *type, Ast *cond, Ast *then, Ast *els);
 
 AstType *astGetResultType(AstBinOp op, AstType *a, AstType *b);
 AstType *astTypeCheck(AstType *expected, Ast *ast, AstBinOp op);

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -1240,6 +1240,7 @@ int lex(Lexer *l, Lexeme *le) {
                 return 1;
             }
             case '~':
+            case '?':
             case '(':
             case ')':
             case ',':

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -788,18 +788,21 @@ static int parseGetPriority(Lexeme *tok) {
     case TK_OR_OR:
         return 13;
 
-    case '=':
-    case TK_ADD_EQU: 
-    case TK_SUB_EQU: 
-    case TK_MUL_EQU: 
-    case TK_DIV_EQU: 
-    case TK_MOD_EQU: 
-    case TK_AND_EQU: 
-    case TK_OR_EQU:  
-    case TK_XOR_EQU: 
-    case TK_SHL_EQU: 
-    case TK_SHR_EQU:
+    case '?':
         return 14;
+
+    case '=':
+    case TK_ADD_EQU:
+    case TK_SUB_EQU:
+    case TK_MUL_EQU:
+    case TK_DIV_EQU:
+    case TK_MOD_EQU:
+    case TK_AND_EQU:
+    case TK_OR_EQU:
+    case TK_XOR_EQU:
+    case TK_SHL_EQU:
+    case TK_SHR_EQU:
+        return 15;
 
     default:
         return -1;
@@ -980,6 +983,18 @@ Ast *parseExpr(Cctrl *cc, int prec) {
             LHS = astUnaryOperator(LHS->type->ptr, AST_UN_OP_DEREF, LHS);
             LHS->deref_symbol = TK_ARROW;
             LHS = parseGetClassField(cc, LHS);
+            continue;
+        }
+
+        /* Ternary operator: cond ? then : else */
+        if (tokenPunctIs(tok, '?')) {
+            Ast *then_expr = parseExpr(cc, 16);
+            cctrlTokenExpect(cc, ':');
+            Ast *else_expr = parseExpr(cc, 14);
+            AstType *result_type = then_expr->type;
+            if (!result_type) result_type = else_expr->type;
+            if (!result_type) result_type = ast_int_type;
+            LHS = astTernary(result_type, LHS, then_expr, else_expr);
             continue;
         }
 

--- a/src/tests/40_compiler_fixes.HC
+++ b/src/tests/40_compiler_fixes.HC
@@ -1,0 +1,46 @@
+#include "testhelper.HC"
+
+I64 TernaryMax(I64 a, I64 b)
+{
+  return (a > b) ? a : b;
+}
+
+I64 TernaryNested(I64 a, I64 b, I64 c)
+{
+  return (a > b) ? ((a > c) ? a : c) : ((b > c) ? b : c);
+}
+
+I32 Main()
+{
+  "Test - Ternary operator:\n";
+  I32 tests = 5, correct = 0;
+
+  // AC-1: Basic ternary
+  I64 a = 10, b = 20;
+  I64 x = (a > b) ? a : b;
+  if (x == 20) correct++;
+  else "\033[0;31mAC-1 FAILED\033[0;0m: got %d\n", x;
+
+  // AC-2: Nested ternary
+  I64 result = TernaryNested(5, 15, 10);
+  if (result == 15) correct++;
+  else "\033[0;31mAC-2 FAILED\033[0;0m: got %d\n", result;
+
+  // AC-3: Ternary with string type
+  U8 *s = (a > 0) ? "yes" : "no";
+  if (!StrCmp(s, "yes")) correct++;
+  else "\033[0;31mAC-3 FAILED\033[0;0m: got %s\n", s;
+
+  // AC-4: Ternary as function argument
+  I64 m = TernaryMax((a > b) ? a : b, 30);
+  if (m == 30) correct++;
+  else "\033[0;31mAC-4 FAILED\033[0;0m: got %d\n", m;
+
+  // AC-5: Ternary in return and assignment
+  I64 r = TernaryMax(100, 50);
+  if (r == 100) correct++;
+  else "\033[0;31mAC-5 FAILED\033[0;0m: got %d\n", r;
+
+  PrintResult(correct, tests);
+  return correct != tests;
+}

--- a/src/x86.c
+++ b/src/x86.c
@@ -2025,6 +2025,25 @@ void asmExpression(Cctrl *cc, AoStr *buf, Ast *ast) {
         break;
     }
 
+    case AST_TERNARY: {
+        asmExpression(cc,buf,ast->cond);
+        label_begin = astMakeLabel();
+        label_end = astMakeLabel();
+        aoStrCatPrintf(buf,
+                "test   %%rax, %%rax\n\t"
+                "je     %s\n\t", label_begin->data);
+        asmExpression(cc,buf,ast->then);
+        aoStrCatPrintf(buf,
+                "jmp    %s\n"
+                "%s:\n\t",
+                label_end->data,
+                label_begin->data);
+        asmExpression(cc,buf,ast->els);
+        asmRemovePreviousTab(buf);
+        aoStrCatPrintf(buf, "%s:\n\t", label_end->data);
+        break;
+    }
+
     case AST_JUMP:
          aoStrCatPrintf(buf, "jmp    %s\n\t", ast->jump_label->data);
          break;


### PR DESCRIPTION
## Summary

Implements the ternary conditional operator `cond ? then : else` as an expression (closes #206).

**Example:**
```hc
I64 MIN(I64 a, I64 b) { return a < b ? a : b; }
I64 max = (x > y) ? x : y;
```

## Changes

- `src/lexer.c` — recognize `?` as a single-char punctuation token (prevents the "token not recognized" error)
- `src/prslib.c` — `?` parsed with precedence 14; assignment operators shifted to precedence 15; ternary parsing in `parseExpr` (right-associative)
- `src/ast.h/c` — new `AST_TERNARY` node with cond/then/els fields and string representations
- `src/x86.c` — `case AST_TERNARY:` in `asmExpression` with conditional jump pattern and joined end label

Supports:
- Arbitrary types in branches (I64, F64, pointers, Bool)
- Nested ternary expressions
- Ternary as function argument, return value, variable initializer

Closes #206

## Test plan

- [x] `src/tests/40_compiler_fixes.HC`: 5/5 PASSED (AC-1 basic, AC-2 nested, AC-3 string type, AC-4 function argument, AC-5 return + assignment)
- [x] Issue #206 reproducer now compiles and runs correctly:
  ```hc
  I64 MIN(I64 a, I64 b) { return a < b ? a : b; }
  ```