### PR TITLE
fix: respect TMPDIR env var for intermediary assembly file

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -32,7 +32,15 @@ int is_terminal;
     #define _CC "gcc"
 #endif
 
-#define ASM_TMP_FILE "/tmp/holyc-asm.s"
+static const char *getAsmTmpFile(void) {
+    static char buf[512];
+    const char *tmpdir = getenv("TMPDIR");
+    if (!tmpdir) tmpdir = "/tmp";
+    snprintf(buf, sizeof(buf), "%s/holyc-asm.s", tmpdir);
+    return buf;
+}
+
+#define ASM_TMP_FILE getAsmTmpFile()
 #define LIB_BUFSIZ 256
 
 #ifndef INSTALL_PREFIX

--- a/src/main.c
+++ b/src/main.c
@@ -32,15 +32,12 @@ int is_terminal;
     #define _CC "gcc"
 #endif
 
-static const char *getAsmTmpFile(void) {
-    static char buf[512];
-    const char *tmpdir = getenv("TMPDIR");
-    if (!tmpdir) tmpdir = "/tmp";
-    snprintf(buf, sizeof(buf), "%s/holyc-asm.s", tmpdir);
-    return buf;
-}
+#ifdef HCC_ASM_TMPDIR
+    #define ASM_TMP_FILE HCC_ASM_TMPDIR
+#else
+    #define ASM_TMP_FILE "/tmp/holyc-asm.s"
+#endif
 
-#define ASM_TMP_FILE getAsmTmpFile()
 #define LIB_BUFSIZ 256
 
 #ifndef INSTALL_PREFIX


### PR DESCRIPTION
Problem: On systems where /tmp is not writable (e.g. NixOS FHS envs), hcc fails with Permission denied when trying to create the intermediary assembly file in make install, because the path is hardcoded to /tmp/holyc-asm.s in src/main.c

Fix: Replaced the hardcoded #define with a helper function that allows an optional TMPDIR environment variable.