### PR TITLE
New x86_64 ir based backend with pinned registers and try/catch

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,7 @@ if (HCC_LINK_SQLITE3)
 endif()
 
 execute_process(
-  COMMAND git rev-parse main
+  COMMAND git rev-parse HEAD
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE HCC_GIT_HASH
   OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -40,6 +40,7 @@ add_compile_definitions(HCC_GIT_HASH="${HCC_GIT_HASH}")
 set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2")
 
 set(SOURCES
+    asm.c
     aostr.c
     arena.c
     ast.c
@@ -67,11 +68,13 @@ set(SOURCES
     prsutil.c
     transpiler.c
     x86.c
+    x86_64.c
 )
 
 set(HEADERS 
     aostr.h
     arena.h
+    asm.h
     ast.h
     cctrl.h
     cfg-print.h
@@ -99,6 +102,7 @@ set(HEADERS
     transpiler.h
     version.h
     x86.h
+    x86_64.h
 )
 
 add_executable(hcc ${SOURCES} ${HEADERS})

--- a/src/aostr.c
+++ b/src/aostr.c
@@ -238,6 +238,12 @@ AoStr *aoStrDup(AoStr *buf) {
     return dupe;
 }
 
+void aoStrRemovePreviousChar(AoStr *s, char ch) {
+    if (s->data[s->len-1] == ch) {
+        s->len--;
+    }
+}
+
 void aoStrCatLen(AoStr *buf, const void *d, u64 len) {
     aoStrExtendBufferIfNeeded(buf, len);
     memcpy(buf->data + buf->len, d, len);

--- a/src/aostr.h
+++ b/src/aostr.h
@@ -34,6 +34,7 @@ void aoStrRepeatChar(AoStr *buf, char ch, int times);
 int aoStrCmp(AoStr *b1, AoStr *b2);
 AoStr *aoStrDupRaw(char *s, u64 len);
 AoStr *aoStrDup(AoStr *buf);
+void aoStrRemovePreviousChar(AoStr *s, char ch);
 
 char *aoStrMove(AoStr *buf);
 

--- a/src/asm.c
+++ b/src/asm.c
@@ -1,0 +1,93 @@
+#include <strings.h>
+#include <math.h>
+#include <string.h>
+
+#include "asm.h"
+#include "cli.h"
+#include "x86.h"
+#include "x86_64.h"
+#include "util.h"
+
+/* Encode `64` as a `u64` */
+uint64_t ieee754(double _f64) {
+    if (_f64 == 0.0) return 0;  // Handle zero value explicitly
+
+    // Calculate exponent and adjust fraction
+    double base2_exp = floorl(log2l(fabs(_f64)));
+    double exponet2_removed = ldexpl(_f64, -base2_exp - 1);
+
+    // Initialize fraction and calculate it bit by bit
+    uint64_t fraction = 0;
+    double digit = 0.5;  // Start with 1/2
+    for (s64 i = 0; i != 53; i++) {
+        if (exponet2_removed >= digit) {
+            exponet2_removed -= digit;
+            fraction |= 1ULL << (52 - i);
+        }
+        digit *= 0.5;  // Move to the next digit (1/4, 1/8, ...)
+    }
+
+    // Calculate exponent representation
+    uint64_t exponent = ((1 << 10) - 1) + base2_exp;
+
+    // Handle sign bit
+    uint64_t sign = (_f64 < 0.0) ? 1 : 0;
+
+    // Assemble the IEEE 754 representation
+    return (sign << 63) |
+           ((exponent & 0x7FF) << 52) |
+           (fraction & ~(1ULL << 52));
+}
+
+/* This is a hacky, but seemingly functional way of me being able
+ * to run this on Macos and Linux */
+char *asmNormaliseFunctionName(Cctrl *cc, AoStr *fname) {
+    AoStr *newfn = aoStrNew();
+    switch(cc->target) {
+        case TARGET_AARCH64_APPLE_DARWIN:
+        case TARGET_X86_64_APPLE_DARWIN: {
+            if (fname->data[0] != '_') {
+                aoStrPutChar(newfn, '_');
+            }
+            break;
+        }
+        case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
+        case TARGET_X86_64_UNKNOWN_LINUX_GNU:
+            break;
+    }
+
+    aoStrCatAoStr(newfn, fname);
+
+    /* User-defined `Main` (capital M) is the conventional HolyC entry.
+     *  - With initialisers: rename to `MainFn`. The synthetic init-driver
+     *    function (named `main` lowercase below) is the real `_main`.
+     *  - Without initialisers: lowercase to `main` so it links as the
+     *    process entry point.
+     * Compare case-sensitively so the synthetic `main` (which we feed in
+     * lowercase) flows straight through as `_main`. */
+    if (fname->len == 4 && !strncmp(fname->data, str_lit("Main"))) {
+         if (cc->flags & CCTRL_ASM_HAS_INITIALISERS) {
+            aoStrCatPrintf(newfn, "Fn");
+        } else {
+            aoStrToLowerCase(newfn);
+        }
+    }
+    return aoStrMove(newfn);
+}
+
+AoStr *asmGenerate(Cctrl *cc) {
+    switch (cc->target) {
+        case TARGET_AARCH64_APPLE_DARWIN:
+        case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
+            loggerPanic("Unsupported codegen target; %s\n",
+                    cliTargetToString(cc->target));
+        case TARGET_X86_64_APPLE_DARWIN:
+        case TARGET_X86_64_UNKNOWN_LINUX_GNU:
+            /* Default: IR-based src/x86_64.c. --use-legacy-x86 opts
+             * back into the AST-based src/x86.c for comparison. */
+            if (cc->flags & CCTRL_USE_LEGACY_X86) {
+                return x86AsmGenerate(cc);
+            }
+            return x86_64AsmGenerate(cc);
+    }
+}

--- a/src/asm.h
+++ b/src/asm.h
@@ -1,0 +1,11 @@
+#ifndef ASM_H__
+#define ASM_H__
+
+#include "aostr.h"
+#include "cctrl.h"
+
+char *asmNormaliseFunctionName(Cctrl *cc, AoStr *fname);
+AoStr *asmGenerate(Cctrl *cc);
+uint64_t ieee754(double _f64);
+
+#endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -7,32 +7,39 @@
 #include "aostr.h"
 #include "arena.h"
 #include "ast.h"
-#include "config.h"
 #include "containers.h"
 #include "list.h"
 #include "lexer.h"
 #include "util.h"
 
 static Arena ast_arena;
+static Arena ast_type_arena;
 static int ast_arena_init = 0;
+static int ast_type_arena_init = 0;
 
 void astMemoryInit(void) {
     if (!ast_arena_init) {
         arenaInit(&ast_arena, sizeof(Ast) * 512);
+        arenaInit(&ast_type_arena, sizeof(AstType) * 512);
         ast_arena_init = 1;
+        ast_type_arena_init = 1;
     }
 }
 
 void astMemoryRelease(void) {
     if (ast_arena_init) {
         ast_arena_init = 0;
+        ast_type_arena_init = 1;
         arenaClear(&ast_arena);
+        arenaClear(&ast_type_arena);
     }
 }
 
 void astMemoryStats(void) {
     printf("Ast Arena:\n");
     arenaPrintStats(&ast_arena);
+    printf("Ast Type Arena:\n");
+    arenaPrintStats(&ast_type_arena);
 }
 
 static Ast *astAlloc(void) {
@@ -40,7 +47,10 @@ static Ast *astAlloc(void) {
 }
 
 static AstType *astTypeAlloc(void) {
-    return (AstType *)arenaAlloc(&ast_arena, sizeof(AstType));
+   AstType *t = (AstType *)arenaAlloc(&ast_type_arena, sizeof(AstType));
+   //memset(t, 0, sizeof(AstType));
+   t->has_var_args = 0;
+   return t;
 }
 
 void astVecStringify(AoStr *buf, void *_ast) {
@@ -100,18 +110,18 @@ Map *astMapNew(void) {
     return mapNew(32, &map_ast_type);
 }
 
-AstType *ast_u8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=0};
-AstType *ast_i8_type = &(AstType){.kind = AST_TYPE_CHAR, .size = 1, .ptr = NULL,.issigned=1};
-AstType *ast_i16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=1};
-AstType *ast_u16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .ptr = NULL,.issigned=0};
-AstType *ast_i32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=1};
-AstType *ast_u32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .ptr = NULL,.issigned=0};
-AstType *ast_int_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=1};
-AstType *ast_uint_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .ptr = NULL,.issigned=0};
+AstType *ast_u8_type = &(AstType){ .kind = AST_TYPE_CHAR, .size = 1, .has_var_args = 0, .ptr = NULL,.issigned=0};
+AstType *ast_i8_type = &(AstType){ .kind = AST_TYPE_CHAR, .size = 1, .has_var_args = 0, .ptr = NULL,.issigned=1};
+AstType *ast_i16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .has_var_args = 0, .ptr = NULL,.issigned=1};
+AstType *ast_u16_type = &(AstType){.kind = AST_TYPE_INT, .size = 2, .has_var_args = 0, .ptr = NULL,.issigned=0};
+AstType *ast_i32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .has_var_args = 0, .ptr = NULL,.issigned=1};
+AstType *ast_u32_type = &(AstType){.kind = AST_TYPE_INT, .size = 4, .has_var_args = 0, .ptr = NULL,.issigned=0};
+AstType *ast_int_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .has_var_args = 0, .ptr = NULL,.issigned=1};
+AstType *ast_uint_type = &(AstType){.kind = AST_TYPE_INT, .size = 8, .has_var_args = 0, .ptr = NULL,.issigned=0};
 
-AstType *ast_float_type = &(AstType){.kind = AST_TYPE_FLOAT, .size = 8, .ptr = NULL,.issigned=0};
-AstType *ast_void_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL,.issigned=0};
-AstType *ast_auto_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .ptr = NULL,.issigned=0};
+AstType *ast_float_type = &(AstType){.kind = AST_TYPE_FLOAT, .size = 8, .has_var_args = 0, .ptr = NULL,.issigned=0};
+AstType *ast_void_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .has_var_args = 0, .ptr = NULL,.issigned=0};
+AstType *ast_auto_type = &(AstType){.kind = AST_TYPE_VOID, .size = 0, .has_var_args = 0, .ptr = NULL,.issigned=0};
 
 Ast *ast_loop_sentinal = &(Ast){.kind = AST_GOTO, .type=NULL,
     .slabel = &(AoStr){.data="loop_sentinal", .len=13, .capacity = 0}};
