### PR TITLE
fix - parsing and errors for running out of tokens

### DIFF
--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -657,13 +657,17 @@ void cctrlCreateColoredLine(Cctrl *cc,
 }
 
 AoStr *cctrlCreateErrorLine(Cctrl *cc,
-                            s64 lineno, 
+                            s64 lineno,
                             char *msg,
                             int severity,
                             char *suggestion)
 {
     char *color = severity == CCTRL_ERROR || CCTRL_ICE ? ESC_BOLD_RED : CCTRL_WARN ? ESC_BOLD_YELLOW : ESC_CYAN;
-    if (!cc->lexer_) {
+    Lexeme *eof_peek = cctrlTokenPeek(cc);
+    if (!cc->lexer_ || !eof_peek) {
+        /* No current token (EOF) or no lexer state: fall back to the
+         * simple message format - the column-pointer rendering below
+         * assumes a live token. */
         AoStr *buf = aoStrNew();
         cctrlFileAndLine(cc,buf,lineno,-1,msg,severity);
         if (is_terminal) {
@@ -675,7 +679,7 @@ AoStr *cctrlCreateErrorLine(Cctrl *cc,
     }
 
     const char *line_buffer = lexerReportLine(cc->lexer_,lineno);
-    Lexeme *cur_tok = cctrlTokenPeek(cc);
+    Lexeme *cur_tok = eof_peek;
     AoStr *buf = aoStrNew();
     s64 char_pos = cctrlGetCharErrorIdx(cc,cur_tok, line_buffer);
 
@@ -733,7 +737,11 @@ AoStr *cctrlMessagVnsPrintF(Cctrl *cc, char *fmt, va_list ap, int severity) {
         aoStrCatFmt(bold_msg, "%s", msg);
     }
     Lexeme *cur_tok = cctrlTokenPeek(cc);
-    AoStr *buf = cctrlCreateErrorLine(cc,cur_tok->line,bold_msg->data,severity,NULL);
+    /* At EOF the peek returns NULL; use the last known line so the
+     * error message still has useful location info instead of
+     * crashing on the field-dereference below. */
+    s64 line = cur_tok ? cur_tok->line : cc->lineno;
+    AoStr *buf = cctrlCreateErrorLine(cc,line,bold_msg->data,severity,NULL);
     aoStrRelease(bold_msg);
     return buf;
 }
@@ -749,7 +757,8 @@ AoStr *cctrlMessagVnsPrintFWithSuggestion(Cctrl *cc, char *fmt, va_list ap,
         aoStrCatFmt(bold_msg, "%s", msg);
     }
     Lexeme *cur_tok = cctrlTokenPeek(cc);
-    AoStr *buf = cctrlCreateErrorLine(cc,cur_tok->line,bold_msg->data,severity,suggestion);
+    s64 line = cur_tok ? cur_tok->line : cc->lineno;
+    AoStr *buf = cctrlCreateErrorLine(cc,line,bold_msg->data,severity,suggestion);
     aoStrRelease(bold_msg);
     return buf;
 }
@@ -842,7 +851,22 @@ void cctrlTokenExpect(Cctrl *cc, s64 expected) {
     Lexeme *tok = cctrlTokenGet(cc);
     if (!tokenPunctIs(tok, expected)) {
         if (!tok) {
-            loggerPanic("line %ld: Ran out of tokens\n",cc->lineno);
+            /* End of input while we still wanted `expected`. This is
+             * almost always an unbalanced bracket / missing terminator
+             * - point at the line we were last consuming so the user
+             * sees the actual region the parse fell off at. */
+            const char *hint = (expected == '}')
+                ? " (unterminated `{ ... }` block?)"
+              : (expected == ')')
+                ? " (unterminated `( ... )`?)"
+              : (expected == ']')
+                ? " (unterminated `[ ... ]`?)"
+              : (expected == ';')
+                ? " (missing terminator?)"
+              : "";
+            cctrlRaiseException(cc,
+                "Unexpected end of input, expected `%c`%s",
+                (char)expected, hint);
         } else {
             cctrlRewindUntilStrMatch(cc,tok->start,tok->len,NULL);
             cctrlTokenRewind(cc);

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -180,7 +180,7 @@ public U0 *PtrVecGet(PtrVec *vec, I64 idx);
 public I64 PtrVecClear(PtrVec *vec);
 public I64 PtrVecRelease(PtrVec *vec, U0 (*_free_value)(U0 *_val) = NULL);
 public U0 PtrVecSort(PtrVec *vec,
-                     I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2))
+                     I64 (*_compare_fn)(U0 *_arg1, U0 *_arg2));
 
 public class IntMapNode
 {
@@ -859,7 +859,7 @@ public extern "c" I32 rmdir(U8 *dirname);
 #define RM_FORCE    0x4  /* Force removal, ignore nonexistent files and arguments */
 
 public I32 RmDir(U8 *path, Bool flags=0);
-public I32 Rm(U8 *path, Bool flags=0)
+public I32 Rm(U8 *path, Bool flags=0);
 public Bool MkDir(U8 *path, I32 mode=MKDIR_DEFAULT, Bool recurse=FALSE);
 
 #define FZF_CASE_SMART   0

--- a/src/parser.c
+++ b/src/parser.c
@@ -1689,7 +1689,7 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {
         return parseFunctionDef(cc,rettype,fname,len,params,has_var_args,is_inline);
-    } else {
+    } else if (tokenPunctIs(tok, ';')) {
         if (rettype->kind == AST_TYPE_AUTO) {
             cctrlRaiseException(cc,"auto cannot be used with a function prototype %.*s() at this time",
                     len,fname);
@@ -1699,6 +1699,22 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
         fn->kind = AST_FUN_PROTO;
         mapAdd(cc->global_env,fn->fname->data,fn);
         return fn;
+    } else {
+        /* Neither `{ ... }` (definition) nor `;` (prototype). Almost
+         * always a missing brace - call it out specifically so the
+         * user doesn't get a downstream "TK_KEYWORD X can only prefix
+         * a class" from the rest of the function body being parsed as
+         * top-level declarations. */
+        if (!tok) {
+            cctrlRaiseException(cc,
+                "Expected `{` to open the body of `%.*s()` or `;` for a "
+                "prototype, got end of input",
+                len, fname);
+        }
+        cctrlRaiseException(cc,
+            "Expected `{` to open the body of `%.*s()` or `;` for a "
+            "prototype, got `%.*s`",
+            len, fname, tok->len, tok->start);
     }
 }
 


### PR DESCRIPTION
Fiddly parser fixes along with adding missing `;`'s to `tos.HH`