### PR TITLE
Fix: Use `cliParseString` instead of `cliParseNop` for parsing `-clibs` argument

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -82,7 +82,7 @@ static CliParser parsers[] = {
     {str_lit("-S"),         0, CLI_ASSEMBLE_ONLY, "-S", "Emit assembly only", &cliParseNop},
     {str_lit("-obj"),       0, CLI_EMIT_OBJECT, "-obj", "Emit an objectfile", &cliParseNop},
     {str_lit("-lib"),       1, CLI_EMIT_DYLIB, "-lib <libname>", "Emit a dynamic and static library: `-lib <libname>`", &cliParseString},
-    {str_lit("-clibs"),     0, CLI_CLIBS, "-clibs", "Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`", &cliParseNop},
+    {str_lit("-clibs"),     1, CLI_CLIBS, "-clibs", "Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`", &cliParseString},
     {str_lit("-run"),       0, CLI_RUN, "-run", "Immediately run the file (not JIT)", &cliParseNop},
     {str_lit("-o"),         1, CLI_OUTPUT_FILENAME, "-o <binary_name>", "Output filename: `-o <name> ./<file>.HC`", &cliParseString},
     {str_lit("-o-"),        0, CLI_TO_STDOUT, "-o-", "Output assembly to stdout, only for use with -S", &cliParseNop},

--- a/src/main.c
+++ b/src/main.c
@@ -229,9 +229,6 @@ void emitFile(AoStr *asmbuf, CliArgs *args) {
         }
         safeSystem(cmd->data);
     }
-    if (strnlen(args->clibs,10) > 1) {
-        free(args->clibs);
-    }
     remove(ASM_TMP_FILE);
     aoStrRelease(cmd);
     aoStrRelease(asmbuf);


### PR DESCRIPTION
This is a follow-up to my previous pull request, #204, however it's done properly this time around :-)

As I mentioned earlier, inside [`cliParseArgs`](https://github.com/Jamesbarford/holyc-lang/blob/main/src/cli.c#L357), line 357 checks for an argument that specifies its value with the `=` sign, and sets `arg` and `arg_to_parse` to the aforementioned value. Afterwards, `arg_to_parse` gets parsed inside `cliParseNop`, which, well, does nothing, thus leaving `value.str` undefined.

This PR simply changes the parser from `cliParseNop` to `cliParseString` that will set `value.str` to the flags specified by the user with `-clibs=''`.

This change also makes the compiler SIGABRT, returning `double free or corruption (!prev)` happening when freeing an arena block and I don't know enough about region-based memory managment to fix it. It still does produce a working executable though.