@@ -261,7 +271,7 @@ Ast *astBinaryOp(AstBinOp operation, Ast *left, Ast *right, int *_is_err) {
 Ast *astI64Type(s64 val) {
     Ast *ast = astNew();
     ast->kind = AST_LITERAL;
-    ast->type = ast_int_type;
+    ast->type = astTypeCopy(ast_int_type);
     ast->i64 = val;
     return ast;
 }
@@ -269,7 +279,7 @@ Ast *astI64Type(s64 val) {
 Ast *astCharType(s64 ch) {
     Ast *ast = astNew();
     ast->kind = AST_LITERAL;
-    ast->type = ast_u8_type;
+    ast->type = astTypeCopy(ast_u8_type);
     ast->i64 = ch;
     return ast;
 }
@@ -277,7 +287,7 @@ Ast *astCharType(s64 ch) {
 Ast *astF64Type(double val) {
     Ast *ast = astNew();
     ast->kind = AST_LITERAL;
-    ast->type = ast_float_type;
+    ast->type = astTypeCopy(ast_float_type);
     ast->f64 = val;
     ast->f64_label = NULL;
     return ast;
@@ -391,8 +401,8 @@ Ast *astFunction(AstType *type, char *fname, int len, Vec *params, Ast *body,
                  List *locals, int has_var_args)
 {
     Ast *ast = astNew();
-    ast->type = type;
-    type->has_var_args = has_var_args;
+    ast->type = astTypeCopy(type);
+    ast->type->has_var_args = has_var_args;
     ast->kind = AST_FUNC;
     ast->fname = aoStrDupRaw(fname, len);
     ast->params = params;
@@ -491,7 +501,7 @@ Ast *astSwitch(Ast *cond, Vec *cases, Ast *case_default,
 
 Ast *astCase(AoStr *case_label, s64 case_begin, s64 case_end, List *case_asts) {
     Ast *ast = astNew();
-    ast->type = ast_int_type;
+    ast->type = astTypeCopy(ast_int_type);
     ast->kind = AST_CASE;
     ast->case_begin = case_begin;
     ast->case_end = case_end;
@@ -581,6 +591,21 @@ Ast *astReturn(Ast *retval, AstType *rettype) {
     ast->kind = AST_RETURN;
     ast->type = rettype;
     ast->retval = retval;
+    return ast;
+}
+
+Ast *astTry(Ast *try_body, Ast *catch_body) {
+    Ast *ast = astNew();
+    ast->kind = AST_TRY;
+    ast->try_body = try_body;
+    ast->catch_body = catch_body;
+    return ast;
+}
+
+Ast *astThrow(Ast *value) {
+    Ast *ast = astNew();
+    ast->kind = AST_THROW;
+    ast->throw_value = value;
     return ast;
 }
 
@@ -684,7 +709,22 @@ Ast *astAsmBlock(AoStr *asm_stmt, List *funcs) {
     ast->type = NULL;
     ast->asm_stmt = asm_stmt;
     ast->funcs = funcs;
+    ast->asm_fragments = NULL;
     return ast;
+}
+
+AsmFragment *asmFragmentText(AoStr *text) {
+    AsmFragment *f = (AsmFragment *)calloc(1, sizeof(AsmFragment));
+    f->kind = ASM_FRAG_TEXT;
+    f->text = text;
+    return f;
+}
+
+AsmFragment *asmFragmentLvarRef(Ast *lvar) {
+    AsmFragment *f = (AsmFragment *)calloc(1, sizeof(AsmFragment));
+    f->kind = ASM_FRAG_LVAR_REF;
+    f->lvar = lvar;
+    return f;
 }
 
 Ast *astAsmFunctionDef(AoStr *asm_fname, AoStr *asm_stmt) {
@@ -742,8 +782,9 @@ Ast *astGlobalCmdArgs(void) {
     Ast *ast = astNew();
     ast->kind = AST_VAR_ARGS;
     ast->type = NULL;
-    ast->argc = astDecl(astGVar(ast_int_type,"argc",4,0),NULL);
-    ast->argv = astDecl(astGVar(astMakePointerType(astMakePointerType(ast_u8_type)),"argv",4,0),NULL);
+    ast->argc = astDecl(astGVar(astTypeCopy(ast_int_type),"argc",4,0),NULL);
+    ast->argv = astDecl(astGVar(astMakePointerType(
+                    astMakePointerType(astTypeCopy(ast_u8_type))),"argv",4,0),NULL);
     return ast;
 }
 
@@ -765,7 +806,7 @@ Ast *astComment(char *comment, int len) {
 }
 
 AoStr *astNormaliseFunctionName(char *fname) {
-    AoStr *newfn = aoStrNew();
+        AoStr *newfn = aoStrNew();
 #if IS_BSD
     if (fname[0] != '_') {
         aoStrPutChar(newfn, '_');
@@ -939,15 +980,15 @@ start_routine:
             switch (ptr2->kind) {
                 case AST_TYPE_INT:
                 case AST_TYPE_CHAR:
-                    return ast_int_type;
+                    return astTypeCopy(ast_int_type);
                 case AST_TYPE_CLASS:
                     if (ptr2->is_intrinsic) {
-                        return ast_int_type;
+                        return astTypeCopy(ast_int_type);
                     } else {
                         goto error;
                     }
                 case AST_TYPE_FLOAT:
-                    return ast_float_type;
+                    return astTypeCopy(ast_float_type);
                 case AST_TYPE_ARRAY:
                 case AST_TYPE_POINTER:
                     return ptr2;
@@ -969,11 +1010,11 @@ start_routine:
             goto start_routine;
         case AST_TYPE_CLASS:
             if (ptr1->is_intrinsic && ptr2->is_intrinsic) {
-                return ast_int_type;
+                return astTypeCopy(ast_int_type);
             } else if (astIsIntType(ptr1) && ptr2->is_intrinsic) {
-                return ast_int_type;
+                return astTypeCopy(ast_int_type);
             } else if (ptr1->is_intrinsic && astIsIntType(ptr2)) {
-                return ast_int_type;
+                return astTypeCopy(ast_int_type);
             } else {
                 goto error;
             }
@@ -1693,6 +1734,21 @@ void _astToString(AoStr *str, Ast *ast, int depth) {
             astStringEndStmt(str);
             break;
 
+        case AST_TRY:
+            aoStrCatPrintf(str, "<try>\n");
+            _astToString(str, ast->try_body, depth+1);
+            aoStrCatRepeat(str, "  ", depth);
+            aoStrCatPrintf(str, "<catch>\n");
+            _astToString(str, ast->catch_body, depth+1);
+            astStringEndStmt(str);
+            break;
+
+        case AST_THROW:
+            aoStrCatPrintf(str, "<throw>\n");
+            _astToString(str, ast->throw_value, depth+1);
+            astStringEndStmt(str);
+            break;
+
         case AST_VAR_ARGS:
             aoStrCatPrintf(str, "<var_args>...\n");
             break;
@@ -1950,6 +2006,8 @@ char *astKindToString(AstKind kind) {
         case AST_COMMENT:       return "AST_COMMENT";
         case AST_BINOP:         return "AST_BINOP";
         case AST_UNOP:          return "AST_UNOP";
+        case AST_TRY:           return "AST_TRY";
+        case AST_THROW:         return "AST_THROW";
             break;
     }
     loggerPanic("Cannot find kind: %d\n", kind);
@@ -2191,6 +2249,22 @@ static void _astLValueToString(AoStr *str, Ast *ast, u64 lexeme_flags) {
                     lexemePunctToStringWithFlags(';',lexeme_flags));
             break;
 
+        case AST_TRY:
+            aoStrCatPrintf(str, "try ");
+            _astLValueToString(str, ast->try_body, lexeme_flags);
+            aoStrCatPrintf(str, " catch ");
+            _astLValueToString(str, ast->catch_body, lexeme_flags);
+            break;
+
+        case AST_THROW:
+            aoStrCatPrintf(str, "throw(");
+            _astLValueToString(str, ast->throw_value, lexeme_flags);
+            aoStrCatPrintf(str, "%s",
+                    lexemePunctToStringWithFlags(')',lexeme_flags));
+            aoStrCatPrintf(str,"%s",
+                    lexemePunctToStringWithFlags(';',lexeme_flags));
+            break;
+
         case AST_DEFAULT:
             aoStrCatPrintf(str,"default:");
             break;
@@ -2337,6 +2411,8 @@ const char *astKindToHumanReadable(Ast *ast) {
         case AST_IF: return "if statement";
         case AST_FOR: return "for loop";
         case AST_RETURN: return "return statement";
+        case AST_TRY: return "try/catch statement";
+        case AST_THROW: return "throw statement";
         case AST_DO_WHILE: return "do-while loop";
         case AST_WHILE: return "while loop";
         case AST_CLASS_REF: return "class reference";

--- a/src/ast.h
+++ b/src/ast.h
@@ -139,6 +139,8 @@ typedef enum AstKind {
     AST_COMMENT       = 295,
     AST_BINOP         = 296,
     AST_UNOP          = 297,
+    AST_TRY           = 298,  /* try { ... } catch <stmt> */
+    AST_THROW         = 299,  /* throw(u64_value); */
 } AstKind;
 
 /* @Cleanup
@@ -154,7 +156,7 @@ typedef struct AstType AstType;
 typedef struct AstType {
     AstTypeKind kind;
     int size;
-    int has_var_args;
+    u8 has_var_args;
 
     /* Alignment of a struct or union */
     u32 alignment;
@@ -180,9 +182,35 @@ typedef struct AstType {
 } AstType;
 
 
-#define AST_FLAG_INLINE (1<<0)
+#define AST_FLAG_INLINE  (1<<0)
+#define AST_FLAG_BUILTIN (1<<1)
+/* Set on an AST_GVAR / AST_DECL that came from `extern Type name;` -
+ * a TempleOS-style forward declaration. The parser registers the
+ * symbol in `cc->global_env` so user code can reference it, but the
+ * codegen skips emitting storage: the canonical definition lives in
+ * another translation unit (typically libtos). */
+#define AST_FLAG_EXTERN  (1<<2)
+
+/* AST_LVAR.pinned_kind values. */
+#define LVAR_AUTO  0  /* compiler chooses storage (default) */
+#define LVAR_REG   1  /* pinned to a specific machine register */
+#define LVAR_NOREG 2  /* explicit stack slot (required by asm functions) */
+
+/* AsmFragment.kind values. An inline `asm { ... }` block is parsed
+ * as a list of fragments: literal TEXT chunks and LVAR_REFs (TempleOS
+ * `&var` references to HolyC locals). The per-arch emitter renders
+ * LVAR_REFs using the local's stack offset, which isn't known until
+ * the layout pass runs (well after parse time). */
+#define ASM_FRAG_TEXT     1
+#define ASM_FRAG_LVAR_REF 2
 
 typedef struct Ast Ast;
+
+typedef struct AsmFragment {
+    int kind;
+    AoStr *text;   /* ASM_FRAG_TEXT */
+    Ast *lvar;     /* ASM_FRAG_LVAR_REF: must point to an AST_LVAR */
+} AsmFragment;
 typedef struct Ast {
     AstKind kind;
     u64 flags;
@@ -205,6 +233,11 @@ typedef struct Ast {
         struct {
             AoStr *asm_stmt;
             List *funcs;
+            /* Optional list of AsmFragment* when the asm body uses
+             * TempleOS-style `&var` refs that need stack-offset
+             * substitution at emit time. NULL for pure-text asm
+             * blocks (the existing code keeps using `asm_stmt`). */
+            List *asm_fragments;
         };
 
         /* String */
@@ -218,6 +251,15 @@ typedef struct Ast {
         struct {
             u32 lvar_id;
             AoStr *lname;
+            /* TempleOS-style register pinning. `pinned_kind` defaults
+             * to LVAR_AUTO (compiler chooses storage); `LVAR_REG` ties
+             * the local to a specific machine register named by
+             * `pinned_reg`; `LVAR_NOREG` explicitly forces a stack
+             * slot. The latter only matters semantically inside
+             * functions that contain `asm { }` blocks, where AUTO is
+             * forbidden. */
+            int pinned_kind;
+            AoStr *pinned_reg;
         };
 
         /* Global variable */
@@ -313,6 +355,17 @@ typedef struct Ast {
         struct {
             /* Return statement */
             Ast *retval;
+        };
+
+        /* try { body } catch <handler> */
+        struct {
+            Ast *try_body;
+            Ast *catch_body;
+        };
+
+        /* throw(value) */
+        struct {
+            Ast *throw_value;
         };
 
         /* @Typeo
@@ -434,6 +487,8 @@ Ast *astFunctionCall(AstType *type, char *fname, int len, Vec *argv);
 Ast *astFunction(AstType *rettype, char *fname, int len, Vec *params,
                  Ast *body, List *locals, int has_var_args);
 Ast *astReturn(Ast *retval, AstType *rettype);
+Ast *astTry(Ast *try_body, Ast *catch_body);
+Ast *astThrow(Ast *value);
 Ast *astFunctionPtr(AstType *type,
                     char *fname,
                     int fname_len, 
@@ -449,6 +504,8 @@ Ast *astFunctionDefaultParam(Ast *var, Ast *init);
 Ast *astVarArgs(void);
 
 Ast *astAsmBlock(AoStr *asm_stmt, List *funcs);
+AsmFragment *asmFragmentText(AoStr *text);
+AsmFragment *asmFragmentLvarRef(Ast *lvar);
 Ast *astAsmFunctionBind(AstType *rettype, AoStr *asm_fname, 
         AoStr *fname, Vec *params);
 Ast *astAsmFunctionCall(AstType *rettype, AoStr *asm_fname, Vec *argv);

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -150,6 +150,17 @@ static void cctrlAddBuiltinMacros(Cctrl *cc) {
     mapAdd(cc->macro_defs,"__HCC_VERSION__",le);
 }
 
+void cctrlAddBuiltinFunctions(Cctrl *cc) {
+      Vec *params = vecNew(&vec_ast_type);
+      AstType *type = astMakePointerType(astMakePointerType(ast_u8_type));
+      Ast *var = astLVar(type,str_lit("fname"));
+      vecPush(params, var);
+      Ast *fn = astFunction(type,str_lit("Uf"),params,NULL,NULL,0);
+      fn->kind = AST_FUN_PROTO;
+      fn->flags |= AST_FLAG_BUILTIN;
+      mapAdd(cc->global_env,fn->fname->data,fn);
+}
+
 Cctrl *ccMacroProcessor(Map *macro_defs) {
     Cctrl *cc = (Cctrl *)malloc(sizeof(Cctrl));
     cc->macro_defs = macro_defs;
@@ -212,6 +223,7 @@ Cctrl *cctrlNew(void) {
     for (int i = 0; i < (int)static_size(built_in_types); ++i) {
         AstType *type = (AstType *)malloc(sizeof(AstType));
         BuiltInType *built_in = &built_in_types[i]; 
+        memset(type, 0, sizeof(AstType));
         type->size = built_in->size;
         type->issigned = built_in->issigned;
         type->kind = built_in->kind;
@@ -220,6 +232,8 @@ Cctrl *cctrlNew(void) {
     }
 
     cctrlAddBuiltinMacros(cc);
+    /* We have no real mechanism of adding compiler builtins */
+    // cctrlAddBuiltinFunctions(cc);
 
     Ast *cmd_args = astGlobalCmdArgs();
     listAppend(cc->ast_list,cmd_args->argc);

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -5,6 +5,7 @@
 
 #include "aostr.h"
 #include "ast.h"
+#include "cli.h"
 #include "config.h"
 #include "containers.h"
 #include "lexer.h"
@@ -12,10 +13,16 @@
 #define CCTRL_TOKEN_BUFFER_SIZE 16
 #define CCTRL_TOKEN_BUFFER_MASK CCTRL_TOKEN_BUFFER_SIZE-1
 
-#define CCTRL_TRANSPILING     (1<<0)
-#define CCTRL_SAVE_ANONYMOUS  (1<<1)
-#define CCTRL_PASTE_DEFINES   (1<<2)
-#define CCTRL_PRESERVE_SIZEOF (1<<3)
+#define CCTRL_TRANSPILING          (1<<0)
+#define CCTRL_SAVE_ANONYMOUS       (1<<1)
+#define CCTRL_PASTE_DEFINES        (1<<2)
+#define CCTRL_PRESERVE_SIZEOF      (1<<3)
+#define CCTRL_ASM_HAS_INITIALISERS (1<<4)
+/* Escape hatch back to the legacy AST-based x86_64 codegen
+ * (src/x86.c). Default is now the IR-based src/x86_64.c. The
+ * legacy path will be deleted once the IR backend has full unit-
+ * test coverage; until then this flag stays as a debugging tool. */
+#define CCTRL_USE_LEGACY_X86       (1<<5)
 
 /* For messages */
 #define CCTRL_ICE   0
@@ -136,7 +143,7 @@ typedef struct Cctrl {
     char *CC;
     
     /* Target triple */
-    char *target;
+    enum CliTarget target;
 } Cctrl;
 
 /* Instantiate a new compiler control struct */

--- a/src/cli.c
+++ b/src/cli.c
@@ -73,7 +73,6 @@ int cliParseBoolean(CliValue *value, char *rawarg) {
 }
 
 static char *target_map[] = {
-    [TARGET_DEFAULT] = "default",
     [TARGET_AARCH64_APPLE_DARWIN] = "aarch64-apple-darwin",
     [TARGET_AARCH64_UNKNOWN_LINUX_GNU] = "aarch64-unknown-linux-gnu",
     [TARGET_X86_64_APPLE_DARWIN] = "x86_64-apple-darwin" ,
@@ -82,8 +81,6 @@ static char *target_map[] = {
 
 const char *cliTargetToString(enum CliTarget target) {
     switch (target) {
-        case TARGET_DEFAULT:
-            return target_map[TARGET_DEFAULT];
         case TARGET_AARCH64_APPLE_DARWIN: 
             return target_map[TARGET_AARCH64_APPLE_DARWIN];
         case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
@@ -112,12 +109,14 @@ static CliParser parsers[] = {
     {str_lit("-o-"),        0, CLI_TO_STDOUT, "-o-", "Output assembly to stdout, only for use with -S", &cliParseNop},
     {str_lit("-transpile"), 0, CLI_TRANSPILE, "-transpile", "Transpile the code to C, this is best effort", &cliParseNop},
     {str_lit("--target"),   0, CLI_TARGET, "--target", "Select the target, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-unknown-linux-gnu` this follows llvm style target triples", &cliParseString},
+    {str_lit("--install-dir"), 0, CLI_INSTALL_DIR, "--install-dir <path>", "Override the install prefix (header dir = <path>/include, lib dir = <path>/lib). Defaults to /usr/local.", &cliParseString},
     {str_lit("-D"),         0, CLI_DEFINES_LIST, "-D<VAR>", "Set a compiler #define (does not accept a value)", &cliParseDefine},
     {str_lit("--dump-ir"),  0, CLI_DUMP_IR, "--dump-ir", "Dump ir to stdout" , &cliParseNop},
     {str_lit("--mem-stats"),  0, CLI_MEM_STATS, "--mem-stats", "Stats about memory usage when compiling" , &cliParseNop},
     {str_lit("--version"),  0, CLI_VERSION, "--version", "Print the version of the compiler", &cliParseNop},
     {str_lit("--help"),     0, CLI_HELP, "--help", "Print this message", &cliParseNop},
     {str_lit("--terry"),    0, CLI_TERRY, "--terry", "Information about Terry A. Davis", &cliParseNop},
+    {str_lit("--use-legacy-x86"), 0, CLI_USE_LEGACY_X86, "--use-legacy-x86", "Fall back to the legacy AST-based x86_64 codegen (src/x86.c) instead of the default IR-based src/x86_64.c. Kept as a debugging escape hatch while the IR backend matures.", &cliParseNop},
 };
 
 static u64 longestCommand(void) {
@@ -183,12 +182,11 @@ __noreturn void cliVersionPrint(CliArgs *args) {
     aoStrCatFmt(buffer,
             "binary: %s/hcc\n"
             "commit-hash: %s\n"
-            "arch: %s %s\n"
+            "arch: %s\n"
             "build: %s\n",
             args->install_dir,
             git_hash->data,
-            OS_STR,
-            ARCH_STR,
+            cliTargetToString(args->target),
             getBuildModeStr());
 
     printf("%s",buffer->data);
@@ -454,11 +452,13 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
                 }
                 break;
             }
+            case CLI_INSTALL_DIR: args->install_dir = value.str; break;
             case CLI_DUMP_IR:   args->dump_ir = 1; break;
             case CLI_MEM_STATS: args->print_mem_stats = 1; break;
             case CLI_HELP:    cliPrintUsage(); break;
             case CLI_VERSION: cliVersionPrint(args); break;
             case CLI_TERRY:   cliTerryInfo(); break;
+            case CLI_USE_LEGACY_X86: args->use_legacy_x86 = 1; break;
         }
     }
 
@@ -477,5 +477,19 @@ void cliArgsInit(CliArgs *args) {
     memset(args,0,sizeof(CliArgs));
     args->clibs = "";
     args->defines_list = NULL;
-    args->target = TARGET_DEFAULT;
+
+    /* We make a stab at trying to guess the target from what we have
+     * discovered in the config file */
+#if IS_ARM_64 && IS_LINUX
+    args->target = TARGET_AARCH64_UNKNOWN_LINUX_GNU;
+#elif IS_ARM_64 && IS_BSD
+    /* Let rosetta work its magic */
+    args->target = TARGET_X86_64_APPLE_DARWIN;
+#elif IS_X86_64 && IS_LINUX
+    args->target = TARGET_X86_64_UNKNOWN_LINUX_GNU;
+#elif IS_X86_64 && IS_BSD
+    args->target = TARGET_X86_64_APPLE_DARWIN;
+#else
+#error "Could not determine system architecture"
+#endif
 }

--- a/src/cli.h
+++ b/src/cli.h
@@ -2,11 +2,13 @@
 #define CLI_H
 
 #include <stdint.h>
+#include <stdarg.h>
 
+#include "config.h"
 #include "list.h"
+#include "types.h"
 
 enum CliTarget {
-    TARGET_DEFAULT,
     TARGET_AARCH64_APPLE_DARWIN,
     TARGET_AARCH64_UNKNOWN_LINUX_GNU,
     TARGET_X86_64_APPLE_DARWIN,
@@ -32,6 +34,7 @@ enum CliArgType {
     CLI_EMIT_DYLIB,
     CLI_EMIT_OBJECT,
     CLI_HELP,
+    CLI_INSTALL_DIR,
     CLI_MEM_STATS,
     CLI_OUTPUT_FILENAME,
     CLI_PRINT_AST,
@@ -41,6 +44,7 @@ enum CliArgType {
     CLI_TERRY,
     CLI_TO_STDOUT,
     CLI_TRANSPILE,
+    CLI_USE_LEGACY_X86,
     CLI_VERSION,
 };
 
@@ -80,6 +84,7 @@ typedef struct CliArgs {
     int assemble;
     int transpile;
     int to_stdout;
+    int use_legacy_x86;
     char *infile;
     char *infile_no_ext;
     char *asm_outfile;

--- a/src/compile.c
+++ b/src/compile.c
@@ -8,7 +8,7 @@
 #include "cli.h"
 #include "compile.h"
 #include "memory.h"
-#include "x86.h"
+#include "asm.h"
 #include "lexer.h"
 #include "list.h"
 #include "parser.h"

--- a/src/config.h
+++ b/src/config.h
@@ -25,6 +25,10 @@
 #define ARCH_STR "aarch64"
 #endif
 
+#ifndef HCC_GIT_HASH
+#define HCC_GIT_HASH "unknown git hash"
+#endif
+
 #ifndef __GNUC__
     #define __attribute__(x)  // Define as empty if not using GCC/Clang
 #endif

--- a/src/containers.c
+++ b/src/containers.c
@@ -918,6 +918,13 @@ static int mapResize(Map *map) {
 
     map->size = new_size;
     map->threashold = (unsigned long)(new_capacity * MAP_LOAD);
+
+    /* Resize relocates every entry, so the lookup cache (set by the last
+     * mapGet/mapHas) now points to whatever happens to live at the old
+     * index. Invalidate it so the next mapGet falls through to a real
+     * search instead of trusting a stale slot. */
+    map->cached_key = (void *)ULONG_MAX;
+    map->cached_idx = ULONG_MAX;
     return 1;
 }
 
@@ -933,10 +940,14 @@ int mapAddLen(Map *map, char *key, s64 key_len, void *value) {
     u64 idx = mapGetCStringNextIdx(map, key, key_len, &is_free);
     MapNode *n = &map->entries[idx];
 
-    /* Only if it is not free do we add to the vector... Though this does mean
-     * the ordering that we are trying to keep is now messed up... */
     if (is_free) {
-        vecPushInt(map->indexes, idx);
+        /* Brand-new FREE slot: append to indexes. Reused DELETED
+         * slot: idx is already in indexes from the original add, so
+         * don't push again - that's what was causing iteration to
+         * yield the same node twice. */
+        if (!(n->flags & MAP_FLAG_DELETED)) {
+            vecPushInt(map->indexes, idx);
+        }
         map->size++;
     }
 
@@ -959,10 +970,10 @@ int mapAdd(Map *map, void *key, void *value) {
     u64 idx = mapGetNextIdx(map, key, &is_free);
     MapNode *n = &map->entries[idx];
 
-    /* Only if it is not free do we add to the vector... Though this does mean
-     * the ordering that we are trying to keep is now messed up... */
     if (is_free) {
-        vecPushInt(map->indexes, idx);
+        if (!(n->flags & MAP_FLAG_DELETED)) {
+            vecPushInt(map->indexes, idx);
+        }
         map->size++;
     }
 
@@ -984,11 +995,13 @@ int mapAddOrErr(Map *map, void *key, void *value) {
     int is_free = 0;
     u64 idx = mapGetNextIdx(map, key, &is_free);
 
-    /* We only add if it is free otherwise this operation is an error - 
+    /* We only add if it is free otherwise this operation is an error -
      * in practice this ensures we can't overwrite values. */
     if (is_free) {
         MapNode *n = &map->entries[idx];
-        vecPushInt(map->indexes, idx);
+        if (!(n->flags & MAP_FLAG_DELETED)) {
+            vecPushInt(map->indexes, idx);
+        }
         n->key = key;
         n->value = value;
         n->key_len = map->type->get_key_len(key);
@@ -1010,10 +1023,13 @@ void mapRemove(Map *map, void *key) {
     n->value = NULL;
     n->key = NULL;
     n->key_len = 0;
-    /* @Bug
-     * Why does reducing the map size cause the hashtable to do weird
-     * things?*/
     map->size--;
+    /* The lookup cache may point at the slot we just deleted, or at
+     * a slot whose contents could change if this DELETED slot is
+     * later reused by mapAdd. Invalidate so the next mapGet does a
+     * real probe instead of trusting stale state. */
+    map->cached_key = (void *)ULONG_MAX;
+    map->cached_idx = ULONG_MAX;
 }
 
 int mapHas(Map *map, void *key) {
@@ -1058,13 +1074,15 @@ void *mapGetAt(Map *map, u64 index) {
 }
 
 void *mapGet(Map *map, void *key) {
-    /* Retrive from cache if we can */
+    /* Retrive from cache if we can. Only honour the hit when the
+     * slot is still TAKEN - if it was deleted or cleared we must
+     * fall through to a real probe, which also walks the parent
+     * chain (returning NULL here would shadow a parent-scope entry). */
     if (map->cached_key == key) {
         MapNode *n = &map->entries[map->cached_idx];
         if (n->flags & MAP_FLAG_TAKEN) {
             return n->value;
         }
-        return NULL;
     }
 
     for (; map != NULL; map = map->parent) {
@@ -1082,13 +1100,12 @@ void *mapGet(Map *map, void *key) {
 }
 
 void *mapGetLen(Map *map, char *key, s64 len) {
-    /* Retrive from cache if we can */
+    /* See mapGet above - same cache-fall-through invariant. */
     if (map->cached_key == key) {
         MapNode *n = &map->entries[map->cached_idx];
         if (n->flags & MAP_FLAG_TAKEN) {
             return n->value;
         }
-        return NULL;
     }
 
     for (; map != NULL; map = map->parent) {
@@ -1119,6 +1136,8 @@ void mapClear(Map *map) {
     }
     map->size = 0;
     vecClear(map->indexes);
+    map->cached_key = (void *)ULONG_MAX;
+    map->cached_idx = ULONG_MAX;
 }
 
 void mapMerge(Map *map1, Map *map2) {

--- a/src/holyc-lib/all.HC
+++ b/src/holyc-lib/all.HC
@@ -1,6 +1,7 @@
 #include "./defs.HH"
 #include "./memory.HC"
 #include "./system.HC"
+#include "./except.HC"
 #include "./math.HC"
 #include "./date.HC"
 #include "./io.HC"

--- a/src/holyc-lib/except.HC
+++ b/src/holyc-lib/except.HC
@@ -1,0 +1,75 @@
+/* TempleOS-style try/catch/throw runtime.
+ *
+ * The compiler lowers `try { body } catch <stmt>` into:
+ *   - alloca CatchFrame on the stack
+ *   - call HCC_TryEnter(&frame)  ; setjmp under the hood
+ *   - if return value == 0:  run body, then HCC_TryLeave
+ *   - else (got here via longjmp): pop frame, run handler
+ *
+ * `throw(value)` becomes `HCC_Throw(value)`; the runtime stashes the
+ * u64 in Fs->except_ch and longjmps to the most recent catch frame.
+ *
+ * The compiler reserves 256 bytes for each CatchFrame slot, which is
+ * larger than every platform jmp_buf we target plus the chain pointer.
+ * The HolyC `class CatchFrame` below pads to exactly 256 bytes so the
+ * layout the runtime sees matches what the compiler allocated.
+ *
+ * Single-thread for now: Fs is a process-wide global. Multi-thread
+ * support requires a pthread_key_t-backed Fs (future work). */
+#include "./defs.HH"
+
+public extern "c" I32 setjmp(U0 *env);
+public extern "c" U0 longjmp(U0 *env, I32 val);
+
+/* Compiler reserves 256 bytes per CatchFrame. We split that into a
+ * 248-byte jmp_buf storage region (setjmp owns the format) plus the
+ * 8-byte chain pointer the runtime walks. */
+#define __JMP_BUF_BYTES__ 248
+
+class CatchFrame;
+class CatchFrame
+{
+  I8 jb[__JMP_BUF_BYTES__];
+  CatchFrame *prev;
+};
+
+class HCFs
+{
+  CatchFrame *catch_top;  /* head of the active-try-frames chain */
+  U64 except_ch;          /* value of the most recent throw */
+};
+
+/* Canonical storage + global pointer. tos.HH declares `Fs` as
+ * `extern HCFs *Fs;` so user TUs reference rather than redefine. We
+ * initialise lazily on first try, since HolyC lifts non-constant
+ * global initialisers into a hidden Main wrapper that would conflict
+ * with the user's Main. */
+static HCFs _fs_storage;
+public HCFs *Fs;
+
+/* Push the frame onto the catch-stack. The setjmp call itself MUST
+ * stay inline in the user function (it captures the caller's frame,
+ * and longjmp to a returned function's frame is UB), so the chain
+ * mutation is the only thing we delegate to a helper. */
+public U0 HCC_PushFrame(CatchFrame *f)
+{
+  if (!Fs) Fs = &_fs_storage;
+  f->prev = Fs->catch_top;
+  Fs->catch_top = f;
+}
+
+public U0 HCC_TryLeave(CatchFrame *f)
+{
+  Fs->catch_top = f->prev;
+}
+
+public U0 HCC_Throw(U64 v)
+{
+  Fs->except_ch = v;
+  auto t = Fs->catch_top;
+  if (!t) {
+    "uncaught throw: %X\n", v;
+    Exit(1);
+  }
+  longjmp(t->jb, 1);
+}

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -467,6 +467,32 @@ public _extern _EXIT U0 Exit(I64 exit_code = EXIT_FAIL);
 public _extern _WRITE I64 Write(I64 fd, U8 *buf, I64 len);
 public _extern _SYSTEM I64 System(U8 *command);
 
+/* TempleOS-style try/catch/throw. CatchFrame is 256 bytes (matches
+ * what the compiler reserves per `try` block); the runtime stores its
+ * jmp_buf bytes plus a chain pointer inside. Fs->except_ch holds the
+ * u64 thrown by the most recent `throw(...)`. */
+public class CatchFrame;
+public class CatchFrame
+{
+  I8 jb[248];
+  CatchFrame *prev;
+};
+public class HCFs
+{
+  CatchFrame *catch_top;
+  U64 except_ch;
+};
+/* `Fs` is the TempleOS-faithful global task pointer. The canonical
+ * definition (and storage init) lives in libtos's except.HC; this
+ * `extern` declaration tells user-side parsing that `Fs` exists
+ * without emitting storage here (which would clash at link time). */
+extern HCFs *Fs;
+public extern "c" I32 setjmp(U0 *env);
+public extern "c" U0 longjmp(U0 *env, I32 val);
+public U0 HCC_PushFrame(CatchFrame *f);
+public U0 HCC_TryLeave(CatchFrame *f);
+public U0 HCC_Throw(U64 v);
+
 public extern "c" F64 acos(F64 f1);
 public extern "c" F64 asin(F64 f1);
 public extern "c" F64 atan(F64 f1);
@@ -733,8 +759,8 @@ class cDIR;
 
 #ifdef IS_MACOS
 #define DIR_MAXPATHLEN (1024)
-
-class Dirent {
+class Dirent
+{
   U64 ino;
   U64 off;
   U16 reclen;        /* length of this record */

--- a/src/ir-debug.c
+++ b/src/ir-debug.c
@@ -706,7 +706,7 @@ void irValuePrint(IrValue *ir_value) {
     } else {
         aoStrCatFmt(buf, "IrValue %S", str);
     }
-    printf("%s\n",str->data);
+    printf("%s\n", buf->data);
     aoStrRelease(str);
     aoStrRelease(buf);
 }

--- a/src/ir-peephole.c
+++ b/src/ir-peephole.c
@@ -248,9 +248,9 @@ static void irPeepholeFuseAddrIntoStoreDeref(IrFunction *func, Map *uses) {
  * register pools are full, which depends on the arg sequence in
  * complicated ways - the existing arg-load loop handles those, but we
  * don't try to fuse them. */
-static void irPeepholeFuseTailArgIntoCall(Cctrl *cc, IrFunction *func, Map *uses) {
+static void irPeepholeFuseTailArgIntoCall(Cctrl *cc, IrFunction *fn, Map *uses) {
     if (!cc) return;
-    listForEach(func->blocks) {
+    listForEach(fn->blocks) {
         IrBlock *bb = (IrBlock *)it->value;
         if (listEmpty(bb->instructions)) continue;
         listForEach(bb->instructions) {
@@ -261,7 +261,8 @@ static void irPeepholeFuseTailArgIntoCall(Cctrl *cc, IrFunction *func, Map *uses
                 continue;
 
             AoStr *fname = call->r1->as.array.label;
-            if (!fname) continue;  /* indirect call - no callee info */
+            if (!fname)
+              continue;  /* indirect call - no callee info */
 
             Ast *callee = (Ast *)mapGetLen(cc->global_env,
                                             fname->data, fname->len);

--- a/src/ir-regalloc.c
+++ b/src/ir-regalloc.c
@@ -35,6 +35,19 @@ void irCgAllocTmp(IrRaCtx *ra, IrValue *val, int starting_offset) {
     irCgSetLoff(ra, val->as.var.id, -(starting_offset + ra->extra_stack));
 }
 
+/* Reserve a fresh stack slot of a specific size (rounded up to 8-byte
+ * alignment). Used by IR_ALLOCA so that a 256-byte alloca actually
+ * gets 256 bytes of stack, not a default 8. */
+static void irCgAllocTmpSized(IrRaCtx *ra, IrValue *val,
+                               int starting_offset, int size_bytes) {
+    if (!val || val->kind != IR_VAL_TMP) return;
+    if (mapHasInt(ra->id_to_loff, val->as.var.id)) return;
+    int aligned = (size_bytes + 7) & ~7;
+    if (aligned < 8) aligned = 8;
+    ra->extra_stack += aligned;
+    irCgSetLoff(ra, val->as.var.id, -(starting_offset + ra->extra_stack));
+}
+
 void irCgAllocOperandsForInstr(IrRaCtx *ra, IrInstr *I, int start) {
     int spill_dst = !(I->flags & IRCG_FUSE_TO_NEXT);
     int load_r1 = !(I->flags & IRCG_R1_IN_REG);
@@ -44,9 +57,18 @@ void irCgAllocOperandsForInstr(IrRaCtx *ra, IrInstr *I, int start) {
     case IR_JMP:
         return;
 
-    case IR_ALLOCA:
-        irCgAllocTmp(ra, I->dst, start);
+    case IR_ALLOCA: {
+        /* The alloca's r1 operand carries the byte size as a constant.
+         * Honour it so multi-byte allocations (struct buffers,
+         * CatchFrame storage, etc.) get the right amount of stack
+         * rather than a default 8 bytes. */
+        int alloca_bytes = 8;
+        if (I->r1 && I->r1->kind == IR_VAL_CONST_INT) {
+            alloca_bytes = (int)I->r1->as._i64;
+        }
+        irCgAllocTmpSized(ra, I->dst, start, alloca_bytes);
         return;
+    }
 
     case IR_LOAD:
         if (spill_dst) irCgAllocTmp(ra, I->dst, start);
@@ -202,7 +224,9 @@ IrValue *irFirstFusableSource(IrInstr *I) {
 
 static void irBumpUseIfTmp(Map *uses, IrValue *v) {
     if (!v || v->kind != IR_VAL_TMP) return;
-    int n = (int)(u64)mapGetInt(uses, v->as.var.id) || 0;
+    int n = mapHasInt(uses, v->as.var.id)
+            ? (int)(u64)mapGetInt(uses, v->as.var.id)
+            : 0;
     mapAdd(uses, (void *)(u64)v->as.var.id, (void *)(u64)(n + 1));
 }
 
@@ -235,10 +259,106 @@ void irCgAnnotate(IrFunction *fn) {
         }
     }
 
+    /* Dead-code elimination: drop instructions whose dst tmp is
+     * never read AND which have no observable side effects. Iterate
+     * to a fixed point - dropping op A may make op B (which fed A)
+     * itself unused. Each iteration recomputes the use-count map.
+     *
+     * Safely droppable ops (pure value producers):
+     *   IR_LEA, IR_IADD, IR_ISUB, IR_IMUL,
+     *   IR_AND, IR_OR, IR_XOR,
+     *   IR_SHL, IR_SHR, IR_SAR,
+     *   IR_INEG, IR_NOT,
+     *   IR_ICMP, IR_FCMP,
+     *   IR_FADD, IR_FSUB, IR_FMUL, IR_FDIV, IR_FNEG,
+     *   IR_TRUNC, IR_ZEXT, IR_SEXT,
+     *   IR_FPTRUNC, IR_FPEXT, IR_FPTOSI, IR_FPTOUI,
+     *   IR_SITOFP, IR_UITOFP,
+     *   IR_PTRTOINT, IR_INTTOPTR, IR_BITCAST
+     *
+     * Kept (side-effecting / control flow / storage):
+     *   IR_STORE, IR_STORE_DEREF, IR_CALL, IR_BR/JMP/RET/SWITCH/LOOP,
+     *   IR_PHI, IR_ALLOCA, IR_LOAD, IR_LOAD_DEREF (may fault),
+     *   IR_IDIV/IR_UDIV/IR_IREM/IR_UREM (may divide by zero),
+     *   IR_ASM, IR_VA_* */
+    int changed = 1;
+    while (changed) {
+        changed = 0;
+        listForEach(fn->blocks) {
+            IrBlock *bb = (IrBlock *)it->value;
+            listForEach(bb->instructions) {
+                IrInstr *I = (IrInstr *)it->value;
+                int safe;
+                switch (I->op) {
+                case IR_LEA:
+                case IR_IADD: case IR_ISUB: case IR_IMUL:
+                case IR_AND:  case IR_OR:   case IR_XOR:
+                case IR_SHL:  case IR_SHR:  case IR_SAR:
+                case IR_INEG: case IR_NOT:
+                case IR_ICMP: case IR_FCMP:
+                case IR_FADD: case IR_FSUB: case IR_FMUL:
+                case IR_FDIV: case IR_FNEG:
+                case IR_TRUNC: case IR_ZEXT: case IR_SEXT:
+                case IR_FPTRUNC: case IR_FPEXT:
+                case IR_FPTOSI: case IR_FPTOUI:
+                case IR_SITOFP: case IR_UITOFP:
+                case IR_PTRTOINT: case IR_INTTOPTR:
+                case IR_BITCAST:
+                    safe = 1; break;
+                default:
+                    safe = 0;
+                }
+                if (!safe) continue;
+                if (!I->dst || I->dst->kind != IR_VAL_TMP) continue;
+                int n = mapHasInt(uses, I->dst->as.var.id)
+                        ? (int)(intptr_t)mapGetInt(uses,
+                                                    I->dst->as.var.id)
+                        : 0;
+                if (n != 0) continue;
+                I->op = IR_NOP;
+                I->dst = NULL;
+                I->r1 = NULL;
+                I->r2 = NULL;
+                changed = 1;
+            }
+        }
+        if (!changed) break;
+        /* Re-tally uses for the next iteration. */
+        mapRelease(uses);
+        uses = mapNew(64, &map_uint_to_uint_type);
+        listForEach(fn->blocks) {
+            IrBlock *bb = (IrBlock *)it->value;
+            listForEach(bb->instructions) {
+                IrInstr *I = (IrInstr *)it->value;
+                if (I->op == IR_NOP) continue;
+                if (I->op == IR_CALL && I->r1 && I->r1->as.array.values) {
+                    Vec *args = I->r1->as.array.values;
+                    for (u64 i = 0; i < args->size; ++i) {
+                        irBumpUseIfTmp(uses, (IrValue *)args->entries[i]);
+                    }
+                } else {
+                    irBumpUseIfTmp(uses, I->r1);
+                }
+                irBumpUseIfTmp(uses, I->r2);
+                if (I->op == IR_BR || I->op == IR_RET ||
+                    I->op == IR_STORE_DEREF) {
+                    irBumpUseIfTmp(uses, I->dst);
+                }
+                if (I->op == IR_PHI && I->extra.phi_pairs) {
+                    for (u64 i = 0; i < I->extra.phi_pairs->size; ++i) {
+                        IrPair *p = vecGet(IrPair *,
+                                            I->extra.phi_pairs, i);
+                        irBumpUseIfTmp(uses, p->ir_value);
+                    }
+                }
+            }
+        }
+    }
+
     listForEach(fn->blocks) {
         IrBlock *bb = (IrBlock *)it->value;
         if (listEmpty(bb->instructions)) continue;
-        listForEach(bb->instructions) { 
+        listForEach(bb->instructions) {
             IrInstr *cur = (IrInstr *)it->value;
             if (cur->op == IR_NOP) continue;
             if (!irInstrDefsIntoReg(cur)) continue;
@@ -437,6 +557,28 @@ int irBlockHasPhi(IrBlock *bb) {
     return 0;
 }
 
+int irPhiPairValueLiveInResultReg(IrBlock *from, IrValue *v) {
+    if (!from || !v || v->kind != IR_VAL_TMP) return 0;
+    if (listEmpty(from->instructions)) return 0;
+    for (List *node = from->instructions->prev;
+         node != from->instructions;
+         node = node->prev) {
+        IrInstr *I = (IrInstr *)node->value;
+        if (I->op == IR_NOP)
+            continue;
+        if (I->op == IR_JMP ||
+            I->op == IR_BR ||
+            I->op == IR_RET)
+            continue;
+        if (!I->dst || I->dst->kind != IR_VAL_TMP)
+            return 0;
+        if (I->dst->as.var.id != v->as.var.id)
+            return 0;
+        return (I->flags & IRCG_FUSE_TO_NEXT) != 0;
+    }
+    return 0;
+}
+
 static IrInstr *irBlockTerminator(IrBlock *bb) {
     IrInstr *term = NULL;
     listForEach(bb->instructions) {
@@ -529,6 +671,8 @@ void irCgBindAstLoffs(IrRaCtx *ra, Ast *ast_func) {
             else if (p->kind == AST_FUNPTR)   param_id = p->fn_ptr_id;
             else                              param_id = p->lvar_id;
             IrValue *iv = irFnGetVar(ra->func, param_id);
+            /* Pinned param: no slot. */
+            if (iv && iv->pinned_reg) continue;
             if (iv) irCgSetLoff(ra, iv->as.var.id, p->loff);
         }
     }
@@ -540,6 +684,9 @@ void irCgBindAstLoffs(IrRaCtx *ra, Ast *ast_func) {
         else if (l->kind == AST_FUNPTR)   id = l->fn_ptr_id;
         else                              id = l->lvar_id;
         IrValue *iv = irFnGetVar(ra->func, id);
+        /* Register-pinned locals have no slot - the codegen reads /
+         * writes the named register directly. */
+        if (iv && iv->pinned_reg) continue;
         if (iv) irCgSetLoff(ra, iv->as.var.id, l->loff);
     }
 }
@@ -578,6 +725,9 @@ int irCgComputeAstLayout(Ast *ast_func, IrFunction *ir_func) {
                        !setHas(surviving, (void *)(u64)iv->as.var.id);
         if (promoted)
             continue;
+        /* Register-pinned local: no stack slot, no loff. */
+        if (iv && iv->pinned_reg)
+            continue;
         total += align(size, 8);
         new_offset -= size;
         l->loff = new_offset;
@@ -594,6 +744,10 @@ int irCgComputeAstLayout(Ast *ast_func, IrFunction *ir_func) {
     if (ast_func->params) {
         for (u64 i = 0; i < ast_func->params->size; ++i) {
             Ast *p = vecGet(Ast *, ast_func->params, i);
+            /* TempleOS-pinned param has no stack slot. */
+            if (p->kind == AST_LVAR &&
+                p->pinned_kind == LVAR_REG &&
+                p->pinned_reg) continue;
             int sz;
             if (p->kind == AST_FUNPTR) {
                 sz = 8;
@@ -625,6 +779,10 @@ int irCgComputeAstLayout(Ast *ast_func, IrFunction *ir_func) {
                 p->argv->loff = 16;
                 continue;
             }
+            /* Pinned param: no slot, no loff. */
+            if (p->kind == AST_LVAR &&
+                p->pinned_kind == LVAR_REG &&
+                p->pinned_reg) continue;
             int sz = (p->kind == AST_FUNPTR) ? 8 : p->type->size;
             p->loff = -offset;
             offset -= align(sz, 8);

--- a/src/ir-regalloc.h
+++ b/src/ir-regalloc.h
@@ -13,7 +13,7 @@
  * arch (e.g. %rax/%xmm0 on x86_64). */
 
 /* The instruction's result is consumed by the next non-NOP instruction
- * as its first source — emit nothing for the spill, the consumer knows
+ * as its first source, emit nothing for the spill, the consumer knows
  * to read directly from the result register. */
 #define IRCG_FUSE_TO_NEXT     (1u << 0)
 /* Paired with IRCG_FUSE_TO_NEXT on the consumer: skip the load of the
@@ -60,6 +60,19 @@
  * emits nothing and reserves no slot. */
 #define IRCG_LEA_INLINE_AT_CALL (1u << 7)
 
+/* This is a builtin compiler function and needs to be handled by the backend
+ * explicitly */
+#define IRCG_FN_BUILTIN (1u << 8)
+
+/* Set on an IR_CALL whose first source-order argument is the hidden
+ * out-pointer for a struct/union by-value return. On AArch64 this
+ * pointer is passed in x8 (the indirect-result-location register),
+ * not in x0; remaining integer args still start at x0. On x86_64 the
+ * pointer goes in %rdi (the first int arg register) so this flag is
+ * informational, the natural arg-slot mapping already does the
+ * right thing. */
+#define IRCG_CALL_AGG_RETURN (1u << 9)
+
 /* Slot offset map. */
 void irCgSetLoff(IrRaCtx *ra, u32 var_id, int loff);
 int  irCgGetLoff(IrRaCtx *ra, IrValue *val);
@@ -91,7 +104,13 @@ void irCgClassifyPhis(IrFunction *func);
 void irCgAnnotate(IrFunction *func);
 
 /* Analysis helpers used by codegen and the peephole pass. */
-int blockHasPhi(IrBlock *bb);
+int irBlockHasPhi(IrBlock *bb);
+
+/* target-agnostic helper that scans the predecessor block to see if a
+ * phi-source value still lives in the result register (x0/rax) because
+ * the producer was marked FUSE_TO_NEXT. Lets us skip a redundant reload. */
+int irPhiPairValueLiveInResultReg(IrBlock *from, IrValue *v);
+
 /* Does this op produce its result naturally into the architecture's
  * canonical result register (i.e. is it a candidate for the
  * "leave in register" fusion path)? Float-typed defs and ops that

--- a/src/ir-types.h
+++ b/src/ir-types.h
@@ -80,7 +80,12 @@ typedef enum IrOp {
     IR_SELECT,      /* Select between two values based on condition */
     IR_VA_ARG,      /* Get next variadic argument */
     IR_VA_START,    /* Initialize va_list */
-    IR_VA_END       /* Clean up va_list */
+    IR_VA_END,      /* Clean up va_list */
+    /* Verbatim assembly text from an inline `asm { ... }` block.
+     * The per-arch codegen just dumps the bytes into the output;
+     * the user is responsible for asm validity. The raw text lives
+     * in `r1->as.str.str`. */
+    IR_ASM
 } IrOp;
 
 
@@ -178,9 +183,15 @@ struct IrValue {
     IrValueType type;
     IrValueKind kind;
     u64 flags;
+    /* When non-NULL, this value is bound to a specific machine
+     * register (TempleOS-style `<Type> reg <REG> name`). The codegen
+     * uses the register name verbatim for reads / writes; the slot
+     * allocator skips reserving a stack slot. Only meaningful for
+     * IR_VAL_LOCAL / IR_VAL_PARAM. */
+    AoStr *pinned_reg;
 
     union {
-        AoStr *name; /* aribitrary string that I seem to have used in my 
+        AoStr *name; /* aribitrary string that I seem to have used in my
                       * previous implementation */
         s64 _i64; /* For integer constants */
         f64 _f64; /* Float constants */
@@ -189,8 +200,8 @@ struct IrValue {
         IrInstr *phi; /* Notes that the value is a phi node, used for either
                        * a logical `OR` or an `AND` */
 
-        /* A string literal, the `str` is an escaped string suitable for 
-         * putting in a file for an assembler to read, the `str_real_len` 
+        /* A string literal, the `str` is an escaped string suitable for
+         * putting in a file for an assembler to read, the `str_real_len`
          * is the length of the string without escape sequences. */
         IrValueString str;
         IrValueGlobal global;
@@ -222,6 +233,11 @@ struct IrInstr {
                       * A switch statments cases in the form;
                       * i64 <number>, label <block>, */
         Vec *phi_pairs; /* `Vec<IrPair *>` */
+        /* For IR_ASM: list of AsmFragment* when the inline asm uses
+         * `&var` references that need stack-offset substitution at
+         * emit time. NULL when the asm body is pure text (read it
+         * from r1's IR_VAL_CONST_STR). */
+        List *asm_fragments;
     } extra;
 };
 
@@ -299,6 +315,11 @@ typedef struct IrCgCtx {
      * call site instead of going through the slot. NULL when no
      * LEA-into-call fusion fired. */
     Map *lea_inline_map;
+    /* Vec<AoStr *>: machine registers that pinned locals occupy in
+     * this function. Populated once at function emit start (walking
+     * the AST locals). The prologue saves these, the epilogue
+     * restores them. NULL when no pinned locals exist. */
+    Vec *pinned_regs;
 } IrCgCtx;
 
 typedef struct IrProgram {

--- a/src/ir.c
+++ b/src/ir.c
@@ -168,7 +168,7 @@ static IrValue *irNarrowToTargetWidth(IrCtx *ctx,
         return val;
     }
 
-    if (val->kind == IR_VAL_TMP && val->as.var.size < (u64)target_ty->size) {
+    if (val->kind == IR_VAL_TMP && val->as.var.size > (u64)target_ty->size) {
         IrValue *narrow = irTmp(narrow_ty, target_ty->size);
         irBlockAddInstr(ctx, irInstrNew(IR_TRUNC, narrow, val, NULL));
         return narrow;
@@ -217,7 +217,7 @@ static void irEmitMemcpy(IrCtx *ctx,
                          int n_bytes)
 {
     IrValue *args_wrap = irValueNew(IR_TYPE_ARRAY, IR_VAL_UNRESOLVED);
-    args_wrap->as.array.label = aoStrPrintf("MEMCPY");
+    args_wrap->as.array.label = aoStrPrintf("MemCpy");
     Vec *args = irValueVecNew();
     args_wrap->as.array.values = args;
     vecPush(args, dst);
@@ -233,6 +233,25 @@ static void irEmitMemcpy(IrCtx *ctx,
     irBlockAddInstr(ctx, call);
 }
 
+/* Emit a one-argument call to a HolyC runtime function by name. The
+ * args wrapper's label is the bare function name (no `_` prefix);
+ * asmNormaliseFunctionName adds the leading underscore at emit time.
+ * Returns the call's dst tmp (for the I64-returning variant) or
+ * NULL for the void variant. */
+static IrValue *irEmitRuntimeCall1(IrCtx *ctx, const char *fname,
+                                    IrValueType ret_type, int ret_size,
+                                    IrValue *arg) {
+    IrValue *args_wrap = irValueNew(IR_TYPE_ARRAY, IR_VAL_UNRESOLVED);
+    args_wrap->as.array.label = aoStrPrintf("%s", fname);
+    Vec *args = irValueVecNew();
+    args_wrap->as.array.values = args;
+    vecPush(args, arg);
+    IrValue *ret = irTmp(ret_type, ret_size);
+    IrInstr *call = irInstrNew(IR_CALL, ret, args_wrap, NULL);
+    irBlockAddInstr(ctx, call);
+    return ret;
+}
+
 
 IrValue *irFnCallTo(IrCtx *ctx, Ast *ast, IrValue *preallocated_buffer) {
     /* Is this returning a struct from the stack? */
@@ -242,6 +261,14 @@ IrValue *irFnCallTo(IrCtx *ctx, Ast *ast, IrValue *preallocated_buffer) {
     IrValue *ir_call_args = irValueNew(IR_TYPE_ARRAY, IR_VAL_UNRESOLVED);
     IrValue *ir_ret_val = irTmp(ret_type, ret_size);
     IrInstr *ir_call_instr = irInstrNew(IR_CALL, ir_ret_val, ir_call_args, NULL);
+
+    if (ast->flags & AST_FLAG_BUILTIN) {
+        ir_call_instr->flags |= IRCG_FN_BUILTIN;
+    }
+
+    if (agg_return) {
+        ir_call_instr->flags |= IRCG_CALL_AGG_RETURN;
+    }
 
     assert(ast->kind == AST_FUNCALL || ast->kind == AST_FUNPTR_CALL ||
            ast->kind == AST_ASM_FUNCALL);
@@ -507,7 +534,25 @@ IrValue *irLowerBinOpExpr(IrCtx *ctx, Ast *ast) {
             ir_result = irTmp(ir_type, 8);
         }
     } else {
-        float_dispatch = irIsFloat(ir_type) || left_is_float;
+        float_dispatch = irIsFloat(ir_type) || left_is_float ||
+                         right_is_float;
+        /* Mixed int/float arithmetic: promote the int side to f64 so the
+         * IR_F* op sees two float operands. Without this, e.g.
+         * `f64 * -1` lowered to fmul(f64, i64) which the codegen treats
+         * as a fmul of garbage. */
+        if (float_dispatch && !(left_is_float && right_is_float)) {
+            IrValue *prom = irTmp(IR_TYPE_F64, 8);
+            IrInstr *cast_instr = NULL;
+            if (!left_is_float) {
+                cast_instr = irInstrNew(IR_SITOFP, prom, lhs, NULL);
+                lhs = prom;
+            }
+            if (!right_is_float) {
+                cast_instr = irInstrNew(IR_SITOFP, prom, rhs, NULL);
+                rhs = prom;
+            }
+            irBlockAddInstr(ctx, cast_instr);
+        }
     }
 
     if (float_dispatch) {
@@ -688,24 +733,32 @@ static IrValue *irLowerCast(IrCtx *ctx,
     int to_float = astIsFloatType(to_type);
 
     if (from_int && to_float) {
+        IrValue *dst = irTmp(IR_TYPE_F64, 8);
         /* HolyC variadic-slot cast `argv[i](F64)`: the source's type
          * carries `has_var_args=1` (the parser tags the argv element
          * type). The slot holds raw 8 bytes that were pushed as the
          * F64 bit pattern - reinterpret rather than convert, matching
          * `asmToFloat`'s `movq %rax, %xmm0` path. */
         if (from_type->has_var_args) {
-            IrValue *dst = irTmp(IR_TYPE_F64, 8);
             irBlockAddInstr(ctx, irInstrNew(IR_BITCAST, dst, src, NULL));
             return dst;
         }
-        IrValue *dst = irTmp(IR_TYPE_F64, 8);
-        irBlockAddInstr(ctx, irInstrNew(IR_SITOFP, dst, src, NULL));
-        return dst;
+        if (from_type->issigned) {
+            irBlockAddInstr(ctx, irInstrNew(IR_SITOFP, dst, src, NULL));
+            return dst;
+        } else {
+            irBlockAddInstr(ctx, irInstrNew(IR_UITOFP, dst, src, NULL));
+            return dst;
+        }
     }
     if (from_float && to_int) {
         IrValueType t = irConvertType(to_type);
         IrValue *dst = irTmp(t, to_type->size);
-        irBlockAddInstr(ctx, irInstrNew(IR_FPTOSI, dst, src, NULL));
+        if (from_type->issigned) {
+            irBlockAddInstr(ctx, irInstrNew(IR_FPTOSI, dst, src, NULL));
+        } else {
+            irBlockAddInstr(ctx, irInstrNew(IR_FPTOUI, dst, src, NULL));
+        }
         return dst;
     }
     /* int<->int and ptr<->int: in our 64-bit-everywhere codegen the bits
@@ -1322,6 +1375,103 @@ void irLowerReturn(IrCtx *ctx, Ast *ast) {
     irBlockAddInstr(ctx, jmp);
 }
 
+/* try { try_body } catch <catch_body> compiles to:
+ *
+ *     frame = alloca(CatchFrame)                 ; ~256 bytes, opaque
+ *     t = HCC_TryEnter(&frame)                   ; setjmp inside runtime
+ *     br (t == 0), body_block, catch_block
+ *   body_block:
+ *     <lower try_body>
+ *     HCC_TryLeave(&frame)                       ; normal completion
+ *     jmp end_block
+ *   catch_block:
+ *     HCC_TryLeave(&frame)                       ; pop *before* handler
+ *                                                ; so a throw inside catch
+ *                                                ; escapes outward
+ *     <lower catch_body>
+ *     jmp end_block
+ *   end_block:
+ *
+ * The CatchFrame layout (jmp_buf bytes + prev pointer) is opaque to
+ * the compiler; we just reserve enough stack for the largest platform
+ * jmp_buf. The HolyC-side `class CatchFrame` agrees on the size. */
+void irLowerTry(IrCtx *ctx, Ast *ast) {
+    /* 1. Reserve CatchFrame storage on the caller's stack. Generous
+     *    size (256 bytes) covers every host jmp_buf we care about. */
+    int frame_size = 256;
+    IrValue *size_const = irConstInt(IR_TYPE_I64, frame_size);
+    IrValue *frame_tmp = irTmp(IR_TYPE_PTR, frame_size);
+    IrInstr *frame_alloca = irInstrNew(IR_ALLOCA, frame_tmp, size_const, NULL);
+    irBlockAddInstr(ctx, frame_alloca);
+    irAddStackSpace(ctx, frame_size);
+
+    /* 2. Materialise &frame as a pointer-typed tmp for the runtime
+     *    calls' arg. */
+    IrValue *frame_addr = irTmp(IR_TYPE_PTR, 8);
+    irBlockAddInstr(ctx,
+        irInstrNew(IR_LEA, frame_addr, frame_tmp, NULL));
+
+    /* 3. Push the frame onto the catch-stack via a tiny helper, then
+     *    call setjmp INLINE in the user's function. setjmp must be
+     *    called from a function whose stack frame still exists when
+     *    longjmp fires - calling it inside HCC_TryEnter (a returned
+     *    helper) was UB. The helper that managed the chain is split
+     *    out so the IR stays declarative. */
+    irEmitRuntimeCall1(ctx, "HCC_PushFrame",
+                        IR_TYPE_VOID, 8, frame_addr);
+    IrValue *enter_ret = irEmitRuntimeCall1(ctx, "setjmp",
+                                              IR_TYPE_I64, 8, frame_addr);
+
+    /* 4. Branch: (enter_ret == 0) -> body, else -> catch. */
+    IrBlock *body_block  = irBlockNew();
+    IrBlock *catch_block = irBlockNew();
+    IrBlock *end_block   = irBlockNew();
+
+    IrValue *cmp_zero = irTmp(IR_TYPE_I64, 8);
+    IrInstr *cmp = irICmp(cmp_zero, IR_CMP_EQ, enter_ret,
+                          irConstInt(IR_TYPE_I64, 0));
+    irBlockAddInstr(ctx, cmp);
+    irBranch(ctx->cur_func, ctx->cur_block, cmp_zero,
+             body_block, catch_block);
+
+    /* 5. body_block: lower try body, leave the catch frame, jump to end. */
+    irFnAddBlock(ctx->cur_func, body_block);
+    ctx->cur_block = body_block;
+    irLowerAst(ctx, ast->try_body);
+    if (!ctx->cur_block->sealed) {
+        irEmitRuntimeCall1(ctx, "HCC_TryLeave",
+                            IR_TYPE_VOID, 8, frame_addr);
+        IrInstr *jmp = irJump(ctx->cur_func, ctx->cur_block, end_block);
+        irBlockAddInstr(ctx, jmp);
+    }
+
+    /* 6. catch_block: pop the frame first (so a throw from inside the
+     *    handler propagates to the next outer try, not back to us),
+     *    then lower the handler, then jump to end. */
+    irFnAddBlock(ctx->cur_func, catch_block);
+    ctx->cur_block = catch_block;
+    irEmitRuntimeCall1(ctx, "HCC_TryLeave",
+                        IR_TYPE_VOID, 8, frame_addr);
+    irLowerAst(ctx, ast->catch_body);
+    if (!ctx->cur_block->sealed) {
+        IrInstr *jmp = irJump(ctx->cur_func, ctx->cur_block, end_block);
+        irBlockAddInstr(ctx, jmp);
+    }
+
+    /* 7. end_block: subsequent statements continue here. */
+    irFnAddBlock(ctx->cur_func, end_block);
+    ctx->cur_block = end_block;
+}
+
+/* throw(value) lowers to a single HCC_Throw(value) call. The runtime
+ * longjmps so control never returns; mark the current block sealed
+ * so the lowering driver doesn't append a fall-through edge. */
+void irLowerThrow(IrCtx *ctx, Ast *ast) {
+    IrValue *v = irExpr(ctx, ast->throw_value);
+    irEmitRuntimeCall1(ctx, "HCC_Throw", IR_TYPE_VOID, 8, v);
+    ctx->cur_block->sealed = 1;
+}
+
 void irLowerIf(IrCtx *ctx, Ast *ast) {
     IrValue *cond_val = irExpr(ctx, ast->cond);
     IrBlock *then_block = irBlockNew();
@@ -1480,6 +1630,26 @@ void irLowerDecl(IrCtx *ctx, Ast *ast) {
     Ast *init = ast->declinit;
     IrInstr *ir_alloca;
     u32 var_id;
+
+    /* Register-pinned local (TempleOS `<Type> reg <REG> name`).
+     * No alloca, no slot - the value lives in the named machine
+     * register for the whole function. Init is performed inline
+     * below as a regular store-to-local (the per-arch emitter sees
+     * the IrValue's `pinned_reg` and writes the register directly). */
+    if (var->kind == AST_LVAR && var->pinned_kind == LVAR_REG) {
+        IrValue *local = irValueNew(irConvertType(var->type), IR_VAL_LOCAL);
+        local->as.var.id = var->lvar_id;
+        local->as.var.size = var->type ? var->type->size : 8;
+        local->pinned_reg = var->pinned_reg;
+        irFnAddVar(ctx->cur_func, var->lvar_id, local);
+        if (init) {
+            IrValue *iv = irExpr(ctx, init);
+            IrInstr *st = irInstrNew(IR_STORE, local, iv, NULL);
+            irBlockAddInstr(ctx, st);
+        }
+        return;
+    }
+
     if (var->kind == AST_FUNPTR) {
         /* Function-pointer slot: 8 bytes, treated as a pointer. */
         IrValue *tmp = irTmp(IR_TYPE_PTR, 8);
@@ -1744,6 +1914,58 @@ void irLowerAst(IrCtx *ctx, Ast *ast) {
             break;
         }
 
+        case AST_TRY: {
+            irLowerTry(ctx, ast);
+            break;
+        }
+
+        case AST_THROW: {
+            irLowerThrow(ctx, ast);
+            break;
+        }
+
+        case AST_ASM_STMT: {
+            /* Inline `asm { ... }` block. Carry both the text (for
+             * legacy/pure asm) and the optional fragment list (when
+             * `&var` references need late binding to stack offsets).
+             *
+             * For each UNIQUE `&y` reference we emit ONE "spectator"
+             * IR_LEA. The result is unused, but mem2reg's
+             * other_uses-counter sees the LEA and skips promoting
+             * `y`, so `y` retains a real stack slot the asm can
+             * read/write through. One LEA per local suffices; we
+             * dedupe by lvar_id to avoid emitting N copies of the
+             * same dead `add xN, x29, #imm` when the asm uses `&y`
+             * multiple times. */
+            if (ast->asm_fragments) {
+                Set *seen = setNew(8, &set_uint_type);
+                listForEach(ast->asm_fragments) {
+                    AsmFragment *f = (AsmFragment *)it->value;
+                    if (f->kind != ASM_FRAG_LVAR_REF) continue;
+                    if (!f->lvar) continue;
+                    if (setHas(seen, (void *)(u64)f->lvar->lvar_id))
+                        continue;
+                    setAdd(seen, (void *)(u64)f->lvar->lvar_id);
+                    IrValue *slot = irFnGetVar(ctx->cur_func,
+                                                f->lvar->lvar_id);
+                    if (!slot) continue;
+                    IrValue *addr = irTmp(IR_TYPE_PTR, 8);
+                    irBlockAddInstr(ctx,
+                        irInstrNew(IR_LEA, addr, slot, NULL));
+                }
+                setRelease(seen);
+            }
+            IrValue *txt = irValueNew(IR_TYPE_ARRAY, IR_VAL_CONST_STR);
+            txt->as.str.str = ast->asm_stmt;
+            txt->as.str.label = NULL;
+            txt->as.str.str_real_len = ast->asm_stmt
+                ? (int)ast->asm_stmt->len : 0;
+            IrInstr *instr = irInstrNew(IR_ASM, NULL, txt, NULL);
+            instr->extra.asm_fragments = ast->asm_fragments;
+            irBlockAddInstr(ctx, instr);
+            break;
+        }
+
         case AST_UNOP: {
             /* Bare ++/-- as a statement: lower as expression and discard. */
             irExpr(ctx, ast);
@@ -1821,29 +2043,6 @@ void irLowerAst(IrCtx *ctx, Ast *ast) {
     }
 }
 
-void irSimplifyFunction(IrFunction *fn) {
-    Set *work_queue_ids = setNew(16, &set_uint_type);
-    List *queue = listNew();
-    Set *blocks_to_delete = setNew(16, &set_int_type);
-
-    (void)work_queue_ids;
-    (void)queue;
-    (void)blocks_to_delete;
-
-    /* Any blocks that don't have a successor lets assume they jump to 
-     * the return */
-    listForEach(fn->blocks) {
-        IrBlock *block = it->value;
-        if (irBlockIsStartOrEnd(fn, block)) continue;
-        Map *cur_successors = irBlockGetSuccessors(fn, block);
-        if (cur_successors && cur_successors->size == 0) {
-            /* @TODO
-             * Think I need a new file to contain making ir instructions/ values*/
-            irJump(fn, block, fn->exit_block);
-        }
-    }
-}
-
 IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
     IrFunction *func = irFunctionNew(ast_func->fname);
     IrBlock *entry = irBlockNew();
@@ -1893,6 +2092,18 @@ IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
         IrValue *ir_tmp_var = irTmp(irConvertType(ast_param->type),
                                     ast_param->type->size);
         ir_tmp_var->kind = IR_VAL_PARAM;
+        /* Propagate TempleOS-style `<Type> reg <REG> name` pinning
+         * from the AST onto the IrValue so the per-arch codegen can
+         * route reads / writes to the named register and skip the
+         * usual stack-slot spill. Only AST_LVAR params can carry the
+         * modifier; AST_FUNPTR / AST_DEFAULT_PARAM go through their
+         * normal slot paths. */
+        if (ast_param->kind == AST_LVAR &&
+            ast_param->pinned_kind == LVAR_REG &&
+            ast_param->pinned_reg)
+        {
+            ir_tmp_var->pinned_reg = ast_param->pinned_reg;
+        }
         irFnAddVar(func, key, ir_tmp_var);
         vecPush(func->params, ir_tmp_var);
         irAddStackSpace(ctx, ast_param->type->size);
@@ -1939,7 +2150,13 @@ IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
         IrInstr *ir_ret = irInstrNew(IR_RET, ir_load_dst, NULL, NULL);
         irBlockAddInstr(ctx, ir_ret);
     } else {
-        IrInstr *ir_ret = irInstrNew(IR_RET, NULL, NULL, NULL);
+        IrInstr *ir_ret = NULL;
+        if (func->name->len == 4 &&
+                !strncasecmp(func->name->data, str_lit("Main"))) {
+            ir_ret = irInstrNew(IR_RET, irConstInt(IR_TYPE_I32, 0), NULL, NULL);
+        } else {
+            ir_ret = irInstrNew(IR_RET, NULL, NULL, NULL);
+        }
         irBlockAddInstr(ctx, ir_ret);
     }
     exit_block->sealed = 1;
@@ -2071,6 +2288,7 @@ static void irRemoveRedundantBlocks(IrFunction *fn) {
 }
 
 void irBasicFunctionOptimisations(IrFunction *fn) {
+    irMem2Reg(fn);
     irRemoveAllNops(fn);
     irRemoveRedundantBlocks(fn);
     irEvalConstantExpressions(fn);
@@ -2084,20 +2302,22 @@ void irBasicFunctionOptimisations(IrFunction *fn) {
 static u32 ircg_func_seq = 0;
 
 void irFunctionPrepForCodeGen(IrCgCtx *ctx, IrFunction *fn, Ast *ast_fn) {
-    irCgClassifyPhis(fn);
-    irCgAnnotate(fn);
-    irPeephole(ctx->cc, fn);
-
-    int locals_params_space = irCgComputeAstLayout(ast_fn, fn);
+    ctx->fn = fn;
+    ctx->cur_block = NULL;
+    ctx->next_block = NULL;
 
     fn->uuid = ircg_func_seq++;
     fn->ra.func = fn;
     fn->ra.id_to_loff = mapNew(32, &map_uint_to_uint_type);
     fn->ra.extra_stack = 0;
 
-    ctx->fn = fn;
-    ctx->cur_block = NULL;
-    ctx->next_block = NULL;
+    irCgClassifyPhis(fn);
+    irCgAnnotate(fn);
+    irPeephole(ctx->cc, fn);
+
+    int locals_params_space = irCgComputeAstLayout(ast_fn, fn);
+
+
     /* Index every peephole-deferred LEA by its dst tmp id, so the
      * IR_CALL emit can re-create the leaq into the arg register. */
     ctx->lea_inline_map = mapNew(8, &map_uint_to_uint_type);
@@ -2116,6 +2336,14 @@ void irFunctionPrepForCodeGen(IrCgCtx *ctx, IrFunction *fn, Ast *ast_fn) {
                    (void *)I);
         }
     }
+
+    /* Bind AST-driven loffs (params + alloca'd locals) before walking the
+     * IR for tmp slots. An alloca's dst tmp shares its var.id with the AST
+     * local it represents; binding first lets `irCgAllocTmp`'s mapHasInt
+     * guard skip those tmps cleanly (and avoids double-counting their
+     * space in `extra_stack`). */
+    irCgBindAstLoffs(&fn->ra, ast_fn);
+
     /* Allocate slots for IR tmps just below the params area. */
     irCgAllocAllTmps(&fn->ra, locals_params_space);
 
@@ -2127,8 +2355,6 @@ void irFunctionPrepForCodeGen(IrCgCtx *ctx, IrFunction *fn, Ast *ast_fn) {
 
     /* Stack required for the function */
     fn->stack_space = (u16)total_stack;
-
-    irCgBindAstLoffs(&fn->ra, ast_fn);
 }
 
 void irCgFinishFunction(IrCgCtx *ctx) {
@@ -2150,10 +2376,6 @@ void irDump(Cctrl *cc) {
             IrFunction *fn = irLowerFunction(ctx, ast);
             irPrintFunction(fn);
  
-            irMem2Reg(fn);
-            printf("===== After mem2reg ===== \n");
-            irPrintFunction(fn);
-
             irBasicFunctionOptimisations(fn);
             printf("===== After basic optimisations ===== \n");
             irPrintFunction(fn);

--- a/src/ir.h
+++ b/src/ir.h
@@ -10,5 +10,9 @@ void irMemoryStats(void);
 void irDump(Cctrl *cc);
 IrValue *irExpr(IrCtx *ctx, Ast *ast);
 IrCtx *irLowerProgram(Cctrl *cc);
+IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func);
+
+void irBasicFunctionOptimisations(IrFunction *fn);
+void irFunctionPrepForCodeGen(IrCgCtx *ctx, IrFunction *fn, Ast *ast_fn);
 
 #endif

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -132,6 +132,11 @@ static LexerType lexer_types[] = {
     {"goto",     KW_GOTO},
     {"default",  KW_DEFAULT},
     {"return",   KW_RETURN},
+    {"try",      KW_TRY},
+    {"catch",    KW_CATCH},
+    {"throw",    KW_THROW},
+    {"reg",      KW_REG},
+    {"noreg",    KW_NOREG},
 
     {"if",      KW_IF},
     {"else",    KW_ELSE},
@@ -470,6 +475,11 @@ AoStr *lexemeToAoStr(Lexeme *tok) {
                 case KW_CAST:        aoStrCatPrintf(str,"cast"); break;
                 case KW_SIZEOF:      aoStrCatPrintf(str,"sizeof");  break;
                 case KW_RETURN:      aoStrCatPrintf(str,"return");  break;
+                case KW_TRY:         aoStrCatPrintf(str,"try");     break;
+                case KW_CATCH:       aoStrCatPrintf(str,"catch");   break;
+                case KW_THROW:       aoStrCatPrintf(str,"throw");   break;
+                case KW_REG:         aoStrCatPrintf(str,"reg");     break;
+                case KW_NOREG:       aoStrCatPrintf(str,"noreg");   break;
                 case KW_SWITCH:      aoStrCatPrintf(str,"switch");  break;
                 case KW_CASE:        aoStrCatPrintf(str,"case");    break;
                 case KW_BREAK:       aoStrCatPrintf(str,"break");   break;
@@ -1224,6 +1234,13 @@ int lex(Lexer *l, Lexeme *le) {
                 return 1;
 
             case '#': {
+                /* Inside an asm{} block `#` could be the immediate
+                 * marker preprocessor directives can't appear there anyway,
+                 * so surface it as a plain punctuation token. */
+                if (l->flags & CCF_ASM_BLOCK) {
+                    lexemeAssignOp(le,start,1,ch,l->lineno);
+                    return 1;
+                }
                 type = lexPreProcDirective(l);
                 le->tk_type = TK_KEYWORD;
                 le->i64 = type->kind;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -121,6 +121,17 @@
 #define KW_PP_DEFINED   77
 #define KW_PP_UNDEF     78
 #define KW_PP_ERROR     79
+/* TempleOS-style structured exceptions. */
+#define KW_TRY          80
+#define KW_CATCH        81
+#define KW_THROW        82
+/* TempleOS-style register pinning for locals/params:
+ *   I64 reg R15 i = 5;    // bound to R15 for the function
+ *   I64 noreg j = 4;      // explicit stack local
+ * `noreg` is also required for any local in a function that contains
+ * an asm { } block (no implicit "compiler picks"). */
+#define KW_REG          83
+#define KW_NOREG        84
 
 /* Compiler Flags*/
 #define CCF_MULTI_CHAR_OP     (1<<0)

--- a/src/main.c
+++ b/src/main.c
@@ -27,7 +27,7 @@ int is_terminal;
 
 #if defined(__aarch64__) || defined(__arm64ec__)
     #define _CC "clang"
-    #define CC_TARGET "--target=x86_64-apple-darwin"
+    #define CC_TARGET ""
 #else
     #define _CC "gcc"
     #define CC_TARGET ""
@@ -40,7 +40,7 @@ int is_terminal;
     #define INSTALL_PREFIX "/usr/local"
 #endif
 
-#define CLIBS_BASE "-ltos -lpthread -lc -lm"
+#define CLIBS_BASE "-lpthread -lc -lm"
 
 #ifdef HCC_LINK_SQLITE3
 #define CLIBS CLIBS_BASE" -lsqlite3"
@@ -69,33 +69,49 @@ typedef struct hccLib {
     char *install_cmd;
 } hccLib;
 
+static int hccCanLinkLibTos(Cctrl *cc) {
+    (void)cc;
+    return 1;
+}
+
 int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) { 
     AoStr *dylib_cmd = aoStrNew();
     AoStr *stylib_cmd = aoStrNew();
     AoStr *installcmd = aoStrNew();
     
+    /* All literal INSTALL_PREFIX paths are now plumbed through
+     * args->install_dir so a `-lib tos --install-dir=X` build lands
+     * in X/lib/ rather than always /usr/local/. The default install
+     * dir is still INSTALL_PREFIX (set in cliArgsInit), so existing
+     * invocations behave unchanged - this is purely an opt-in
+     * redirection for cross-builds and sandboxed installs. */
 #if IS_BSD
     snprintf(lib->stylib_name,LIB_BUFSIZ,"%s.a",name);
     snprintf(lib->dylib_name,LIB_BUFSIZ,"%s.dylib",name);
     snprintf(lib->dylib_version_name,LIB_BUFSIZ,"%s.0.0.1.dylib",name);
 
-    aoStrCatFmt(dylib_cmd,
-            "cp -pPR ./%s "INSTALL_PREFIX"/lib/lib%s && "
-            "cc -dynamiclib -Wl,-install_name,"INSTALL_PREFIX"/lib/%s -o %s "CLIBS" -o %s %s",
+    aoStrCatPrintf(dylib_cmd,
+            "cp -pPR ./%s %s/lib/lib%s && "
+            "%s -dynamiclib -Wl,-install_name,%s/lib/%s -o %s "CLIBS" -o %s %s",
             lib->stylib_name,
+            args->install_dir,
             lib->stylib_name,
+            cc->CC,
+            args->install_dir,
             name,
             lib->dylib_version_name,
             lib->dylib_name,
             args->obj_outfile);
 
     aoStrCatPrintf(installcmd,
-            "cp -pPR ./%s "INSTALL_PREFIX"/lib/lib%s && "
-            "ln -sf "INSTALL_PREFIX"/lib/%s "INSTALL_PREFIX"/lib/%s",
+            "cp -pPR ./%s %s/lib/lib%s && "
+            "ln -sf %s/lib/%s %s/lib/%s",
             lib->dylib_name,
+            args->install_dir,
             lib->dylib_version_name,
-
+            args->install_dir,
             lib->dylib_version_name,
+            args->install_dir,
             lib->dylib_name);
 
 #elif IS_LINUX
@@ -103,15 +119,16 @@ int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
     snprintf(lib->dylib_name,LIB_BUFSIZ,"%s.so",name);
     snprintf(lib->dylib_version_name,LIB_BUFSIZ,"%s.so.0.0.1",name);
     aoStrCatPrintf(dylib_cmd,
-            "%s -fPIC -shared -Wl,-soname,"INSTALL_PREFIX"/lib/%s -o %s "CLIBS,
+            "%s -fPIC -shared -Wl,-soname,%s/lib/%s -o %s "CLIBS,
             cc->CC,
+            args->install_dir,
             name,
             lib->dylib_name,
             lib->dylib_name);
     aoStrCatPrintf(dylib_cmd," -o %s %s",lib->dylib_name,args->obj_outfile);
     aoStrCatPrintf(installcmd,
-            "cp -pPR ./%s "INSTALL_PREFIX"/lib/lib%s",
-            lib->stylib_name,lib->stylib_name);
+            "cp -pPR ./%s %s/lib/lib%s",
+            lib->stylib_name,args->install_dir,lib->stylib_name);
 #else
 #error "System not supported"
 #endif
@@ -207,10 +224,17 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         if (args->run) {
             AoStr *run_cmd = aoStrNew();
             writeAsmToTmp(asmbuf);
-            aoStrCatPrintf(run_cmd,"%s -L"INSTALL_PREFIX"/lib %s "CLIBS" && ./a.out && rm ./a.out",
-                    cc->CC,
-                    ASM_TMP_FILE);
-            /* Don't use 'safeSystem' else anything other than a '0' exit 
+            if (hccCanLinkLibTos(cc)) {
+                aoStrCatPrintf(run_cmd,"%s -L%s/lib %s "CLIBS" -ltos && ./a.out && rm ./a.out",
+                        cc->CC,
+                        args->install_dir,
+                        ASM_TMP_FILE);
+            } else {
+                aoStrCatPrintf(run_cmd,"%s %s "CLIBS" && ./a.out && rm ./a.out",
+                        cc->CC,
+                        ASM_TMP_FILE);
+            }
+            /* Don't use 'safeSystem' else anything other than a '0' exit
              * code will cause a panic which is incorrect... This is a bit of a
              * hack as run, in an ideal world, would not be calling out to `_CC` */
             int ret = system(run_cmd->data);
@@ -226,13 +250,34 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         }
 
         if (args->clibs) {
-            aoStrCatPrintf(cmd, "%s -L"INSTALL_PREFIX"/lib %s %s "CLIBS" -o %s", 
-                    cc->CC,
-                    ASM_TMP_FILE,args->clibs,args->output_filename);
+            if (hccCanLinkLibTos(cc)) {
+                aoStrCatPrintf(cmd, "%s -L%s/lib %s %s "CLIBS" -ltos -o %s",
+                        cc->CC,
+                        args->install_dir,
+                        ASM_TMP_FILE,args->clibs,args->output_filename);
+            } else {
+                aoStrCatPrintf(cmd, "%s %s %s "CLIBS" -o %s",
+                        cc->CC,
+                        ASM_TMP_FILE,
+                        args->clibs,
+                        args->output_filename);
+            }
+
         } else {
-            aoStrCatPrintf(cmd, "%s -L"INSTALL_PREFIX"/lib %s "CLIBS" -o %s", 
-                    cc->CC,
-                    ASM_TMP_FILE, args->output_filename);
+            if (hccCanLinkLibTos(cc)) {
+                aoStrCatPrintf(cmd,
+                               "%s -L%s/lib %s "CLIBS" -ltos -o %s",
+                               cc->CC,
+                               args->install_dir,
+                               ASM_TMP_FILE,
+                               args->output_filename);
+            } else {
+                aoStrCatPrintf(cmd,
+                               "%s %s "CLIBS" -o %s",
+                               cc->CC,
+                               ASM_TMP_FILE,
+                               args->output_filename);
+            }
         }
         safeSystem(cmd->data);
     }
@@ -253,14 +298,27 @@ void assemble(Cctrl *cc, CliArgs *args) {
             .capacity = len,
         };
         writeAsmToTmp(&asm_buf);
-        aoStrCatPrintf(run_cmd,"%s -L"INSTALL_PREFIX"/lib %s "CLIBS" && ./a.out && rm ./a.out",
-                cc->CC,
-                ASM_TMP_FILE);
+        if (hccCanLinkLibTos(cc)) {
+            aoStrCatPrintf(run_cmd,
+                           "%s -L"INSTALL_PREFIX"/lib %s "CLIBS" -ltos && ./a.out && rm ./a.out",
+                            cc->CC,
+                            ASM_TMP_FILE);
+        } else {
+            aoStrCatPrintf(run_cmd,
+                           "%s %s "CLIBS" && ./a.out && rm ./a.out",
+                           cc->CC,
+                           ASM_TMP_FILE);
+        }
         free(buffer);
         int ret = system(run_cmd->data);
         (void)ret;
     } else {
-        aoStrCatPrintf(run_cmd, "%s %s -L"INSTALL_PREFIX"/lib "CLIBS, cc->CC, args->infile);
+        if (hccCanLinkLibTos(cc)) {
+            aoStrCatPrintf(run_cmd, "%s %s -L"INSTALL_PREFIX"/lib "CLIBS" -ltos",
+                    cc->CC, args->infile);
+        } else {
+            aoStrCatPrintf(run_cmd, "%s %s "CLIBS, cc->CC, args->infile);
+        }
         safeSystem(run_cmd->data);
     }
     aoStrRelease(run_cmd);
@@ -316,27 +374,20 @@ int main(int argc, char **argv) {
     cc = cctrlNew();
 
     /* Plumb in support for cross compiling... currently does nothing :)*/
-    cc->target = (char *)cliTargetToString(args.target);
+    const char *str_target = cliTargetToString(args.target);
     switch (args.target) {
-        case TARGET_DEFAULT:
-            cc->CC = mprintf("%s %s", _CC, CC_TARGET);
-            break;
-        case TARGET_AARCH64_APPLE_DARWIN:
-            cc->CC = mprintf("clang --target=%s", cc->target);
-            break;
+        /* Let clang do the heavy lifting */
         case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
-            cc->CC = mprintf("clang --target=%s", cc->target);
-            break;
         case TARGET_X86_64_APPLE_DARWIN:
-            cc->CC = mprintf("clang --target=%s", cc->target);
-            break;
         case TARGET_X86_64_UNKNOWN_LINUX_GNU:
-            cc->CC = mprintf("clang --target=%s", cc->target);
+        case TARGET_AARCH64_APPLE_DARWIN:
+            cc->CC = mprintf("clang --target=%s", str_target);
+            cc->target = args.target;
             break;
     }
 
-    if (args.target != TARGET_DEFAULT) {
-        loggerPanic("This is an unfinished feature :(, please do not set the `-`-target=` cli flag\n");
+    if (args.use_legacy_x86) {
+        cc->flags |= CCTRL_USE_LEGACY_X86;
     }
 
     if (args.assemble) {
@@ -344,11 +395,9 @@ int main(int argc, char **argv) {
         goto success;
     }
 
-
     if (!listEmpty(args.defines_list)) {
         cctrlSetCommandLineDefines(cc,args.defines_list);
     }
-
 
     if (args.print_tokens) {
         compileToTokens(cc,&args,lexer_flags);

--- a/src/parser.c
+++ b/src/parser.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 
 #include "aostr.h"
+#include "asm.h"
 #include "ast.h"
 #include "cctrl.h"
 #include "lexer.h"
@@ -25,8 +26,37 @@ Ast *parseVariableInitialiser(Cctrl *cc, Ast *var, s64 terminator_flags);
 Ast *parseDecl(Cctrl *cc);
 Ast *parseDeclOrStatement(Cctrl *cc);
 Ast *parseCompoundStatement(Cctrl *cc);
+Ast *parseTryStatement(Cctrl *cc);
+Ast *parseThrowStatement(Cctrl *cc);
 AstType *parseClassDef(Cctrl *cc, int is_intrinsic);
 AstType *parseUnionDef(Cctrl *cc);
+
+/* TempleOS-style `reg <REG>` / `noreg` modifier after a decl type.
+ * If the next token is `reg`, consume it plus the following register-
+ * name identifier; if `noreg`, consume it. Otherwise leave the token
+ * stream alone and report LVAR_AUTO. Shared with parseParams in
+ * prslib.c for the parameter-list case. */
+void parseRegModifier(Cctrl *cc, int *kind_out, AoStr **reg_out) {
+    *kind_out = LVAR_AUTO;
+    *reg_out = NULL;
+    Lexeme *peek = cctrlTokenPeek(cc);
+    if (!peek || peek->tk_type != TK_KEYWORD) return;
+    if (peek->i64 == KW_REG) {
+        cctrlTokenGet(cc);  /* consume `reg` */
+        Lexeme *reg_tok = cctrlTokenGet(cc);
+        if (!reg_tok || reg_tok->tk_type != TK_IDENT) {
+            cctrlRaiseException(cc,
+                "`reg` must be followed by a register name, got `%.*s`",
+                reg_tok ? reg_tok->len : 0,
+                reg_tok ? reg_tok->start : "");
+        }
+        *kind_out = LVAR_REG;
+        *reg_out = aoStrDupRaw(reg_tok->start, reg_tok->len);
+    } else if (peek->i64 == KW_NOREG) {
+        cctrlTokenGet(cc);  /* consume `noreg` */
+        *kind_out = LVAR_NOREG;
+    }
+}
 
 static AoStr *getRangeLoopIdx(void) {
     static int id = 0;
@@ -720,7 +750,7 @@ Ast *parseOptExpr(Cctrl *cc) {
 Ast *parseDesugarArrayLoop(Cctrl *cc, Ast *iteratee, Ast *static_array) {
     /* Create a temporay variable as the counter */
     AoStr *range_tmp_var = getRangeLoopIdx();
-    Ast *counter_var = astLVar(ast_int_type,range_tmp_var->data,
+    Ast *counter_var = astLVar(astTypeCopy(ast_int_type),range_tmp_var->data,
                                range_tmp_var->len);
 
     Ast *counter = astDecl(counter_var,astI64Type(0));
@@ -750,7 +780,7 @@ Ast *parseDesugarArrayLoop(Cctrl *cc, Ast *iteratee, Ast *static_array) {
                 AST_UN_OP_DEREF,
                 parseCreateBinaryOp(cc,AST_BIN_OP_ADD, static_array, counter_var))
             );
-    Ast *step = astUnaryOperator(ast_int_type,AST_UN_OP_PRE_INC,counter_var);
+    Ast *step = astUnaryOperator(astTypeCopy(ast_int_type),AST_UN_OP_PRE_INC,counter_var);
 
     cctrlTokenExpect(cc,')');
     Ast *forbody = parseStatement(cc);
@@ -788,7 +818,7 @@ Ast *parseCreateForRange(Cctrl *cc, Ast *iteratee,
                          Ast *size_ref, Ast *entries_ref)
 {
     AoStr *range_tmp_var = getRangeLoopIdx();
-    Ast *counter_var = astLVar(ast_int_type,range_tmp_var->data,
+    Ast *counter_var = astLVar(astTypeCopy(ast_int_type),range_tmp_var->data,
                                range_tmp_var->len);
     Ast *counter = astDecl(counter_var,astI64Type(0));
 
@@ -806,7 +836,7 @@ Ast *parseCreateForRange(Cctrl *cc, Ast *iteratee,
                 AST_UN_OP_DEREF,
                 parseCreateBinaryOp(cc,AST_BIN_OP_ADD, entries_ref, counter_var))
             );
-    Ast *step = astUnaryOperator(ast_int_type,AST_UN_OP_PRE_INC,counter_var);
+    Ast *step = astUnaryOperator(astTypeCopy(ast_int_type),AST_UN_OP_PRE_INC,counter_var);
     cctrlTokenExpect(cc,')');
     Ast *forbody = parseStatement(cc);
     listPrepend(forbody->stms,iterator);
@@ -1101,6 +1131,40 @@ Ast *parseReturnStatement(Cctrl *cc) {
     return astReturn(retval,cc->tmp_rettype);
 }
 
+/* TempleOS-strict `try { ... } catch <stmt>`. The catch handler is a
+ * single statement (often `{...}` so braces still work via the
+ * normal block-statement path) and does NOT bind the thrown value -
+ * read it via the global `Fs->except_ch`. */
+Ast *parseTryStatement(Cctrl *cc) {
+    cctrlTokenExpect(cc,'{');
+    Ast *try_body = parseCompoundStatement(cc);
+    Lexeme *tok = cctrlTokenPeek(cc);
+    if (!tok) {
+        cctrlRaiseException(cc,
+            "Expected `catch` after `try { ... }`, got end of input");
+    }
+    if (tok->tk_type != TK_KEYWORD || tok->i64 != KW_CATCH) {
+        cctrlRaiseException(cc,
+            "Expected `catch` after `try { ... }`, got `%.*s`",
+            tok->len, tok->start);
+    }
+    cctrlTokenGet(cc);  /* consume `catch` */
+    Ast *catch_body = parseStatement(cc);
+    return astTry(try_body, catch_body);
+}
+
+/* `throw(expr);` - the expression yields a u64 (commonly a multi-
+ * char constant like `'BlkDev'` which the lexer packs into 8 bytes
+ * via TK_CHAR_CONST). The runtime stashes it into `Fs->except_ch`
+ * and longjmps to the nearest enclosing catch. */
+Ast *parseThrowStatement(Cctrl *cc) {
+    cctrlTokenExpect(cc,'(');
+    Ast *value = parseExpr(cc,16);
+    cctrlTokenExpect(cc,')');
+    cctrlTokenExpect(cc,';');
+    return astThrow(value);
+}
+
 void parseRaiseCaseException(Cctrl *cc, Ast *case_expr) {
     cctrlRewindUntilStrMatch(cc,str_lit("case"),NULL);
     char *exp = astLValueToString(case_expr,0);
@@ -1304,11 +1368,28 @@ Ast *parseStatement(Cctrl *cc) {
             case KW_WHILE:    return parseWhileStatement(cc);
             case KW_DO:       return parseDoWhileStatement(cc);
             case KW_RETURN:   return parseReturnStatement(cc);
+            case KW_TRY:      return parseTryStatement(cc);
+            case KW_THROW:    return parseThrowStatement(cc);
             case KW_SWITCH:   return parseSwitchStatement(cc);
             case KW_CASE:     return parseCaseLabel(cc,tok);
             case KW_DEFAULT:  return parseDefaultStatement(cc);
             case KW_BREAK:    return parseBreakStatement(cc);
             case KW_CONTINUE: return parseContinueStatement(cc);
+            case KW_ASM: {
+                /* Inline `asm { ... }` block as a statement. TempleOS
+                 * lets functions splice raw asm directly into the body
+                 * (no `Name::` wrapper inside). prsAsm's `parse_one`
+                 * mode is the one-block-no-label path we need. */
+                Lexeme *p = cctrlTokenPeek(cc);
+                if (!tokenPunctIs(p,'{')) {
+                    cctrlRaiseException(cc,
+                        "Expected `{` after `asm`, got `%.*s`",
+                        p ? p->len : 0, p ? p->start : "");
+                }
+                Ast *asm_block = prsAsm(cc, 1);
+                listAppend(cc->asm_blocks, asm_block);
+                return asm_block;
+            }
             case KW_STATIC: {
                 env = cc->localenv;
                 cc->localenv = NULL;
@@ -1466,6 +1547,9 @@ void parseCompoundStatementInternal(Cctrl *cc, Ast *body) {
             base_type = parseBaseDeclSpec(cc);
             while (1) {
                 next_type = parsePointerType(cc,base_type);
+                int pinned_kind;
+                AoStr *pinned_reg;
+                parseRegModifier(cc, &pinned_kind, &pinned_reg);
                 peek = cctrlTokenPeek(cc);
 
                 if (!tokenPunctIs(peek,'(')) {
@@ -1479,6 +1563,8 @@ void parseCompoundStatementInternal(Cctrl *cc, Ast *body) {
                     }
                     type = parseArrayDimensions(cc,next_type);
                     var = astLVar(type,varname->start,varname->len);
+                    var->pinned_kind = pinned_kind;
+                    var->pinned_reg = pinned_reg;
                     if (!mapAddOrErr(cc->localenv,var->lname->data,var)) {
                         cctrlRewindUntilStrMatch(cc,var->lname->data,var->lname->len,NULL);
                         cctrlRaiseException(cc,"variable `%s` already declared",
@@ -1548,10 +1634,96 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
         Lexeme *peek = cctrlTokenPeek(cc);
         if (tokenPunctIs(peek,'{')) {
             AoStr *fname_duped = aoStrDupRaw(fname,len);
-            AoStr *asm_fname = astNormaliseFunctionName(fname_duped->data);
+            /* Target-aware: adds the leading `_` on Mach-O so it
+             * matches what `bl _Add` callers expect. The compile-time
+             * `astNormaliseFunctionName` only handles IS_BSD and would
+             * leave the symbol as `Add` (no underscore) on this build. */
+            AoStr *asm_fname = aoStrPrintf("%s",
+                asmNormaliseFunctionName(cc, fname_duped));
             AoStr *prev_asm_name = cc->tmp_asm_fname;
             cc->tmp_asm_fname = asm_fname;
             Ast *asm_block = prsAsm(cc,1);
+
+            /* If any param is `reg <REG>` pinned, emit shuffle moves
+             * up-front so the user's asm can refer to the pinned
+             * register names. The asm-only-function path bypasses
+             * the normal ParamSpills path that runs for IR-codegen'd
+             * functions; we splice the shuffle directly into the asm
+             * text. Note: this path doesn't save/restore callee-
+             * saved regs - the user's `RET` exits before any epilogue
+             * can run, so if the body clobbers callee-saved registers
+             * the caller is on the hook for that ABI rule.
+             * TempleOS-flavoured asm functions are explicit by design.
+             *
+             * Target-aware: AArch64 uses x0..x7 (8 int arg regs, mov
+             * "dst, src" order); x86_64 SysV uses rdi/rsi/rdx/rcx/r8/r9
+             * (6 int arg regs, AT&T "movq %src, %dst" order). */
+            const char **kIntArgRegs;
+            int max_int_args;
+            int is_x86;
+            switch (cc->target) {
+                case TARGET_AARCH64_APPLE_DARWIN:
+                case TARGET_AARCH64_UNKNOWN_LINUX_GNU: {
+                    static const char *aarch64_regs[] = {
+                        "x0", "x1", "x2", "x3",
+                        "x4", "x5", "x6", "x7"
+                    };
+                    kIntArgRegs = aarch64_regs;
+                    max_int_args = 8;
+                    is_x86 = 0;
+                    break;
+                }
+                case TARGET_X86_64_APPLE_DARWIN:
+                case TARGET_X86_64_UNKNOWN_LINUX_GNU: {
+                    static const char *x86_regs[] = {
+                        "rdi", "rsi", "rdx", "rcx", "r8", "r9"
+                    };
+                    kIntArgRegs = x86_regs;
+                    max_int_args = 6;
+                    is_x86 = 1;
+                    break;
+                }
+                default:
+                    kIntArgRegs = NULL;
+                    max_int_args = 0;
+                    is_x86 = 0;
+            }
+
+            if (params && kIntArgRegs) {
+                AoStr *shuffle = aoStrNew();
+                int int_idx = 0;
+                for (u64 pi = 0; pi < params->size; ++pi) {
+                    Ast *p = vecGet(Ast *, params, pi);
+                    if (!p || p->kind != AST_LVAR) continue;
+                    if (p->pinned_kind != LVAR_REG || !p->pinned_reg) {
+                        if (p->type && p->type->kind != AST_TYPE_FLOAT) {
+                            int_idx++;
+                        }
+                        continue;
+                    }
+                    if (int_idx < max_int_args) {
+                        if (is_x86) {
+                            /* AT&T: "movq %src, %dst" => pinned = arg. */
+                            aoStrCatFmt(shuffle,
+                                    "\tmovq    %%%s, %%%S\n",
+                                    kIntArgRegs[int_idx], p->pinned_reg);
+                        } else {
+                            /* AArch64: "mov dst, src" => pinned = arg. */
+                            aoStrCatFmt(shuffle,
+                                    "\tmov     %S, %s\n",
+                                    p->pinned_reg, kIntArgRegs[int_idx]);
+                        }
+                    }
+                    int_idx++;
+                }
+                if (shuffle->len > 0) {
+                    aoStrCatAoStr(shuffle, asm_block->asm_stmt);
+                    aoStrRelease(asm_block->asm_stmt);
+                    asm_block->asm_stmt = shuffle;
+                } else {
+                    aoStrRelease(shuffle);
+                }
+            }
 
             Ast *asm_function = astAsmFunctionDef(asm_fname, asm_block->asm_stmt);
 
@@ -1642,8 +1814,49 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
     }
     parseCompoundStatementInternal(cc, func_body);
     fn_type->rettype = cc->tmp_rettype;
+    /* `astFunction` shallow-copies the type into the AST node, so
+     * `func->type` is a different AstType than the local `fn_type`.
+     * Updating only `fn_type->rettype` would leave the version stored
+     * in `cc->global_env` (and hence visible to every later caller)
+     * still pointing at the original `auto` type. Mirror the
+     * resolution onto `func->type` too. */
+    if (func->type) {
+        func->type->rettype = cc->tmp_rettype;
+    }
     if (is_inline) {
         listAppend(func->locals,func->inline_ret);
+    }
+
+    /* TempleOS rule: a function containing an `asm { }` block may
+     * declare register-pinned locals via `<Type> reg <REG> name`;
+     * the asm block can then reference the register directly. Plain
+     * locals (default stack) still work as ordinary stack slots that
+     * the asm can reach through `&var[RBP]`. We reject `noreg` here
+     * because the explicit-stack form duplicates the default and just
+     * adds complexity. */
+    int has_asm = 0;
+    if (func_body->stms) {
+        listForEach(func_body->stms) {
+            Ast *stmt = (Ast *)it->value;
+            if (stmt && stmt->kind == AST_ASM_STMT) {
+                has_asm = 1;
+                break;
+            }
+        }
+    }
+    if (has_asm && func->locals) {
+        listForEach(func->locals) {
+            Ast *l = (Ast *)it->value;
+            if (!l || l->kind != AST_LVAR) continue;
+            if (l->pinned_kind == LVAR_NOREG) {
+                cctrlRaiseException(cc,
+                    "`noreg` is not supported in `asm { }` functions; "
+                    "drop the modifier (locals default to a stack slot) "
+                    "or use `reg <REG>` to pin to a register",
+                    l->lname ? l->lname->data : "?",
+                    len, fname);
+            }
+        }
     }
 
     cc->localenv = NULL;
@@ -1804,6 +2017,7 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
                 case KW_EXTERN: {
                     tok = cctrlTokenGet(cc);
                     if (tok->tk_type == TK_STR && !strncmp(tok->start,"c",1)) {
+                        /* extern "c" func(...) - C-ABI function decl. */
                         type = parseDeclSpec(cc);
                         name = cctrlTokenGet(cc);
                         cctrlTokenExpect(cc,'(');
@@ -1811,8 +2025,26 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
                                 name->start,name->len);
                         return extern_func;
                     }
-                    cctrlRaiseException(cc,"Can only call external c functions for the "
-                            "time being");
+                    /* TempleOS-style `extern Type name;` data forward
+                     * declaration. The next token was the start of the
+                     * type; put it back so parseFullType sees it. */
+                    cctrlTokenRewind(cc);
+                    type = parseFullType(cc);
+                    name = cctrlTokenGet(cc);
+                    if (name->tk_type != TK_IDENT) {
+                        cctrlRaiseException(cc,
+                            "`extern <Type>` must be followed by an "
+                            "identifier, got `%.*s`",
+                            name->len, name->start);
+                    }
+                    type = parseArrayDimensions(cc, type);
+                    cctrlTokenExpect(cc,';');
+                    Ast *gvar = astGVar(type, name->start, name->len, 0);
+                    Ast *decl = astDecl(gvar, NULL);
+                    decl->flags |= AST_FLAG_EXTERN;
+                    gvar->flags |= AST_FLAG_EXTERN;
+                    mapAdd(cc->global_env, gvar->gname->data, gvar);
+                    return decl;
                 }
                 case KW_INLINE: {
                     peek = cctrlTokenPeek(cc);

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -2,6 +2,7 @@
 #include <stdio.h>
 
 #include "aostr.h"
+#include "asm.h"
 #include "ast.h"
 #include "cctrl.h"
 #include "lexer.h"
@@ -155,8 +156,22 @@ void prsAsmPunct(Cctrl *cc, Lexeme *tok, AoStr *buf) {
 }
 
 /* Custom assembly to AT&T */
+/* Format used to placeholder-mark a TempleOS `&y` operand inside an
+ * AT&T asm body. The numeric suffix is the index into `all_lvars`
+ * built up during parsing; after each instruction is emitted into
+ * `curblock`, we walk the freshly-written text looking for these
+ * markers and split into AsmFragment::TEXT / ASM_FRAG_LVAR_REF runs
+ * so codegen can resolve to `<loff>(%rbp)` once layout has assigned
+ * loffs.
+ *
+ * `__hcclv_` is intentionally lowercase + underscore-prefixed so it
+ * survives `aoStrToLowerCase(op1)` and won't collide with any token
+ * a user might reasonably write in inline asm. */
+#define ATT_LVAR_PLACEHOLDER_PREFIX "__hcclv_"
+#define ATT_LVAR_PLACEHOLDER_SUFFIX "__"
+
 Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
-    AoStr *op1 = NULL, *op2 = NULL, *op3 = NULL, *asm_code = NULL, *curblock = NULL, *stdfunc = NULL, *curfunc = NULL;
+    AoStr *op1 = NULL, *op2 = NULL, *op3 = NULL, *asm_code = NULL, *curblock = NULL, *curfunc = NULL;
     List *asm_functions;
     Ast *asm_function, *asm_block;
     Lexeme *tok, *next;
@@ -166,6 +181,17 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
     asm_code = aoStrNew();
     curblock = parse_one ? asm_code : NULL;
     memset(asm_code->data,'\0',asm_code->capacity-1);
+
+    /* TempleOS `&var` references: every `&IDENT` whose IDENT is a
+     * local in the surrounding HolyC function records the lvar here
+     * and stamps a `__hcclv_<idx>__` placeholder into the operand
+     * buffer. After each instruction flush we scan curblock for the
+     * placeholders and emit fragments. fragments stays empty for
+     * asm blocks that don't use the feature - we attach it only when
+     * non-empty, so the plain-text path is unchanged for those. */
+    Vec *all_lvars = astVecNew();
+    List *fragments = listNew();
+    s64 last_flush_pos = 0;
 
     cctrlTokenExpect(cc, '{');
     tok = cctrlAsmTokenGet(cc);
@@ -267,7 +293,14 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
 
             case TK_PUNCT: {
                 switch (tok->i64) {
-                    case '\n':
+                    case '\n': {
+                        /* curblock is NULL until the first `Name::`
+                         * label is seen; with CCF_ACCEPT_NEWLINES on,
+                         * the `\n` between `asm {` and that label
+                         * arrives here first. count is 0 in that
+                         * case, so the inner switch is a no-op and
+                         * there's nothing to scan for placeholders. */
+                        s64 inst_start = curblock ? (s64)curblock->len : 0;
                         switch (count) {
                             case 0:
                                 break;
@@ -281,9 +314,13 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
                                  * operation */
                                 aoStrToLowerCase(op1);
                                 if (setHasLen(cc->libc_functions, op1->data,op1->len)) {
-                                    stdfunc = astNormaliseFunctionName(op1->data);
-                                    aoStrCatFmt(curblock,"%S\n",stdfunc);
-                                    aoStrRelease(stdfunc);
+                                    /* Target-aware mangling: Darwin
+                                     * needs a leading `_`, Linux
+                                     * doesn't. asmNormaliseFunctionName
+                                     * reads cc->target rather than
+                                     * the build host's IS_BSD. */
+                                    char *stdfn = asmNormaliseFunctionName(cc, op1);
+                                    aoStrCatPrintf(curblock,"%s\n",stdfn);
                                 } else {
                                     aoStrCatFmt(curblock,"%S\n",op1);
                                 }
@@ -296,11 +333,10 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
                                 int is_call = op1->len == 4 && !strncasecmp(op1->data,str_lit("call"));
 
                                 if (is_call) {
-                                    if (mapGetLen(cc->global_env, op2->data, op2->len) != NULL || 
+                                    if (mapGetLen(cc->global_env, op2->data, op2->len) != NULL ||
                                         setHasLen(cc->libc_functions, op2->data, op2->len)) {
-                                        stdfunc = astNormaliseFunctionName(op2->data);
-                                        aoStrCatFmt(curblock,"%S\n",stdfunc);
-                                        aoStrRelease(stdfunc);
+                                        char *stdfn = asmNormaliseFunctionName(cc, op2);
+                                        aoStrCatPrintf(curblock,"%s\n",stdfn);
                                     } else {
                                         if (op2->data[0] == '%') {
                                             aoStrPutChar(curblock,'*');
@@ -337,12 +373,115 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
                                         " x86 transpilation: %d %s %s",
                                         count,op1->data,op2->data);
                         }
+                        /* If the freshly-emitted instruction has any
+                         * `__hcclv_<idx>__` placeholders, split the
+                         * range [inst_start, curblock->len) into
+                         * TEXT / LVAR_REF fragments. The text before
+                         * the placeholder becomes a TEXT fragment;
+                         * the placeholder itself maps to LVAR_REF
+                         * via all_lvars[idx]; trailing text after
+                         * the last placeholder is left for the next
+                         * iteration (or the final flush). */
+                        if (curblock && all_lvars->size > 0) {
+                            s64 cursor = inst_start;
+                            s64 end = (s64)curblock->len;
+                            size_t pfx_len =
+                                strlen(ATT_LVAR_PLACEHOLDER_PREFIX);
+                            while (cursor < end) {
+                                /* Bounded search for the prefix. */
+                                char *hay = curblock->data + cursor;
+                                size_t hay_len = (size_t)(end - cursor);
+                                char *hit = NULL;
+                                for (size_t i = 0;
+                                     i + pfx_len <= hay_len; ++i)
+                                {
+                                    if (memcmp(hay + i,
+                                            ATT_LVAR_PLACEHOLDER_PREFIX,
+                                            pfx_len) == 0)
+                                    {
+                                        hit = hay + i;
+                                        break;
+                                    }
+                                }
+                                if (!hit) break;
+                                s64 ph_pos = (s64)(hit - curblock->data);
+                                char *idx_str = hit + pfx_len;
+                                char *idx_end = NULL;
+                                long long idx_val = strtoll(idx_str,
+                                                            &idx_end,
+                                                            10);
+                                if (!idx_end ||
+                                    idx_end[0] != '_' ||
+                                    idx_end[1] != '_')
+                                {
+                                    /* Malformed - skip past the
+                                     * prefix and keep scanning so a
+                                     * spurious "__hcclv_" in user
+                                     * text doesn't break the loop. */
+                                    cursor = ph_pos + (s64)pfx_len;
+                                    continue;
+                                }
+                                s64 ph_end =
+                                    (s64)((idx_end + 2) - curblock->data);
+
+                                if (ph_pos > last_flush_pos) {
+                                    AoStr *chunk = aoStrDupRaw(
+                                        curblock->data + last_flush_pos,
+                                        ph_pos - last_flush_pos);
+                                    listAppend(fragments,
+                                            asmFragmentText(chunk));
+                                }
+                                Ast *lvar = vecGet(Ast *, all_lvars,
+                                                   (u64)idx_val);
+                                listAppend(fragments,
+                                        asmFragmentLvarRef(lvar));
+                                last_flush_pos = ph_end;
+                                cursor = ph_end;
+                            }
+                        }
                         isbol = 1;
                         count = 0;
                         break;
+                    }
 
                     case ',':
                         break;
+                    case '&': {
+                        /* TempleOS `&y` -> address of a HolyC local.
+                         * Record the lvar, stamp a placeholder into
+                         * the current operand slot; codegen resolves
+                         * it once layout has assigned the loff. Only
+                         * active for inline asm with a surrounding
+                         * localenv - falls through to the default
+                         * punct path otherwise so `&FUNCNAME`-style
+                         * usages keep working. */
+                        int handled = 0;
+                        if (parse_one && cc->localenv) {
+                            Lexeme *p = cctrlTokenPeek(cc);
+                            if (p && p->tk_type == TK_IDENT) {
+                                Ast *local = mapGetLen(cc->localenv,
+                                        p->start, p->len);
+                                if (local && local->kind == AST_LVAR) {
+                                    cctrlAsmTokenGet(cc);
+                                    s64 idx = (s64)all_lvars->size;
+                                    vecPush(all_lvars, local);
+                                    AoStr *ph = aoStrPrintf(
+                                        ATT_LVAR_PLACEHOLDER_PREFIX
+                                        "%lld"
+                                        ATT_LVAR_PLACEHOLDER_SUFFIX,
+                                        (long long)idx);
+                                    if (count == 0)      op1 = ph;
+                                    else if (count == 1) op2 = ph;
+                                    else                 op3 = ph;
+                                    count++;
+                                    handled = 1;
+                                }
+                            }
+                        }
+                        if (handled) break;
+                        /* fallthrough to default punct emission */
+                    }
+                    /* fallthrough */
                     default:
                         switch (count) {
                             case 0:
@@ -379,11 +518,28 @@ Ast *prsAsmToATT(Cctrl *cc, int parse_one) {
         }
     }
     asm_block = astAsmBlock(asm_code,asm_functions);
+    /* Attach fragments only if any `&var` placeholder was actually
+     * seen. Otherwise the plain-text path runs unchanged. */
+    if (parse_one && fragments && fragments->next != fragments) {
+        if ((s64)curblock->len > last_flush_pos) {
+            AoStr *chunk = aoStrDupRaw(
+                curblock->data + last_flush_pos,
+                curblock->len - last_flush_pos);
+            listAppend(fragments, asmFragmentText(chunk));
+        }
+        asm_block->asm_fragments = fragments;
+    }
     return asm_block;
 }
 
 /* The next token is expected to be '{' so the parser has just seen 'asm' */
 Ast *prsAsm(Cctrl *cc, int parse_one) {
+    if (cc->target == TARGET_AARCH64_APPLE_DARWIN ||
+        cc->target == TARGET_AARCH64_UNKNOWN_LINUX_GNU)
+    {
+        loggerPanic("Unsupported target, cannot use asm blocks %s\n",
+                cliTargetToString(cc->target));
+    }
     return prsAsmToATT(cc, parse_one);
 }
 

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -155,6 +155,9 @@ Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
         }
 
         type = parseDeclSpec(cc);
+        int pinned_kind;
+        AoStr *pinned_reg;
+        parseRegModifier(cc, &pinned_kind, &pinned_reg);
         pname = cctrlTokenGet(cc);
 
         if (tokenPunctIs(pname, ')') && arg_count == 0) {
@@ -197,6 +200,11 @@ Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
                     type = astMakePointerType(type->ptr);
                 }
                 var = astLVar(type,"_unknown",7);
+                /* Anonymous param can still carry a `reg <REG>` modifier
+                 * (TempleOS-style `Foo(I64 reg X19, I64 reg X20)` -
+                 * names omitted, register IS the identity). */
+                var->pinned_kind = pinned_kind;
+                var->pinned_reg = pinned_reg;
                 if (cc->tmp_locals) {
                     listAppend(cc->tmp_locals, var);
                 }
@@ -217,6 +225,8 @@ Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
             type = astMakePointerType(type->ptr);
         }
         var = astLVar(type,pname->start,pname->len);
+        var->pinned_kind = pinned_kind;
+        var->pinned_reg = pinned_reg;
 
         tok = cctrlTokenGet(cc);
         if (tokenPunctIs(tok, '=')) {

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -22,4 +22,8 @@ Ast *findFunctionDecl(Cctrl *cc, char *fname, int len);
 Ast *parseCreateBinaryOp(Cctrl *cc, AstBinOp operation, Ast *left, Ast *right);
 Ast *parseSizeof(Cctrl *cc);
 
+/* Defined in parser.c; used here by parseParams to honour `reg`/`noreg`
+ * on parameter declarations as well as locals. */
+void parseRegModifier(Cctrl *cc, int *kind_out, AoStr **reg_out);
+
 #endif

--- a/src/tests/39_try_catch.HC
+++ b/src/tests/39_try_catch.HC
@@ -1,0 +1,113 @@
+#include "testhelper.HC"
+
+/* TempleOS-style try/catch/throw. Each test sets `marker` to a
+ * known value and reads `Fs->except_ch` inside the catch handler
+ * to verify the thrown u64 made it through unchanged. */
+
+U0 ThrowFromHelper()
+{
+  throw('Help');
+}
+
+U0 ChainedThrowA()
+{
+  throw('Aaa');
+}
+
+U0 ChainedThrowB()
+{
+  ChainedThrowA();
+}
+
+I32 Main()
+{
+  "Test - try/catch/throw: ";
+  I64 correct = 0, tests = 8;
+
+  /* 1. Basic: throw fires, catch runs, value preserved. */
+  I64 marker_1 = 0;
+  try {
+    throw('Foo');
+    marker_1 = 0xBAD;          /* unreachable */
+  } catch
+    marker_1 = Fs->except_ch;
+  if (marker_1 == 'Foo') correct++;
+
+  /* 2. No-throw: try body completes, catch skipped. */
+  I64 marker_2 = 0;
+  try {
+    marker_2 = 1;
+  } catch
+    marker_2 = 0xBAD;
+  if (marker_2 == 1) correct++;
+
+  /* 3. Throw escapes a function boundary. */
+  I64 marker_3 = 0;
+  try {
+    ThrowFromHelper();
+    marker_3 = 0xBAD;
+  } catch
+    marker_3 = Fs->except_ch;
+  if (marker_3 == 'Help') correct++;
+
+  /* 4. Throw escapes two function levels. */
+  I64 marker_4 = 0;
+  try {
+    ChainedThrowB();
+    marker_4 = 0xBAD;
+  } catch
+    marker_4 = Fs->except_ch;
+  if (marker_4 == 'Aaa') correct++;
+
+  /* 5. Nested try: inner catch handles, outer doesn't fire. */
+  I64 marker_5_inner = 0, marker_5_outer = 0;
+  try {
+    try {
+      throw('In');
+    } catch
+      marker_5_inner = Fs->except_ch;
+    /* This statement should run after the inner catch completes. */
+    marker_5_inner += 1;
+  } catch
+    marker_5_outer = 0xBAD;
+  if (marker_5_inner == 'In' + 1 && marker_5_outer == 0) correct++;
+
+  /* 6. Rethrow from inside catch: inner handler throws a new
+   *    value, outer catches it. */
+  I64 marker_6_outer = 0;
+  try {
+    try {
+      throw('Inn');
+    } catch
+      throw('Out');
+  } catch
+    marker_6_outer = Fs->except_ch;
+  if (marker_6_outer == 'Out') correct++;
+
+  /* 7. Sequential try blocks: second try is independent of first. */
+  I64 marker_7a = 0, marker_7b = 0;
+  try {
+    throw('AAA');
+  } catch
+    marker_7a = Fs->except_ch;
+  try {
+    throw('BBB');
+  } catch
+    marker_7b = Fs->except_ch;
+  if (marker_7a == 'AAA' && marker_7b == 'BBB') correct++;
+
+  /* 8. Catch handler with a compound statement body, runs more
+   *    than a single expression. */
+  I64 marker_8 = 0;
+  try {
+    throw('Big');
+  } catch {
+    marker_8 = Fs->except_ch;
+    marker_8 = marker_8 ^ 0xFF;
+  }
+  if (marker_8 == ('Big' ^ 0xFF)) correct++;
+
+  PrintResult(correct, tests);
+  "=====\n";
+  return 0;
+}

--- a/src/tests/run.HC
+++ b/src/tests/run.HC
@@ -56,10 +56,42 @@ Bool ShouldExclude(U8 *filename, I64 namelen)
   return FALSE;
 }
 
+/* Cross-compilation hook.
+ *
+ * When the runner is invoked with `--target=<triple>` as argv[1] we
+ * pass `--target=<triple> --install-dir=../../build/<triple>` to hcc
+ * for each test, then invoke the resulting binary via the
+ * appropriate emulator (`arch -x86_64 ./a.out` on Apple Silicon for
+ * x86_64 targets). Empty target string = host arch, default flow.
+ */
+/* HolyC doesn't seem to honour `U8 *name = "lit";` initialisers
+ * for globals - the pointer comes through NULL and any later
+ * dereference segfaults. Declare uninitialised and assign in Main
+ * before any reader runs. */
+U8 *g_target;
+
+I64 IsX86_64Target(U8 *target)
+{
+  return StrNCmp(target, "x86_64-", 7) == 0;
+}
+
 U0 RunTest(U8 *filename)
 {
-  U8 buffer[256];
-  auto len = snprintf(buffer,sizeof(buffer),"hcc %s",filename);
+  U8 buffer[512];
+  I64 len;
+
+  /* Use the local build (../../hcc relative to src/tests/) so we
+   * always test what's actually been compiled, not whatever older
+   * hcc happens to be on PATH (e.g. an installed /usr/local/bin/hcc
+   * from a prior version - this trap cost us a session of confused
+   * cross-test triage). */
+  if (g_target[0] == '\0') {
+    len = snprintf(buffer, sizeof(buffer), "../../hcc %s", filename);
+  } else {
+    len = snprintf(buffer, sizeof(buffer),
+                   "../../hcc --target=%s --install-dir=../../build/%s %s",
+                   g_target, g_target, filename);
+  }
   buffer[len] = '\0';
   auto res = System(buffer);
 
@@ -79,8 +111,24 @@ I32 Main(I32 argc, U8 **argv)
   auto vec = PtrVecNew();
   Dirent *ent;
 
-  if (argc != 1) {
-    RunTest(argv[1]);
+  /* Argv contract:
+   *   ./run                     -> host arch, all tests
+   *   ./run --target=<triple>   -> cross to <triple>, all tests
+   *   ./run <file.HC>           -> host arch, single file
+   *   ./run --target=<triple> <file.HC>
+   *                             -> cross to <triple>, single file
+   *
+   * Disambiguation is by the --target= prefix so the existing
+   * single-file workflow keeps working unchanged. */
+  g_target = "";
+  I64 arg_idx = 1;
+  if (argc >= 2 && StrNCmp(argv[1], "--target=", 9) == 0) {
+    g_target = argv[1] + 9;
+    arg_idx = 2;
+  }
+
+  if (argc > arg_idx) {
+    RunTest(argv[arg_idx]);
     Exit(0);
   }
 

--- a/src/x86.c
+++ b/src/x86.c
@@ -7,6 +7,8 @@
 
 #include "aostr.h"
 #include "ast.h"
+#include "asm.h"
+#include "cli.h"
 #include "cctrl.h"
 #include "config.h"
 #include "containers.h"
@@ -37,7 +39,6 @@ static char *FLOAT_REGISTERS[] = {"xmm0", "xmm1", "xmm2", "xmm3",
     "xmm12", "xmm13", "xmm14", "xmm15"};
 
 static int stack_pointer = 0;
-static int has_initialisers = 0;
 
 #define REG_RAX "rax"
 #define REG_RDX "rdx"
@@ -51,50 +52,6 @@ void asmExpression(Cctrl *cc, AoStr *buf, Ast *ast);
 
 #define asmGetGlabel(gvar) \
     gvar->is_static ? gvar->glabel : gvar->gname
-
-uint64_t ieee754(double _f64) {
-    if (_f64 == 0.0) return 0;  // Handle zero value explicitly
-
-    // Calculate exponent and adjust fraction
-    double base2_exp = floorl(log2l(fabs(_f64)));
-    double exponet2_removed = ldexpl(_f64, -base2_exp - 1);
-
-    // Initialize fraction and calculate it bit by bit
-    uint64_t fraction = 0;
-    double digit = 0.5;  // Start with 1/2
-    for (s64 i = 0; i != 53; i++) {
-        if (exponet2_removed >= digit) {
-            exponet2_removed -= digit;
-            fraction |= 1ULL << (52 - i);
-        }
-        digit *= 0.5;  // Move to the next digit (1/4, 1/8, ...)
-    }
-
-    // Calculate exponent representation
-    uint64_t exponent = ((1 << 10) - 1) + base2_exp;
-
-    // Handle sign bit
-    uint64_t sign = (_f64 < 0.0) ? 1 : 0;
-
-    // Assemble the IEEE 754 representation
-    return (sign << 63) |
-           ((exponent & 0x7FF) << 52) |
-           (fraction & ~(1ULL << 52));
-}
-
-/* This is a hacky, but seemingly functional way of me being able
- * to run this on Macos and Linux */
-char *asmNormaliseFunctionName(char *fname) {
-    AoStr *newfn = astNormaliseFunctionName(fname);
-    if (!strncasecmp(fname, "Main", 4)) {
-        if (has_initialisers) {
-            aoStrCatPrintf(newfn,"Fn");
-        } else {
-            aoStrToLowerCase(newfn);
-        }
-    }
-    return aoStrMove(newfn);
-}
 
 void asmRemovePreviousTab(AoStr *buf) {
     if (buf->data[buf->len-1] == '\t') {
@@ -246,8 +203,8 @@ void asmPop(AoStr *buf, char *reg) {
     }
 }
 
-void asmCall(AoStr *buf, char *fname) {
-    char *_fname = asmNormaliseFunctionName(fname);
+void asmCall(Cctrl *cc, AoStr *buf, AoStr *fname) {
+    char *_fname = asmNormaliseFunctionName(cc, fname);
     aoStrCatPrintf(buf,"call   %s\n\t", _fname);
 }
 
@@ -842,7 +799,7 @@ void asmAddr(Cctrl *cc, AoStr *buf, Ast *ast) {
         }
 
         case AST_FUNC: {
-            char *normalised = asmNormaliseFunctionName(ast->operand->fname->data);
+            char *normalised = asmNormaliseFunctionName(cc, ast->operand->fname);
             aoStrCatPrintf(buf, "leaq   %s(%%rip), %%rax\n\t", normalised);
             break;
         }
@@ -1134,7 +1091,7 @@ void asmBinOpFunctionAssign(Cctrl *cc, AoStr *buf, Ast *fnptr, Ast *fn) {
     (void)cc;
     switch (fn->kind) {
         case AST_FUNC: {
-            char *normalised = asmNormaliseFunctionName(fn->fname->data);
+            char *normalised = asmNormaliseFunctionName(cc, fn->fname);
             aoStrCatPrintf(buf,
                     "leaq   %s(%%rip), %%rax\n\t"
                     "movq    %%rax, %d(%%rbp)\n\t",
@@ -1758,7 +1715,7 @@ void asmPrepFuncCallArgs(Cctrl *cc, AoStr *buf, Ast *funcall) {
     if (funcall->kind == AST_FUNPTR_CALL) {
         aoStrCatPrintf(buf, "call    *%%r11\n\t");
     } else {
-        asmCall(buf, funcall->fname->data);
+        asmCall(cc, buf, funcall->fname);
     }
 
     if (float_cnt) {
@@ -2249,6 +2206,11 @@ void asmGlobalVar(Set *seen_globals, AoStr *buf, Ast* ast) {
     AoStr *varname = declvar->gname;
     AoStr *label = asmGetGlabel(declvar);
 
+    /* `extern Type name;` is a forward declaration; the storage lives
+     * in another TU. Register-only - no emission. */
+    if (ast->flags & AST_FLAG_EXTERN) return;
+    if (declvar->flags & AST_FLAG_EXTERN) return;
+
     if (setHasLen(seen_globals,varname->data,varname->len)) {
         return;
     }
@@ -2371,7 +2333,7 @@ int asmFunctionInit(Cctrl *cc, AoStr *buf, Ast *func) {
     int ireg = 0, freg = 0, locals = 0, arg = 2;
     Ast *ast_tmp = NULL;
 
-    char *fname = asmNormaliseFunctionName(func->fname->data);
+    char *fname = asmNormaliseFunctionName(cc, func->fname);
 
     aoStrCatPrintf(buf, ".text"            "\n\t"
                         ".global %s\n"
@@ -2523,14 +2485,20 @@ void asmPasteAsmBlocks(AoStr *buf, Cctrl *cc) {
 
 void asmInitaliser(Cctrl *cc, AoStr *buf) {
     if (listEmpty(cc->initalisers)) return;
-    char *fname = NULL;
+    char *fname = "main";
+    switch (cc->target) {
+        case TARGET_AARCH64_APPLE_DARWIN:
+        case TARGET_X86_64_APPLE_DARWIN:
+            fname = "_main";
+            break;
+        case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
+        case TARGET_X86_64_UNKNOWN_LINUX_GNU:
+            break;
+        default:
+            break;
+    }
     int locals = 0, stack_space;
 
-#if IS_BSD
-    fname = "_main";
-#else
-    fname = "main";
-#endif
     aoStrCatPrintf(buf, ".text"            "\n\t"
                         ".global %s\n"
                         "%s:\n\t"
@@ -2572,18 +2540,17 @@ void asmInitaliser(Cctrl *cc, AoStr *buf) {
 }
 
 /* Create assembly */
-AoStr *asmGenerate(Cctrl *cc) {
+AoStr *x86AsmGenerate(Cctrl *cc) {
     Ast *ast;
     Set *seen_globals = setNew(32, &set_cstring_type);
     AoStr *asmbuf = aoStrAlloc(1<<10);
  
     if (!listEmpty(cc->initalisers)) {
-        has_initialisers = 1;
+        cc->flags |= CCTRL_ASM_HAS_INITIALISERS;
     }
 
     asmPasteAsmBlocks(asmbuf,cc);
     asmDataSection(cc,asmbuf);
-
 
     listForEach(cc->ast_list) {
         ast = (Ast *)it->value;
@@ -2613,6 +2580,6 @@ AoStr *asmGenerate(Cctrl *cc) {
     aoStrCatFmt(asmbuf, ".section    .note.GNU-stack,\"\",@progbits\n\t");
 #endif
     aoStrCatFmt(asmbuf,".ident      \"hcc: %s %s %s\"\n",
-            OS_STR, ARCH_STR, cctrlGetVersion());
+                                     OS_STR, cliTargetToString(cc->target), cctrlGetVersion());
     return asmbuf;
 }

--- a/src/x86.h
+++ b/src/x86.h
@@ -1,9 +1,10 @@
-#ifndef ASM_H
-#define ASM_H
+#ifndef X86_H__
+#define X86_H__
 
 #include "aostr.h"
 #include "cctrl.h"
 #include "list.h"
 
-AoStr *asmGenerate(Cctrl *cc);
-#endif // !ASM_H
+AoStr *x86AsmGenerate(Cctrl *cc);
+
+#endif

--- a/src/x86_64.c
+++ b/src/x86_64.c
@@ -1,0 +1,1649 @@
+/* x86_64 IR-based codegen.
+ *
+ * SysV AMD64 ABI for both Linux and macOS (only the symbol naming and
+ * PIC syntax differ - same call convention, same register set, same
+ * struct passing). 
+ *
+ * Default codegen for X86_64 targets. The legacy AST-based x86.c
+ * remains compiled in as a debugging fallback - pass --use-legacy-x86
+ * (sets CCTRL_USE_LEGACY_X86) to route through it instead. Thes AST backend
+ * will eventually be deleted. */
+#include <assert.h>
+#include <math.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "aostr.h"
+#include "ast.h"
+#include "asm.h"
+#include "cctrl.h"
+#include "cli.h"
+#include "config.h"
+#include "containers.h"
+#include "ir.h"
+#include "ir-debug.h"
+#include "ir-regalloc.h"
+#include "list.h"
+#include "util.h"
+#include "version.h"
+#include "x86_64.h"
+
+/* SysV first-six integer arg registers, ordered as arg 0..5. */
+static const char *kIntRegs64[] = {
+    "rdi", "rsi", "rdx", "rcx", "r8", "r9"
+};
+/* SysV first-eight FP arg registers. */
+static const char *kXmmRegs[] = {
+    "xmm0", "xmm1", "xmm2", "xmm3",
+    "xmm4", "xmm5", "xmm6", "xmm7"
+};
+
+/* Map a 64-bit GP register name to its narrower variant. The
+ * heterogeneous register-naming scheme on x86 makes this a lookup
+ * table rather than a name-mangling rule. */
+static void x86_64RegForWidth(const char *reg64,
+                              int size,
+                              char *out,
+                              u64 out_sz)
+{
+    static const struct { const char *q, *d, *w, *b; } tab[] = {
+        {"rax", "eax",  "ax",  "al"},
+        {"rbx", "ebx",  "bx",  "bl"},
+        {"rcx", "ecx",  "cx",  "cl"},
+        {"rdx", "edx",  "dx",  "dl"},
+        {"rsi", "esi",  "si",  "sil"},
+        {"rdi", "edi",  "di",  "dil"},
+        {"rbp", "ebp",  "bp",  "bpl"},
+        {"rsp", "esp",  "sp",  "spl"},
+        {"r8",  "r8d",  "r8w", "r8b"},
+        {"r9",  "r9d",  "r9w", "r9b"},
+        {"r10", "r10d", "r10w","r10b"},
+        {"r11", "r11d", "r11w","r11b"},
+        {"r12", "r12d", "r12w","r12b"},
+        {"r13", "r13d", "r13w","r13b"},
+        {"r14", "r14d", "r14w","r14b"},
+        {"r15", "r15d", "r15w","r15b"},
+    };
+    for (u64 i = 0; i < sizeof(tab)/sizeof(tab[0]); ++i) {
+        if (!strcmp(reg64, tab[i].q)) {
+            const char *pick;
+            if (size == 1)      pick = tab[i].b;
+            else if (size == 2) pick = tab[i].w;
+            else if (size == 4) pick = tab[i].d;
+            else                pick = tab[i].q;
+            snprintf(out, out_sz, "%s", pick);
+            return;
+        }
+    }
+    loggerPanic("ir-cg-x86_64: unrecognised 64-bit reg name '%s'\n", reg64);
+}
+
+/* leaq <sym>(%rip), %<reg64>. Caller has already normalised the
+ * symbol name */
+static void x86_64GlobalAddr(IrCgCtx *ctx, const char *sym, const char *reg) {
+    (void)ctx;
+    aoStrCatFmt(ctx->buf, "leaq    %s(%%rip), %%%s\n\t", sym, reg);
+}
+
+/* leaq <loff>(%rbp), %<reg64>. AT&T allows signed displacements
+ * natively. */
+static void x86_64FrameAddr(AoStr *buf, int loff, const char *reg) {
+    aoStrCatFmt(buf, "leaq    %i(%%rbp), %%%s\n\t", loff, reg);
+}
+
+static void x86_64Lea(IrCgCtx *ctx, IrInstr *lea, const char *reg) {
+    if (lea->r1 && lea->r1->kind == IR_VAL_GLOBAL) {
+        const char *name = lea->r1->as.global.name->data;
+        if (lea->r1->flags & IR_VAL_FLAG_FUNC) {
+            name = asmNormaliseFunctionName(ctx->cc,
+                    lea->r1->as.global.name);
+        }
+        x86_64GlobalAddr(ctx, name, reg);
+    } else {
+        int loff = irCgGetLoff(&ctx->fn->ra, lea->r1);
+        x86_64FrameAddr(ctx->buf, loff, reg);
+    }
+}
+
+/* If the source value was marked for LEA-inlining by peephole, emit
+ * the address arithmetic directly into <reg> instead of going through
+ * the slot. Returns 1 if it handled the value, 0 if the caller should
+ * fall back to a regular load. */
+static int x86_64InlinedLea(IrCgCtx *ctx, IrValue *val, const char *reg) {
+    if (!ctx->lea_inline_map) return 0;
+    if (!val || val->kind != IR_VAL_TMP) return 0;
+    if (!mapHasInt(ctx->lea_inline_map, val->as.var.id)) return 0;
+    IrInstr *lea = mapGetInt(ctx->lea_inline_map, val->as.var.id);
+    if (!lea || lea->op != IR_LEA || !lea->r1) return 0;
+    x86_64Lea(ctx, lea, reg);
+    return 1;
+}
+
+/* Width-aware load from <loff>(%rbp) into <reg64>.
+ *
+ * Width policy mirrors aarch64's choice: sub-word loads (1/2) zero-
+ * extend to the full register, 4-byte loads sign-extend.
+ * 8-byte loads are plain movq. */
+static void x86_64Load(AoStr *buf, const char *reg, u32 size, int loff) {
+    switch (size) {
+        case 1:  aoStrCatFmt(buf, "movzbq  %i(%%rbp), %%%s\n\t", loff, reg); break;
+        case 2:  aoStrCatFmt(buf, "movzwq  %i(%%rbp), %%%s\n\t", loff, reg); break;
+        case 4:  aoStrCatFmt(buf, "movslq  %i(%%rbp), %%%s\n\t", loff, reg); break;
+        default: aoStrCatFmt(buf, "movq    %i(%%rbp), %%%s\n\t", loff, reg); break;
+    }
+}
+
+/* Width-aware load from (<addr_reg>) into <reg64>. Same extension
+ * policy as x86_64Load. */
+static void x86_64DerefLoadWidth(AoStr *buf,
+                                 u32 size,
+                                 const char *reg,
+                                 const char *addr_reg)
+{
+    switch (size) {
+        case 1:  aoStrCatFmt(buf, "movzbq  (%%%s), %%%s\n\t", addr_reg, reg); break;
+        case 2:  aoStrCatFmt(buf, "movzwq  (%%%s), %%%s\n\t", addr_reg, reg); break;
+        case 4:  aoStrCatFmt(buf, "movslq  (%%%s), %%%s\n\t", addr_reg, reg); break;
+        default: aoStrCatFmt(buf, "movq    (%%%s), %%%s\n\t", addr_reg, reg); break;
+    }
+}
+
+/* Width-aware store of <reg64>'s low bits into <loff>(%rbp). The
+ * narrower stores use the matching subregister name (e.g. al for
+ * size=1) so the assembler picks the right encoding. */
+static void x86_64FrameStoreWidth(AoStr *buf,
+                                  int loff,
+                                  u32 size,
+                                  const char *reg)
+{
+    char nreg[8];
+    switch (size) {
+        case 1:
+            x86_64RegForWidth(reg, 1, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movb    %%%s, %i(%%rbp)\n\t", nreg, loff);
+            break;
+        case 2:
+            x86_64RegForWidth(reg, 2, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movw    %%%s, %i(%%rbp)\n\t", nreg, loff);
+            break;
+        case 4:
+            x86_64RegForWidth(reg, 4, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movl    %%%s, %i(%%rbp)\n\t", nreg, loff);
+            break;
+        default:
+            aoStrCatFmt(buf, "movq    %%%s, %i(%%rbp)\n\t", reg, loff);
+            break;
+    }
+}
+
+/* Width-aware store of <reg64> into (<addr_reg>). */
+static void x86_64DerefStoreWidth(AoStr *buf,
+                                  u32 size,
+                                  const char *reg,
+                                  const char *addr_reg)
+{
+    char nreg[8];
+    switch (size) {
+        case 1:
+            x86_64RegForWidth(reg, 1, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movb    %%%s, (%%%s)\n\t", nreg, addr_reg);
+            break;
+        case 2:
+            x86_64RegForWidth(reg, 2, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movw    %%%s, (%%%s)\n\t", nreg, addr_reg);
+            break;
+        case 4:
+            x86_64RegForWidth(reg, 4, nreg, sizeof(nreg));
+            aoStrCatFmt(buf, "movl    %%%s, (%%%s)\n\t", nreg, addr_reg);
+            break;
+        default:
+            aoStrCatFmt(buf, "movq    %%%s, (%%%s)\n\t", reg, addr_reg);
+            break;
+    }
+}
+
+/* Load any IrValue into the given 64-bit GP register.
+ *
+ * - Constants are materialised directly (no slot needed).
+ * - String labels become PC-relative LEA.
+ * - Tmp/local/param values either come from their pinned register
+ *   (when one is set) or are loaded from their frame slot via
+ *   x86_64Load. */
+static void x86_64LoadToReg(IrCgCtx *ctx, IrValue *val, const char *reg) {
+    switch (val->kind) {
+        case IR_VAL_CONST_INT:
+            /* GNU as picks the 7-byte mov-imm32 or 10-byte movabs
+             * encoding depending on whether the value fits in a
+             * 32-bit sign-extended immediate. */
+            aoStrCatFmt(ctx->buf, "movq    $%I, %%%s\n\t",
+                        val->as._i64, reg);
+            break;
+
+        case IR_VAL_CONST_FLOAT:
+            /* Load the raw bit pattern as an integer. Rarely needed
+             * - float constants normally go through LoadToFpr but might
+             *   be needed in some cases for bitcasts. */
+            aoStrCatPrintf(ctx->buf, "movabsq $0x%lX, %%%s\n\t",
+                           (u64)ieee754(val->as._f64), reg);
+            break;
+
+        case IR_VAL_CONST_STR:
+            x86_64GlobalAddr(ctx, val->as.str.label->data, reg);
+            break;
+
+        case IR_VAL_TMP:
+        case IR_VAL_LOCAL:
+        case IR_VAL_PARAM: {
+            if (val->pinned_reg) {
+                aoStrCatFmt(ctx->buf, "movq    %%%s, %%%s\n\t",
+                            val->pinned_reg->data, reg);
+                break;
+            }
+            u32 size = irValueByteSize(val);
+            int loff = irCgGetLoff(&ctx->fn->ra, val);
+            x86_64Load(ctx->buf, reg, size, loff);
+            break;
+        }
+        default:
+            loggerPanic("ir-cg-x86_64: cannot load value of kind %s\n",
+                        irValueKindToString(val->kind));
+    }
+}
+
+/* Store a 64-bit GP register into the destination IrValue's home.
+ * If the destination is pinned, this is just a register-to-register
+ * move; otherwise it's a width-aware store to the frame slot. */
+static void x86_64StoreReg(IrCgCtx *ctx, IrValue *dst, const char *reg) {
+    if (dst->pinned_reg) {
+        aoStrCatFmt(ctx->buf, "movq    %%%s, %%%s\n\t",
+                    reg, dst->pinned_reg->data);
+        return;
+    }
+    u32 size = irValueByteSize(dst);
+    int loff = irCgGetLoff(&ctx->fn->ra, dst);
+    x86_64FrameStoreWidth(ctx->buf, loff, size, reg);
+}
+
+/* Spill the result register into instr->dst's slot unless this
+ * instruction is fusing into the next (its consumer will read
+ * directly from the live register). */
+static void x86_64SpillDst(IrCgCtx *ctx, IrInstr *instr, const char *reg) {
+    if (instr->flags & IRCG_FUSE_TO_NEXT)
+        return;
+    x86_64StoreReg(ctx, instr->dst, reg);
+}
+
+/* Materialise a 64-bit double constant in .data and load it via
+ * PC-relative addressing. x86_64 movsd <sym>(%rip), %xmm is a
+ * single instruction. */
+static void x86_64EmitFloatLiteralData(IrCgCtx *ctx,
+                                       const char *xmm_reg,
+                                       f64 f)
+{
+    static int float_seq = 0;
+    char label[64];
+    snprintf(label, sizeof(label), ".LIRF%d", float_seq++);
+
+    aoStrRemovePreviousChar(ctx->buf, '\t');
+    aoStrCatPrintf(ctx->buf,
+                   ".data\n\t.p2align 3\n%s:\n\t"
+                   ".quad 0x%lX # %.9f\n"
+                   ".text\n\t"
+                   "movsd   %s(%%rip), %%%s\n\t",
+                   label, (unsigned long)ieee754(f), f,
+                   label, xmm_reg);
+}
+
+/* Load any IrValue into an xmm register. Integer constants are
+ * coerced to double (matching aarch64). Float-typed locals/params
+ * come from their frame slot via movsd. Pinned-reg variants are not
+ * yet supported on the FP side. */
+static void x86_64LoadToFpr(IrCgCtx *ctx, IrValue *val, const char *xmm_reg) {
+    switch (val->kind) {
+        case IR_VAL_CONST_FLOAT:
+        case IR_VAL_CONST_INT: {
+            double _f64 = val->kind == IR_VAL_CONST_INT ?
+                                       (double)val->as._i64 :
+                                       val->as._f64;
+            x86_64EmitFloatLiteralData(ctx, xmm_reg, _f64);
+            break;
+        }
+
+        case IR_VAL_TMP:
+        case IR_VAL_LOCAL:
+        case IR_VAL_PARAM: {
+            int loff = irCgGetLoff(&ctx->fn->ra, val);
+            aoStrCatFmt(ctx->buf, "movsd   %i(%%rbp), %%%s\n\t",
+                        loff, xmm_reg);
+            break;
+        }
+        default:
+            loggerPanic("ir-cg-x86_64: cannot load float of kind %s\n",
+                        irValueKindToString(val->kind));
+    }
+}
+
+static void x86_64StoreFpr(IrCgCtx *ctx, IrValue *dst, const char *xmm_reg) {
+    int loff = irCgGetLoff(&ctx->fn->ra, dst);
+    aoStrCatFmt(ctx->buf, "movsd   %%%s, %i(%%rbp)\n\t",
+                xmm_reg, loff);
+}
+
+/* Does this value fit in the 32-bit sign-extended immediate form that
+ * most x86 integer ops accept (add/sub/and/or/xor/cmp etc.)? */
+static int x86_64IsImm32(IrValue *val, s64 *out) {
+    if (!val || !irIsConstInt(val)) return 0;
+    s64 v = val->as._i64;
+    if (v < INT32_MIN || v > INT32_MAX) return 0;
+    *out = v;
+    return 1;
+}
+
+/* Load instr->r1 into %rax, honouring producer-side fusion: when
+ * IRCG_R1_IN_REG is set the previous instruction already left the
+ * value in %rax (avoids a redundant reload from the slot). Falls
+ * back to LEA-inlining when the value's def was a peephole-marked
+ * IR_LEA, otherwise a plain LoadToReg. */
+static void x86_64LoadFirstSrc(IrCgCtx *ctx, IrInstr *instr, IrValue *src) {
+    if (instr->flags & IRCG_R1_IN_REG) return;
+    if (x86_64InlinedLea(ctx, src, "rax")) return;
+    x86_64LoadToReg(ctx, src, "rax");
+}
+
+/* The float branch uses ucomisd, whose flags follow unsigned-int
+ * semantics (b/be/a/ae). NaN sets CF=ZF=PF=1; we treat IR cmps as
+ * loose-ordered (matches aarch64's behaviour - the IR_CMP_O* /
+ * IR_CMP_UNO / IR_CMP_ORD strict variants aren't currently emitted
+ * by the HolyC frontend). */
+static const char *x86_64CcFor(IrCmpKind cmp, int is_float) {
+    if (is_float) {
+        switch (cmp) {
+            case IR_CMP_EQ: return "e";
+            case IR_CMP_NE: return "ne";
+            case IR_CMP_LT: return "b";
+            case IR_CMP_LE: return "be";
+            case IR_CMP_GT: return "a";
+            case IR_CMP_GE: return "ae";
+            default:        return NULL;
+        }
+    }
+    switch (cmp) {
+        case IR_CMP_EQ:  return "e";
+        case IR_CMP_NE:  return "ne";
+        case IR_CMP_LT:  return "l";
+        case IR_CMP_LE:  return "le";
+        case IR_CMP_GT:  return "g";
+        case IR_CMP_GE:  return "ge";
+        case IR_CMP_ULT: return "b";
+        case IR_CMP_ULE: return "be";
+        case IR_CMP_UGT: return "a";
+        case IR_CMP_UGE: return "ae";
+        default:         return NULL;
+    }
+}
+
+static const char *x86_64CcInvFor(IrCmpKind cmp, int is_float) {
+    if (is_float) {
+        switch (cmp) {
+            case IR_CMP_EQ: return "ne";
+            case IR_CMP_NE: return "e";
+            case IR_CMP_LT: return "ae";
+            case IR_CMP_LE: return "a";
+            case IR_CMP_GT: return "be";
+            case IR_CMP_GE: return "b";
+            default:        return NULL;
+        }
+    }
+    switch (cmp) {
+        case IR_CMP_EQ:  return "ne";
+        case IR_CMP_NE:  return "e";
+        case IR_CMP_LT:  return "ge";
+        case IR_CMP_LE:  return "g";
+        case IR_CMP_GT:  return "le";
+        case IR_CMP_GE:  return "l";
+        case IR_CMP_ULT: return "ae";
+        case IR_CMP_ULE: return "a";
+        case IR_CMP_UGT: return "be";
+        case IR_CMP_UGE: return "b";
+        default:         return NULL;
+    }
+}
+
+/* Materialise the EFLAGS-encoded comparison result as 0/1 in %rax.
+ * setcc only writes the low byte, so we follow with a zero-extension
+ * into the full 64-bit register. */
+static void x86_64EmitSetCC(IrCgCtx *ctx, IrCmpKind cmp, int is_float) {
+    const char *cc = x86_64CcFor(cmp, is_float);
+    if (!cc) {
+        loggerPanic("ir-cg-x86_64: unsupported cmp kind %s\n",
+                    irCmpKindToString(cmp));
+    }
+    aoStrCatFmt(ctx->buf,
+                "set%s    %%al\n\t"
+                "movzbq  %%al, %%rax\n\t",
+                cc);
+}
+
+/* Save each pinned register with `pushq`. If the count is odd, add a
+ * trailing 8-byte pad so the stack stays 16-byte aligned for any
+ * downstream call. The restore mirror reverses both halves. */
+static void x86_64SavePinnedRegs(AoStr *buf, Vec *pinned) {
+    if (!pinned || pinned->size == 0) return;
+    for (u64 i = 0; i < pinned->size; ++i) {
+        AoStr *r = (AoStr *)pinned->entries[i];
+        aoStrCatFmt(buf, "pushq   %%%S\n\t", r);
+    }
+    if (pinned->size & 1) {
+        aoStrCatFmt(buf, "subq    $8, %%rsp\n\t");
+    }
+}
+
+static void x86_64RestorePinnedRegs(AoStr *buf, Vec *pinned) {
+    if (!pinned || pinned->size == 0) return;
+    if (pinned->size & 1) {
+        aoStrCatFmt(buf, "addq    $8, %%rsp\n\t");
+    }
+    for (s64 i = (s64)pinned->size - 1; i >= 0; --i) {
+        AoStr *r = (AoStr *)pinned->entries[i];
+        aoStrCatFmt(buf, "popq    %%%S\n\t", r);
+    }
+}
+
+/* leaveq is `movq %rbp, %rsp; popq %rbp` in one instruction. Saves a
+ * byte over the explicit pair, no other difference. */
+static void x86_64Epilogue(AoStr *buf) {
+    aoStrCatFmt(buf,
+                "leaveq\n\t"
+                "retq\n");
+}
+
+/* Did the last emit already place an epilogue at the tail of buf?
+ * Used so we don't double-emit when the function ends with an
+ * explicit return. */
+static int x86_64HasRet(AoStr *buf) {
+    static const char *needle = "leaveq\n\tretq\n";
+    int nlen = (int)strlen(needle);
+    if ((int)buf->len < nlen) return 0;
+    return memcmp(buf->data + buf->len - nlen, needle, nlen) == 0;
+}
+
+static void x86_64BlockLabel(IrCgCtx *ctx,
+                             IrBlock *block,
+                             char *out,
+                             int n)
+{
+    snprintf(out, n, ".LIRBB%d_%u", ctx->fn->uuid, block->id);
+}
+
+/* Move a single phi's incoming value into the phi's destination. The
+ * value either lives in %rax already (when the producer fused to
+ * this block's terminator), in a slot, or is dangling (no slot yet -
+ * happens when the value is mem2reg-promoted and we got here via a
+ * never-taken path; zero out as a safe filler). */
+static void x86_64EmitOnePhi(IrCgCtx *ctx, IrInstr *phi, IrPair *match) {
+    IrValue *v = match->ir_value;
+
+    int in_rax = !irIsFloat(phi->dst->type) &&
+                 irPhiPairValueLiveInResultReg(match->ir_block, v);
+
+    int v_dangling = !in_rax && v &&
+                      v->kind == IR_VAL_TMP &&
+                     !mapHasInt(ctx->fn->ra.id_to_loff, v->as.var.id);
+
+    if (irIsFloat(phi->dst->type)) {
+        if (v_dangling) {
+            aoStrCatFmt(ctx->buf, "xorpd   %%xmm0, %%xmm0\n\t");
+        } else {
+            x86_64LoadToFpr(ctx, v, "xmm0");
+        }
+        x86_64StoreFpr(ctx, phi->dst, "xmm0");
+        return;
+    }
+    if (v_dangling) {
+        aoStrCatFmt(ctx->buf, "xorq    %%rax, %%rax\n\t");
+    } else if (!in_rax) {
+        x86_64LoadToReg(ctx, v, "rax");
+    }
+    if (!(phi->flags & IRCG_PHI_IN_REG)) {
+        x86_64StoreReg(ctx, phi->dst, "rax");
+    }
+}
+
+/* Materialise all phis at block `to` from predecessor `from`, ordered
+ * so a phi never overwrites a value still needed by another pending
+ * phi in the same group (parallel-copy semantics). Cycles among
+ * phis would need a temporary swap; we panic loudly if one appears,
+ * matching aarch64's behaviour. This is target-agnostic */
+#define kMaxPhisX86 32
+static void x86_64PhiMaterialise(IrCgCtx *ctx,
+                                 IrBlock *from,
+                                 IrBlock *to)
+{
+    if (!to || !from) return;
+
+    IrInstr *phis[kMaxPhisX86];
+    IrPair  *pairs[kMaxPhisX86];
+    int     done[kMaxPhisX86];
+    int n = 0;
+
+    listForEach(to->instructions) {
+        IrInstr *I = (IrInstr *)it->value;
+        if (I->op == IR_NOP) continue;
+        if (I->op != IR_PHI) break;
+        if (n >= kMaxPhisX86) {
+            loggerPanic("ir-cg-x86_64: too many phis at one block "
+                        "(>%d)\n", kMaxPhisX86);
+        }
+        IrPair *match = NULL;
+        if (I->extra.phi_pairs) {
+            for (u64 i = 0; i < I->extra.phi_pairs->size; ++i) {
+                IrPair *p = vecGet(IrPair *, I->extra.phi_pairs, i);
+                if (p->ir_block == from) { match = p; break; }
+            }
+        }
+        if (!match || !match->ir_value) continue;
+        phis[n] = I;
+        pairs[n] = match;
+        done[n] = 0;
+        n++;
+    }
+    if (n == 0) return;
+
+    int emitted = 0;
+    while (emitted < n) {
+        int progress = 0;
+        for (int i = 0; i < n; ++i) {
+            if (done[i]) continue;
+            int read_by_pending = 0;
+            for (int j = 0; j < n; ++j) {
+                if (i == j || done[j]) continue;
+                IrValue *v = pairs[j]->ir_value;
+                if (v && v->kind == IR_VAL_TMP &&
+                    phis[i]->dst &&
+                    phis[i]->dst->kind == IR_VAL_TMP &&
+                    v->as.var.id == phis[i]->dst->as.var.id) {
+                    read_by_pending = 1;
+                    break;
+                }
+            }
+            if (!read_by_pending) {
+                x86_64EmitOnePhi(ctx, phis[i], pairs[i]);
+                done[i] = 1;
+                emitted++;
+                progress = 1;
+            }
+        }
+        if (!progress) {
+            loggerPanic("ir-cg-x86_64: phi materialisation cycle "
+                        "unimplemented\n");
+        }
+    }
+}
+
+/* SysV AMD64 has 6 int arg regs (rdi/rsi/rdx/rcx/r8/r9) and 8 FP
+ * (xmm0-7); anything past that goes on the stack right-to-left
+ * (we lay them out left-to-right at [rsp + i*8] which produces the
+ * same memory image once the call instruction's return-address
+ * push lands on top).
+ *
+ * HolyC's variadic convention sends every arg past var_arg_start
+ * through the stack regardless of register availability (unlike
+ * C-style variadic, which uses normal regs until they run out).
+ *
+ * Unlike aarch64, x86_64 has no separate indirect-result-location
+ * register: when the callee returns by hidden pointer, args[0] is
+ * that pointer and lives in %rdi like any first int arg. So we
+ * don't special-case it here. */
+static s32 x86_64PartitionCallArgs(u8 *is_stack, u64 n, Vec *args,
+                                   int holyc_variadic,
+                                   int var_arg_start)
+{
+    s32 n_stack_total = 0;
+    if (holyc_variadic && (s64)n > var_arg_start) {
+        for (u64 i = (u64)var_arg_start; i < n; ++i) {
+            is_stack[i] = 1;
+            n_stack_total++;
+        }
+    }
+    int int_idx = 0, float_idx = 0;
+    for (u64 i = 0; i < n; ++i) {
+        if (is_stack[i]) continue;
+        IrValue *a = vecGet(IrValue *, args, i);
+        if (irIsFloat(a->type)) {
+            if (float_idx >= 8) {
+                is_stack[i] = 1;
+                n_stack_total++;
+            } else {
+                float_idx++;
+            }
+        } else {
+            if (int_idx >= 6) {
+                is_stack[i] = 1;
+                n_stack_total++;
+            } else {
+                int_idx++;
+            }
+        }
+    }
+    return n_stack_total;
+}
+
+static void x86_64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
+    (void)ctx;
+    switch (instr->op) {
+        /* No-ops at codegen: ALLOCA/GEP/PHI/LABEL are all resolved
+         * elsewhere (alloca slots are assigned during layout, GEPs
+         * fold into addressing modes, PHIs materialise at predecessor
+         * edges, LABEL is dropped during IR resolution). */
+        case IR_NOP:
+        case IR_ALLOCA:
+        case IR_PHI:
+        case IR_GEP:
+        case IR_LABEL:
+            break;
+
+        case IR_LOAD: {
+            if (instr->r1 && instr->r1->pinned_reg) {
+                aoStrCatFmt(ctx->buf, "movq    %%%s, %%rax\n\t",
+                            instr->r1->pinned_reg->data);
+                x86_64SpillDst(ctx, instr, "rax");
+                break;
+            }
+            int loff = irCgGetLoff(&ctx->fn->ra, instr->r1);
+            u32 size = instr->dst ? instr->dst->as.var.size : 8;
+            x86_64Load(ctx->buf, "rax", size, loff);
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_STORE: {
+            /* Width comes from the value's size, not the destination's:
+             * when dst is a GEP'd pointer to a sub-word slot (e.g.
+             * `I8 a[3]`), forcing an 8-byte store would overrun the
+             * slot and clobber adjacent stack data. */
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            if (instr->dst && instr->dst->pinned_reg) {
+                aoStrCatFmt(ctx->buf, "movq    %%rax, %%%s\n\t",
+                            instr->dst->pinned_reg->data);
+                break;
+            }
+            int loff = irCgGetLoff(&ctx->fn->ra, instr->dst);
+            u32 size = irValueByteSize(instr->r1);
+            x86_64FrameStoreWidth(ctx->buf, loff, size, "rax");
+            break;
+        }
+
+        case IR_LOAD_DEREF: {
+            const char *addr_reg;
+            if (instr->flags & IRCG_R1_IN_REG) {
+                /* r1 already lives in %rax from the fused producer
+                 * - we'll load from (%rax) and write the result to
+                 * %rax in the same instruction. */
+                addr_reg = "rax";
+            } else {
+                x86_64LoadToReg(ctx, instr->r1, "rcx");
+                addr_reg = "rcx";
+            }
+            u32 size = instr->dst ? instr->dst->as.var.size : 8;
+            x86_64DerefLoadWidth(ctx->buf, size, "rax", addr_reg);
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_STORE_DEREF: {
+            if (instr->flags & IRCG_DST_IN_REG) {
+                /* dst (the destination pointer) is already in %rax
+                 * from the fused producer. Shuffle it to %rcx so
+                 * %rax is free for the value to store. */
+                aoStrCatFmt(ctx->buf, "movq    %%rax, %%rcx\n\t");
+                x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            } else {
+                x86_64LoadFirstSrc(ctx, instr, instr->r1);
+                x86_64LoadToReg(ctx, instr->dst, "rcx");
+            }
+            u32 sz = irValueByteSize(instr->r1);
+            x86_64DerefStoreWidth(ctx->buf, sz, "rax", "rcx");
+            break;
+        }
+
+        case IR_LEA: {
+            /* Peephole may have marked this LEA to inline at its
+             * (single) call-site consumer; in that case the emit
+             * happens there, not here. */
+            if (instr->flags & IRCG_LEA_INLINE_AT_CALL) break;
+            x86_64Lea(ctx, instr, "rax");
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_IADD:
+        case IR_ISUB:
+        case IR_AND:
+        case IR_OR:
+        case IR_XOR: {
+            const char *op;
+            switch (instr->op) {
+                case IR_IADD: op = "addq"; break;
+                case IR_ISUB: op = "subq"; break;
+                case IR_AND:  op = "andq"; break;
+                case IR_OR:   op = "orq";  break;
+                case IR_XOR:  op = "xorq"; break;
+                default: loggerPanic("Invalid op: %s\n",
+                                     irOpcodeToString(instr));
+            }
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            s64 imm;
+            if (x86_64IsImm32(instr->r2, &imm)) {
+                aoStrCatFmt(ctx->buf, "%s    $%I, %%rax\n\t",
+                            op, (s64)imm);
+            } else {
+                x86_64LoadToReg(ctx, instr->r2, "rcx");
+                aoStrCatFmt(ctx->buf, "%s    %%rcx, %%rax\n\t", op);
+            }
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_IMUL: {
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            s64 imm;
+            if (x86_64IsImm32(instr->r2, &imm)) {
+                /* imulq has a 3-operand form with a 32-bit signed
+                 * immediate: dst = src * imm. */
+                aoStrCatFmt(ctx->buf,
+                            "imulq   $%I, %%rax, %%rax\n\t",
+                            (s64)imm);
+            } else {
+                x86_64LoadToReg(ctx, instr->r2, "rcx");
+                aoStrCatFmt(ctx->buf, "imulq   %%rcx, %%rax\n\t");
+            }
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_IDIV:
+        case IR_UDIV:
+        case IR_IREM:
+        case IR_UREM: {
+            /* idiv/div divide rdx:rax by the source operand.
+             * Sign-extend rax into rdx with cqo for signed, or zero
+             * rdx for unsigned. Quotient lands in rax, remainder in
+             * rdx; we move rdx into rax for the REM ops so SpillDst
+             * always writes from rax. */
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            x86_64LoadToReg(ctx, instr->r2, "rcx");
+            if (instr->op == IR_IDIV || instr->op == IR_IREM) {
+                aoStrCatFmt(ctx->buf,
+                            "cqo\n\t"
+                            "idivq   %%rcx\n\t");
+            } else {
+                aoStrCatFmt(ctx->buf,
+                            "xorq    %%rdx, %%rdx\n\t"
+                            "divq    %%rcx\n\t");
+            }
+            if (instr->op == IR_IREM || instr->op == IR_UREM) {
+                aoStrCatFmt(ctx->buf, "movq    %%rdx, %%rax\n\t");
+            }
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_SHL:
+        case IR_SHR:
+        case IR_SAR: {
+            const char *op = (instr->op == IR_SHL) ? "shlq"
+                           : (instr->op == IR_SAR) ? "sarq"
+                                                   : "shrq";
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            if (irIsConstInt(instr->r2) &&
+                instr->r2->as._i64 >= 0 &&
+                instr->r2->as._i64 <= 63)
+            {
+                aoStrCatFmt(ctx->buf, "%s    $%I, %%rax\n\t",
+                            op, (s64)instr->r2->as._i64);
+            } else {
+                /* Variable shift count must live in %cl. */
+                x86_64LoadToReg(ctx, instr->r2, "rcx");
+                aoStrCatFmt(ctx->buf, "%s    %%cl, %%rax\n\t", op);
+            }
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_INEG:
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            aoStrCatFmt(ctx->buf, "negq    %%rax\n\t");
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+
+        case IR_NOT:
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            aoStrCatFmt(ctx->buf, "notq    %%rax\n\t");
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+
+        case IR_FADD:
+        case IR_FSUB:
+        case IR_FMUL:
+        case IR_FDIV: {
+            const char *op = (instr->op == IR_FADD) ? "addsd"
+                           : (instr->op == IR_FSUB) ? "subsd"
+                           : (instr->op == IR_FMUL) ? "mulsd"
+                                                    : "divsd";
+            x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+            x86_64LoadToFpr(ctx, instr->r2, "xmm1");
+            aoStrCatFmt(ctx->buf, "%s   %%xmm1, %%xmm0\n\t", op);
+            x86_64StoreFpr(ctx, instr->dst, "xmm0");
+            break;
+        }
+
+        case IR_FNEG: {
+            /* No fneg on SSE - flip the sign bit by XORing with
+             * 0x8000000000000000. `sign_bit` is the shared global
+             * emitted by the data-section pass. */
+            x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+            aoStrCatFmt(ctx->buf,
+                        "xorpd   sign_bit(%%rip), %%xmm0\n\t");
+            x86_64StoreFpr(ctx, instr->dst, "xmm0");
+            break;
+        }
+
+        case IR_ICMP: {
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            s64 imm;
+            if (x86_64IsImm32(instr->r2, &imm)) {
+                /* AT&T cmpq A, B computes B - A; cc names mirror the
+                 * natural ordering (e.g. cmpq $5, %rax + setg = rax>5). */
+                aoStrCatFmt(ctx->buf, "cmpq    $%I, %%rax\n\t", (s64)imm);
+            } else {
+                x86_64LoadToReg(ctx, instr->r2, "rcx");
+                aoStrCatFmt(ctx->buf, "cmpq    %%rcx, %%rax\n\t");
+            }
+            if (instr->flags & IRCG_CMP_FUSED_BR) break;
+            x86_64EmitSetCC(ctx, instr->extra.cmp_kind, 0);
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_FCMP: {
+            x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+            x86_64LoadToFpr(ctx, instr->r2, "xmm1");
+            /* ucomisd %xmm1, %xmm0 sets flags from (xmm0 cmp xmm1). */
+            aoStrCatFmt(ctx->buf, "ucomisd %%xmm1, %%xmm0\n\t");
+            if (instr->flags & IRCG_CMP_FUSED_BR) break;
+            x86_64EmitSetCC(ctx, instr->extra.cmp_kind, 1);
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        /* IR_TRUNC, SITOFP, UITOFP, FPTOSI, FPTOUI, BITCAST are
+         * implemented. The remaining ZEXT/SEXT/FPTRUNC/FPEXT/
+         * PTRTOINT/INTTOPTR aren't currently emitted by the IR
+         * builder for HolyC programs. */
+        case IR_TRUNC: {
+            x86_64LoadFirstSrc(ctx, instr, instr->r1);
+            u32 sz = instr->dst ? instr->dst->as.var.size : 8;
+            switch (sz) {
+                case 1: aoStrCatFmt(ctx->buf, "movzbq  %%al, %%rax\n\t"); break;
+                case 2: aoStrCatFmt(ctx->buf, "movzwq  %%ax, %%rax\n\t"); break;
+                case 4: /* movl into a 32-bit subreg zero-extends to 64 */
+                        aoStrCatFmt(ctx->buf, "movl    %%eax, %%eax\n\t"); break;
+                default: break;
+            }
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+        }
+
+        case IR_SITOFP:
+            x86_64LoadToReg(ctx, instr->r1, "rax");
+            aoStrCatFmt(ctx->buf, "cvtsi2sdq %%rax, %%xmm0\n\t");
+            x86_64StoreFpr(ctx, instr->dst, "xmm0");
+            break;
+
+        case IR_UITOFP:
+            /* x86 has no unsigned int-to-float; treat the source as
+             * signed. True U64 -> double for values >= 2^63 would
+             * need the signed-bit-fixup dance; not currently needed. */
+            x86_64LoadToReg(ctx, instr->r1, "rax");
+            aoStrCatFmt(ctx->buf, "cvtsi2sdq %%rax, %%xmm0\n\t");
+            x86_64StoreFpr(ctx, instr->dst, "xmm0");
+            break;
+
+        case IR_FPTOSI:
+            x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+            aoStrCatFmt(ctx->buf, "cvttsd2siq %%xmm0, %%rax\n\t");
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+
+        case IR_FPTOUI:
+            /* Same simplification as UITOFP - signed truncation. */
+            x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+            aoStrCatFmt(ctx->buf, "cvttsd2siq %%xmm0, %%rax\n\t");
+            x86_64SpillDst(ctx, instr, "rax");
+            break;
+
+        case IR_BITCAST:
+            /* Reinterpret 8 bytes between int and fp. x86's movq has a
+             * dedicated xmm<->gp form for exactly this. */
+            if (instr->dst && irIsFloat(instr->dst->type)) {
+                x86_64LoadToReg(ctx, instr->r1, "rax");
+                aoStrCatFmt(ctx->buf, "movq    %%rax, %%xmm0\n\t");
+                x86_64StoreFpr(ctx, instr->dst, "xmm0");
+            } else {
+                x86_64LoadToFpr(ctx, instr->r1, "xmm0");
+                aoStrCatFmt(ctx->buf, "movq    %%xmm0, %%rax\n\t");
+                x86_64SpillDst(ctx, instr, "rax");
+            }
+            break;
+
+        case IR_ZEXT:    case IR_SEXT:
+        case IR_FPTRUNC: case IR_FPEXT:
+        case IR_PTRTOINT: case IR_INTTOPTR:
+            loggerPanic("ir-cg-x86_64: conversion op not yet implemented "
+                        "(IR op %d) - not currently emitted by IR\n",
+                        instr->op);
+
+        case IR_RET:
+            if (instr->dst) {
+                if (irIsFloat(instr->dst->type)) {
+                    x86_64LoadToFpr(ctx, instr->dst, "xmm0");
+                } else {
+                    /* Canonically XOR EAX for returning 0 */
+                    if (irIsConstInt(instr->dst) && instr->dst->as._i64 == 0) {
+                        aoStrCatFmt(ctx->buf, "xorl    %%eax, %%eax\n\t");
+                    } else {
+                        x86_64LoadFirstSrc(ctx, instr, instr->dst);
+                    }
+                }
+            }
+            x86_64RestorePinnedRegs(ctx->buf, ctx->pinned_regs);
+            x86_64Epilogue(ctx->buf);
+            break;
+
+        case IR_JMP: {
+            IrBlock *target = instr->extra.blocks.target_block;
+            x86_64PhiMaterialise(ctx, ctx->cur_block, target);
+            if (target != ctx->next_block) {
+                char tlbl[64];
+                x86_64BlockLabel(ctx, target, tlbl, sizeof(tlbl));
+                aoStrCatFmt(ctx->buf, "jmp     %s\n\t", tlbl);
+            }
+            break;
+        }
+
+        case IR_BR: {
+            IrBlock *t = instr->extra.blocks.target_block;
+            IrBlock *f = instr->extra.blocks.fallthrough_block;
+            char tlbl[64], flbl[64];
+
+            x86_64BlockLabel(ctx, t, tlbl, sizeof(tlbl));
+            x86_64BlockLabel(ctx, f, flbl, sizeof(flbl));
+
+            /* Was the preceding ICMP/FCMP fused into this branch?
+             * If so we walk backwards to find its cmp_kind so we can
+             * emit a direct j<cc> against the still-live EFLAGS. */
+            int fused_br = (instr->flags & IRCG_BR_USE_PRIOR_CMP) != 0;
+            IrCmpKind fused_kind = IR_CMP_INVALID;
+            int fused_is_float = 0;
+            if (fused_br) {
+                for (List *node = ctx->cur_block->instructions->prev;
+                     node != ctx->cur_block->instructions;
+                     node = node->prev)
+                {
+                    IrInstr *prev = (IrInstr *)node->value;
+                    if (prev == instr)   continue;
+                    if (prev->op == IR_NOP) continue;
+                    fused_kind = prev->extra.cmp_kind;
+                    fused_is_float = (prev->op == IR_FCMP);
+                    break;
+                }
+            }
+
+            if (!fused_br)
+                x86_64LoadFirstSrc(ctx, instr, instr->dst);
+
+            int t_phi = irBlockHasPhi(t);
+            int f_phi = irBlockHasPhi(f);
+            if (!t_phi && !f_phi) {
+                if (fused_br) {
+                    const char *cc_t = x86_64CcFor(fused_kind, fused_is_float);
+                    const char *cc_f = x86_64CcInvFor(fused_kind, fused_is_float);
+                    if (ctx->next_block == t) {
+                        aoStrCatFmt(ctx->buf, "j%s     %s\n\t", cc_f, flbl);
+                    } else if (ctx->next_block == f) {
+                        aoStrCatFmt(ctx->buf, "j%s     %s\n\t", cc_t, tlbl);
+                    } else {
+                        aoStrCatFmt(ctx->buf,
+                                    "j%s     %s\n\t"
+                                    "jmp     %s\n\t",
+                                    cc_t, tlbl, flbl);
+                    }
+                    break;
+                }
+                /* Not fused: dst holds a 0/1 in %rax. testq sets ZF
+                 * without clobbering rax; jz/jnz selects the path. */
+                aoStrCatFmt(ctx->buf, "testq   %%rax, %%rax\n\t");
+                if (ctx->next_block == t) {
+                    aoStrCatFmt(ctx->buf, "jz      %s\n\t", flbl);
+                } else if (ctx->next_block == f) {
+                    aoStrCatFmt(ctx->buf, "jnz     %s\n\t", tlbl);
+                } else {
+                    aoStrCatFmt(ctx->buf,
+                                "jz      %s\n\t"
+                                "jmp     %s\n\t",
+                                flbl, tlbl);
+                }
+            } else {
+                /* One arm has phis: we need to land at a dedicated
+                 * shim that materialises them before the real jump. */
+                static int br_seq = 0;
+                char else_lbl[64];
+                int br_id = br_seq++;
+                snprintf(else_lbl, sizeof(else_lbl),
+                         ".LIRBR%d_E%d", ctx->fn->uuid, br_id);
+                if (fused_br) {
+                    const char *cc_f = x86_64CcInvFor(fused_kind,
+                                                     fused_is_float);
+                    aoStrCatFmt(ctx->buf, "j%s     %s\n\t",
+                                cc_f, else_lbl);
+                } else {
+                    aoStrCatFmt(ctx->buf,
+                                "testq   %%rax, %%rax\n\t"
+                                "jz      %s\n\t", else_lbl);
+                }
+                x86_64PhiMaterialise(ctx, ctx->cur_block, t);
+                aoStrCatFmt(ctx->buf, "jmp     %s\n", tlbl);
+                aoStrRemovePreviousChar(ctx->buf, '\t');
+                aoStrCatFmt(ctx->buf, "%s:\n\t", else_lbl);
+                x86_64PhiMaterialise(ctx, ctx->cur_block, f);
+                if (ctx->next_block != f) {
+                    aoStrCatFmt(ctx->buf, "jmp     %s\n\t", flbl);
+                }
+            }
+            break;
+        }
+
+        case IR_SWITCH:
+            loggerPanic("ir-cg-x86_64: IR_SWITCH not currently emitted "
+                        "by the IR builder\n");
+
+        case IR_CALL: {
+            /* Indirect call: wrap->as.array.label is NULL and the
+             * function-pointer source lives in instr->r2. Load it
+             * into %r11 (scratch, outside the arg-reg range) BEFORE
+             * the arg loads so subsequent arg evaluation can't
+             * clobber the target. callq *%r11 is the indirect form. */
+            IrValue *wrap = instr->r1;
+            Vec *args = wrap ? wrap->as.array.values : NULL;
+            AoStr *fname = wrap ? wrap->as.array.label : NULL;
+            int indirect = (fname == NULL);
+            if (indirect) {
+                if (!instr->r2) {
+                    loggerPanic("ir-cg-x86_64: indirect IR_CALL "
+                                "without target\n");
+                }
+                x86_64LoadToReg(ctx, instr->r2, "r11");
+            }
+
+            Ast *callee = NULL;
+            if (!indirect) {
+                callee = (Ast *)mapGetLen(ctx->cc->global_env,
+                                          fname->data, fname->len);
+            }
+            int callee_va = 0;
+            if (callee) {
+                if ((callee->type && callee->type->has_var_args) ||
+                    callee->has_var_args)
+                {
+                    callee_va = 1;
+                } else if (callee->params && callee->params->size > 0) {
+                    Ast *last = vecGet(Ast *, callee->params,
+                                       callee->params->size - 1);
+                    if (last && last->kind == AST_VAR_ARGS)
+                        callee_va = 1;
+                }
+            }
+            int holyc_variadic = callee_va && callee &&
+                                 callee->kind != AST_EXTERN_FUNC;
+            int extern_variadic = callee_va && callee &&
+                                  callee->kind == AST_EXTERN_FUNC;
+
+            int var_arg_start = -1;
+            if (holyc_variadic && callee->params) {
+                for (u64 i = 0; i < callee->params->size; ++i) {
+                    Ast *p = vecGet(Ast *, callee->params, i);
+                    var_arg_start++;
+                    if (p && p->kind == AST_VAR_ARGS)
+                        break;
+                }
+                var_arg_start += 1;
+            }
+
+            u64 n = args ? args->size : 0;
+            u8 *is_stack = (n > 0) ? (u8 *)malloc(sizeof(u8) * n) : NULL;
+            if (is_stack) memset(is_stack, 0, n);
+            s32 n_stack_total = x86_64PartitionCallArgs(
+                    is_stack, n, args, holyc_variadic, var_arg_start);
+
+            /* Stack args sit in 8-byte lanes; SysV requires the
+             * stack to be 16-byte aligned at the call instruction
+             * (and the call pushes 8 bytes for the return address),
+             * so the region we sub off has to be a multiple of 16. */
+            s32 stack_bytes = n_stack_total * 8;
+            if (stack_bytes & 15) stack_bytes += 8;
+            if (stack_bytes > 0) {
+                aoStrCatFmt(ctx->buf, "subq    $%i, %%rsp\n\t",
+                            stack_bytes);
+            }
+
+            /* Place stack args at [rsp + i*8] in source order. */
+            s32 stack_idx = 0;
+            int tail_in_rax = (instr->flags &
+                               IRCG_CALL_TAIL_ARG_IN_REG) != 0;
+            for (u64 i = 0; i < n; ++i) {
+                if (!is_stack[i]) continue;
+                IrValue *a = vecGet(IrValue *, args, i);
+                s32 slot_off = stack_idx * 8;
+                if (irIsFloat(a->type)) {
+                    x86_64LoadToFpr(ctx, a, "xmm0");
+                    aoStrCatFmt(ctx->buf,
+                                "movsd   %%xmm0, %i(%%rsp)\n\t",
+                                slot_off);
+                } else {
+                    int skip_load = (tail_in_rax && i == n - 1);
+                    if (!skip_load) {
+                        if (!x86_64InlinedLea(ctx, a, "rax")) {
+                            x86_64LoadToReg(ctx, a, "rax");
+                        }
+                    }
+                    aoStrCatFmt(ctx->buf,
+                                "movq    %%rax, %i(%%rsp)\n\t",
+                                slot_off);
+                }
+                stack_idx++;
+            }
+
+            /* Reg args. Hidden struct-return pointer (when present)
+             * is args[0] and naturally lands in %rdi. No special
+             * handling needed (unlike aarch64's x8). */
+            int int_idx = 0, float_idx = 0;
+            int xmm_used = 0;
+            for (u64 i = 0; i < n; ++i) {
+                if (is_stack[i]) continue;
+                IrValue *a = vecGet(IrValue *, args, i);
+                if (irIsFloat(a->type)) {
+                    if (float_idx >= 8) {
+                        loggerPanic("ir-cg-x86_64: too many float args\n");
+                    }
+                    x86_64LoadToFpr(ctx, a, kXmmRegs[float_idx++]);
+                    xmm_used++;
+                } else {
+                    if (int_idx >= 6) {
+                        loggerPanic("ir-cg-x86_64: too many int args\n");
+                    }
+                    const char *target = kIntRegs64[int_idx++];
+                    if (!x86_64InlinedLea(ctx, a, target)) {
+                        x86_64LoadToReg(ctx, a, target);
+                    }
+                }
+            }
+
+            /* SysV variadic ABI: %al = number of XMM regs used.
+             * Required by C-variadic callees so their va_start can
+             * spill the right registers; cheap to set unconditionally
+             * for any variadic call. */
+            if (extern_variadic || holyc_variadic) {
+                aoStrCatFmt(ctx->buf, "movb    $%i, %%al\n\t",
+                            xmm_used);
+            }
+
+            if (indirect) {
+                aoStrCatFmt(ctx->buf, "callq   *%%r11\n\t");
+            } else {
+                aoStrCatFmt(ctx->buf, "callq   %s\n\t",
+                            asmNormaliseFunctionName(ctx->cc, fname));
+            }
+
+            if (stack_bytes > 0) {
+                aoStrCatFmt(ctx->buf, "addq    $%i, %%rsp\n\t",
+                            stack_bytes);
+            }
+
+            if (instr->dst && instr->dst->type != IR_TYPE_VOID &&
+                instr->dst->kind == IR_VAL_TMP)
+            {
+                if (irIsFloat(instr->dst->type)) {
+                    x86_64StoreFpr(ctx, instr->dst, "xmm0");
+                } else {
+                    x86_64SpillDst(ctx, instr, "rax");
+                }
+            }
+            if (is_stack) free(is_stack);
+            break;
+        }
+
+        /* Inline `asm { ... }` block. When fragments are present
+         * (the parser saw `&var` references in the asm body) walk
+         * them and substitute `<loff>(%rbp)` for each LVAR_REF using
+         * the lvar's now-known stack offset. Otherwise paste the
+         * plain text. Mirrors aarch64's IR_ASM case modulo the
+         * frame-relative syntax. */
+        case IR_ASM: {
+            aoStrRemovePreviousChar(ctx->buf, '\t');
+            if (instr->extra.asm_fragments) {
+                listForEach(instr->extra.asm_fragments) {
+                    AsmFragment *f = (AsmFragment *)it->value;
+                    if (f->kind == ASM_FRAG_TEXT) {
+                        if (f->text) {
+                            aoStrCatLen(ctx->buf,
+                                        f->text->data,
+                                        f->text->len);
+                        }
+                    } else if (f->kind == ASM_FRAG_LVAR_REF) {
+                        if (f->lvar) {
+                            aoStrCatFmt(ctx->buf,
+                                        "%i(%%rbp)",
+                                        f->lvar->loff);
+                        }
+                    }
+                }
+            } else if (instr->r1 && instr->r1->as.str.str) {
+                aoStrCatLen(ctx->buf,
+                            instr->r1->as.str.str->data,
+                            instr->r1->as.str.str->len);
+            }
+            aoStrPutChar(ctx->buf, '\n');
+            aoStrPutChar(ctx->buf, '\t');
+            break;
+        }
+
+        /* IR_SELECT and IR_VA_* aren't currently emitted by the IR
+         * builder for HolyC programs. Panic if they ever start appearing so
+         * we notice. Select could be interesting to avoid branching */
+        case IR_SELECT:
+        case IR_VA_ARG: case IR_VA_START: case IR_VA_END:
+            loggerPanic("ir-cg-x86_64: IR op %d not yet implemented "
+                        "(not currently emitted by IR builder; "
+                        "matches aarch64)\n", instr->op);
+    }
+}
+
+/* On entry, each parameter lives in its ABI-mandated home register
+ * (rdi/rsi/rdx/rcx/r8/r9 for int, xmm0-7 for FP). Spill each into
+ * its frame slot (or its pinned register, when the user annotated
+ * the param with `<Type> reg <REG>`) so the function body can see
+ * a stable, addressable location. Mirrors aarch64ParamSpills modulo
+ * register-set differences. */
+static void x86_64ParamSpills(AoStr *buf, Ast *func) {
+    int int_idx = 0, float_idx = 0;
+
+    AstType *rt = func->type ? func->type->rettype : NULL;
+    if (rt &&
+        (rt->kind == AST_TYPE_CLASS || rt->kind == AST_TYPE_UNION) &&
+        !rt->is_intrinsic && rt->size > 0)
+    {
+        /* SysV x86_64: the hidden out-pointer for struct-by-value
+         * returns arrives in %rdi - which IS the first int arg slot
+         * (unlike aarch64's separate x8). Save it to the function's
+         * local slot and advance int_idx past rdi so user-visible
+         * params start at rsi. */
+        x86_64FrameStoreWidth(buf, func->loff, 8, "rdi");
+        int_idx = 1;
+    }
+    if (!func->params)
+        return;
+
+    for (u64 i = 0; i < func->params->size; ++i) {
+        Ast *p = vecGet(Ast *, func->params, i);
+
+        if (p->kind == AST_VAR_ARGS) {
+            /* HolyC variadic ABI: argc in the next int reg, argv on
+             * the caller's stack frame. */
+            x86_64FrameStoreWidth(buf, p->argc->loff, 8,
+                                  kIntRegs64[int_idx++]);
+            continue;
+        }
+
+        /* Register-pinned param: move from the ABI arg reg straight
+         * into the user-named register. No slot, no loff. */
+        if (p->kind == AST_LVAR && p->pinned_kind == LVAR_REG &&
+            p->pinned_reg)
+        {
+            aoStrCatFmt(buf, "movq    %%%s, %%%S\n\t",
+                        kIntRegs64[int_idx], p->pinned_reg);
+            int_idx++;
+            continue;
+        }
+
+        AstType *ptype = (p->kind == AST_DEFAULT_PARAM)
+                         ? p->declvar->type : p->type;
+        if (ptype && ptype->kind == AST_TYPE_FLOAT) {
+            const char *xmm = kXmmRegs[float_idx++];
+            aoStrCatFmt(buf, "movsd   %%%s, %i(%%rbp)\n\t",
+                        xmm, p->loff);
+        } else {
+            int size = (p->kind == AST_FUNPTR) ? 8 :
+                       (ptype ? ptype->size : 8);
+            if (size != 1 && size != 2 && size != 4) size = 8;
+            x86_64FrameStoreWidth(buf, p->loff, (u32)size,
+                                  kIntRegs64[int_idx]);
+            int_idx++;
+        }
+    }
+}
+
+void x86_64PasteDataSection(Cctrl *cc, AoStr *buf) {
+    /* sign_bit / one_dbl are shared FP scratch globals - referenced
+     * by FNEG and convert-float ops. */
+    aoStrCatFmt(buf, "sign_bit:\n\t.quad 0x8000000000000000\n");
+    aoStrCatFmt(buf, "one_dbl:\n\t.double 1.0\n");
+
+    MapIter it;
+    mapIterInit(cc->strs, &it);
+    while (mapIterNext(&it)) {
+        MapNode *n = it.node;
+        Ast *ast = (Ast *)n->value;
+        assert(ast->kind == AST_STRING);
+        aoStrCatFmt(buf,
+                    "%S:\n\t"
+                    ".asciz \"%S\"\n",
+                    ast->slabel, ast->sval);
+    }
+    aoStrPutChar(buf, '\t');
+}
+
+static void x86_64EmitFunctionPrologue(Cctrl *cc,
+                                       AoStr *buf,
+                                       Ast *func,
+                                       u16 total_stack,
+                                       Vec *pinned)
+{
+    char *fname = asmNormaliseFunctionName(cc, func->fname);
+    /* .p2align 4 = 16-byte aligned function entries (x86_64
+     * convention for the I-cache fetch boundary). */
+    aoStrCatFmt(buf,
+                ".text\n\t"
+                ".p2align 4\n\t"
+                ".globl %s\n"
+                "%s:\n\t"
+                "pushq   %%rbp\n\t"
+                "movq    %%rsp, %%rbp\n\t",
+                fname, fname);
+    if (total_stack > 0) {
+        /* Round up to 16 so rsp stays aligned for inner calls. The
+         * call instruction pushes 8 bytes, our pushq %rbp pushes
+         * another 8 - so the frame base is already aligned; the
+         * subq has to preserve that. */
+        u32 aligned = ((u32)total_stack + 15u) & ~15u;
+        aoStrCatFmt(buf, "subq    $%u, %%rsp\n\t", aligned);
+    }
+    /* Pinned saves AFTER reserving locals so rbp-relative offsets
+     * for slots stay valid throughout the function body. */
+    x86_64SavePinnedRegs(buf, pinned);
+}
+
+void x86_64GenerateFunction(IrCgCtx *ctx, Ast *ast) {
+    AoStr *buf = ctx->buf;
+    IrFunction *fn = ctx->fn;
+
+    /* Collect pinned-register set used by this function's locals
+     * AND params (same sweep aarch64 does). The prologue saves;
+     * each ret restores. */
+    ctx->pinned_regs = NULL;
+    if (ast->locals) {
+        listForEach(ast->locals) {
+            Ast *l = (Ast *)it->value;
+            if (!l || l->kind != AST_LVAR) continue;
+            if (l->pinned_kind != LVAR_REG) continue;
+            if (!l->pinned_reg) continue;
+            if (!ctx->pinned_regs) ctx->pinned_regs = irValueVecNew();
+            vecPush(ctx->pinned_regs, l->pinned_reg);
+        }
+    }
+    if (ast->params) {
+        for (u64 i = 0; i < ast->params->size; ++i) {
+            Ast *p = vecGet(Ast *, ast->params, i);
+            if (!p || p->kind != AST_LVAR) continue;
+            if (p->pinned_kind != LVAR_REG) continue;
+            if (!p->pinned_reg) continue;
+            int seen = 0;
+            if (ctx->pinned_regs) {
+                for (u64 k = 0; k < ctx->pinned_regs->size; ++k) {
+                    AoStr *r = (AoStr *)ctx->pinned_regs->entries[k];
+                    if (r == p->pinned_reg) { seen = 1; break; }
+                }
+            }
+            if (seen) continue;
+            if (!ctx->pinned_regs) ctx->pinned_regs = irValueVecNew();
+            vecPush(ctx->pinned_regs, p->pinned_reg);
+        }
+    }
+
+    x86_64EmitFunctionPrologue(ctx->cc, buf, ast,
+                               fn->stack_space,
+                               ctx->pinned_regs);
+    x86_64ParamSpills(buf, ast);
+
+    Set *referenced = irCgComputeReferencedBlocks(fn);
+
+    listForEach(fn->blocks) {
+        IrBlock *block = (IrBlock *)it->value;
+        ctx->cur_block = block;
+        ctx->next_block = (it->next != fn->blocks)
+                         ? (IrBlock *)it->next->value
+                         : NULL;
+        if (setHas(referenced, (void *)(u64)block->id)) {
+            char lbl[64];
+            x86_64BlockLabel(ctx, block, lbl, sizeof(lbl));
+            aoStrRemovePreviousChar(buf, '\t');
+            aoStrCatPrintf(buf, "%s:\n\t", lbl);
+        }
+        listForEach(block->instructions) {
+            IrInstr *instr = (IrInstr *)it->value;
+            x86_64EmitInstr(ctx, instr);
+        }
+    }
+    setRelease(referenced);
+
+    /* If the function body didn't end with an explicit ret, emit
+     * the epilogue ourselves so we don't fall through. */
+    if (!x86_64HasRet(buf)) {
+        x86_64RestorePinnedRegs(buf, ctx->pinned_regs);
+        x86_64Epilogue(buf);
+    }
+
+    mapRelease(ctx->lea_inline_map);
+}
+
+void x86_64InitialiseEmptyGlobal(Cctrl *cc,
+                                 AoStr *buf,
+                                 Ast *global,
+                                 int zerofill)
+{
+    AoStr *label = global->is_static ? global->glabel : global->gname;
+    int size = global->type->size;
+
+    if (zerofill && (cc->target == TARGET_AARCH64_APPLE_DARWIN ||
+                     cc->target == TARGET_X86_64_APPLE_DARWIN))
+    {
+        aoStrCatFmt(buf, ".globl %S\n\t", label);
+        aoStrCatFmt(buf, ".zerofill __DATA,__common,%S,%i,%i\n\t",
+                    label, size, (int)log2((double)size));
+    } else {
+        aoStrCatFmt(buf, ".globl %S\n\t.comm %S, %i, %u\n\t",
+                    label, label, size,
+                    roundUpToNextPowerOf2((unsigned long)size));
+    }
+}
+
+static void x86_64DataInternal(AoStr *buf, Ast *data) {
+    if (data->kind == AST_STRING) {
+        aoStrCatPrintf(buf, ".quad %s\n\t", data->slabel->data);
+        return;
+    }
+    if (data->kind == AST_ARRAY_INIT) {
+        listForEach(data->arrayinit) {
+            x86_64DataInternal(buf, (Ast *)it->value);
+        }
+        return;
+    }
+    if (data->type->kind == AST_TYPE_FLOAT) {
+        aoStrCatPrintf(buf, ".quad 0x%lX #%.9f\n\t",
+                       ieee754(data->f64), data->f64);
+        return;
+    }
+    switch (data->type->size) {
+        case 1: aoStrCatPrintf(buf, ".byte %d\n\t", data->i64); break;
+        case 4: aoStrCatPrintf(buf, ".long %d\n\t", data->i64); break;
+        case 8: aoStrCatPrintf(buf, ".quad %d\n\t", data->i64); break;
+        default:
+            loggerPanic("Cannot create size information for: %s\n",
+                        astToString(data));
+    }
+}
+
+void x86_64GlobalVar(Cctrl *cc,
+                     Set *seen_globals,
+                     AoStr *buf,
+                     Ast *ast)
+{
+    Ast *declvar = ast->declvar;
+    Ast *declinit = ast->declinit;
+    AoStr *varname = declvar->gname;
+    AoStr *label = declvar->is_static ? declvar->glabel : declvar->gname;
+
+    if (ast->flags & AST_FLAG_EXTERN) return;
+    if (declvar->flags & AST_FLAG_EXTERN) return;
+    if (setHasLen(seen_globals, varname->data, varname->len)) return;
+
+    aoStrRemovePreviousChar(buf, '\t');
+    setAdd(seen_globals, varname->data);
+
+    if (declinit &&
+        (declinit->kind == AST_ARRAY_INIT ||
+         declinit->kind == AST_LITERAL ||
+         declinit->kind == AST_STRING))
+    {
+        if (declinit->kind == AST_STRING) {
+            aoStrCatFmt(buf,
+                        "%S:\n\t.asciz \"%S\"\n\t",
+                        declvar->gname, declinit->sval);
+            return;
+        }
+        if (!declvar->is_static) {
+            aoStrCatFmt(buf, ".globl %S\n", label);
+        }
+        aoStrCatPrintf(buf, ".data\n");
+        if (declinit->kind == AST_ARRAY_INIT) {
+            Ast *head = (Ast *)declinit->arrayinit->next->value;
+            if (head->kind == AST_STRING) {
+                aoStrCatPrintf(buf, ".align 4\n");
+            }
+        }
+        aoStrCatFmt(buf, "%S:\n\t", label);
+        if (declinit->kind == AST_ARRAY_INIT) {
+            listForEach(declinit->arrayinit) {
+                x86_64DataInternal(buf, (Ast *)it->value);
+            }
+            return;
+        }
+        x86_64DataInternal(buf, declinit);
+    } else {
+        if (declvar->is_static) {
+            aoStrCatFmt(buf, ".lcomm %S, %i\n\t", label,
+                        declvar->type->size);
+        } else {
+            /* argc/argv are linked from the startup file - use .comm
+             * not .zerofill so the linker doesn't double-allocate. */
+            if (label->len == 4 &&
+                (!strncmp(label->data, str_lit("argc")) ||
+                 !strncmp(label->data, str_lit("argv"))))
+            {
+                x86_64InitialiseEmptyGlobal(cc, buf, declvar, 0);
+            } else {
+                x86_64InitialiseEmptyGlobal(cc, buf, declvar, 1);
+            }
+        }
+    }
+}
+
+static void x86_64PasteAsmBlocks(AoStr *buf, Cctrl *cc) {
+    if (!cc->asm_blocks) return;
+    for (List *bl = cc->asm_blocks->next; bl != cc->asm_blocks;
+         bl = bl->next)
+    {
+        Ast *asm_block = (Ast *)bl->value;
+        if (!asm_block->funcs) continue;
+        for (List *fl = asm_block->funcs->next; fl != asm_block->funcs;
+             fl = fl->next)
+        {
+            Ast *asm_func = (Ast *)fl->value;
+            aoStrCatPrintf(buf, ".text\n");
+            aoStrCatPrintf(buf, ".globl %s\n",
+                           asm_func->asmfname->data);
+            aoStrCatPrintf(buf, "%s:\n", asm_func->asmfname->data);
+            aoStrCatLen(buf,
+                        asm_func->body->asm_stmt->data,
+                        asm_func->body->asm_stmt->len);
+            aoStrPutChar(buf, '\n');
+        }
+    }
+}
+
+AoStr *x86_64AsmGenerate(Cctrl *cc) {
+    AoStr *buf = aoStrAlloc(2048);
+    x86_64PasteDataSection(cc, buf);
+    x86_64PasteAsmBlocks(buf, cc);
+
+    /* Top-level statements parsed into cc->initalisers become the
+     * body of a synthetic `main`. CCTRL_ASM_HAS_INITIALISERS makes
+     * asmNormaliseFunctionName rename the user's `Main` to `MainFn`
+     * so the symbols don't collide. */
+    Ast *synth_main = NULL;
+    if (!listEmpty(cc->initalisers)) {
+        cc->flags |= CCTRL_ASM_HAS_INITIALISERS;
+        listAppend(cc->initalisers,
+                   astReturn(astI64Type(0), ast_i32_type));
+        Ast *body = astCompountStatement(cc->initalisers);
+        Vec *empty_params = astVecNew();
+        AstType *fn_type = astMakeFunctionType(ast_i32_type, empty_params);
+        synth_main = astFunction(fn_type, "main", 4, empty_params, body,
+                                 cc->initaliser_locals, 0);
+    }
+
+    IrCtx *ir_ctx = irCtxNew(cc);
+    IrCgCtx ctx;
+    ctx.buf = buf;
+    ctx.cc = cc;
+
+    Set *seen_globals = setNew(32, &set_cstring_type);
+
+    listForEach(cc->ast_list) {
+        Ast *ast = it->value;
+        if (ast->kind == AST_FUNC) {
+            IrFunction *fn = irLowerFunction(ir_ctx, ast);
+            irBasicFunctionOptimisations(fn);
+            irFunctionPrepForCodeGen(&ctx, fn, ast);
+            x86_64GenerateFunction(&ctx, ast);
+        } else if (ast->kind == AST_DECL || ast->kind == AST_GVAR) {
+            x86_64GlobalVar(cc, seen_globals, buf, ast);
+        }
+    }
+
+    if (synth_main) {
+        IrFunction *fn = irLowerFunction(ir_ctx, synth_main);
+        irBasicFunctionOptimisations(fn);
+        irFunctionPrepForCodeGen(&ctx, fn, synth_main);
+        x86_64GenerateFunction(&ctx, synth_main);
+    }
+
+    aoStrCatFmt(buf, ".ident      \"hcc: %s %s %s hash: %s\"\n",
+                OS_STR,
+                cliTargetToString(cc->target),
+                cctrlGetVersion(),
+                HCC_GIT_HASH);
+    setRelease(seen_globals);
+    return buf;
+}

--- a/src/x86_64.h
+++ b/src/x86_64.h
@@ -1,0 +1,9 @@
+#ifndef X86_64_H__
+#define X86_64_H__
+
+#include "aostr.h"
+#include "cctrl.h"
+
+AoStr *x86_64AsmGenerate(Cctrl *cc);
+
+#endif


### PR DESCRIPTION
Allows for much better code generation and a simpler backend file.

Intermixed in this are some fixes as follows;

## Features
- better x86_64 codegen, there is no more `push/pop`
- `try/catch`, using `setjmp` + `longjmp`
```holyc
U0 Main()
{
  try {
    throw('whoops!');
  } catch {
    "%c", Fs->except_ch;
  }
}
```
- Pinning variables or function parameters to registers, this does not produce good code. For integers only.
```holyc
U0 Main()
{
  I64 reg RAX x = 10;
  asm {
    ADD RAX, 10
  }
  "%d\n", x; // prints 20
}
```
- Referencing locals in asm blocks, this also does not produce good code. For integers only
```holyc
U0 Main()
{
  I64 x = 10;
  asm {
    MOV RAX, &x
    ADD RAX, 10
    MOV &x, RAX
  }
  "%d\n", x; // prints 20
}
```
- Cross compilation in it's infancy
- Command line option for install directory `--install-dir=`, default is `/usr/local`
- `--use-legacy-x86` for the `Ast -> x86_64` backend. Soon to be deleted.

## Fixes
- Hashtable removal of items
- Not setting `has_var_args` to zero which could cause garbage being read on `AstType`'s
- Always copy an `AstType` to ensure that if we manipulate it we are not manipulating a global instance.
- Correct the check in `ir.c` for when to narrow

closes https://github.com/Jamesbarford/holyc-lang/issues/161 https://github.com/Jamesbarford/holyc-lang/issues/140