### PR TITLE
Fix for unterminated comment

### DIFF
--- a/src/lexer.c
+++ b/src/lexer.c
@@ -646,19 +646,22 @@ static void lexSkipCodeComment(Lexer *l) {
             l->ptr++;
         }
     } else if (*l->ptr == '*') {
-        while ((*l->ptr != '\0' && *(l->ptr + 1) != '\0')) {
+        int start_line = l->lineno;
+        while (*l->ptr != '\0') {
+            if (*l->ptr == '*' && *(l->ptr + 1) == '/') {
+                l->ptr += 2;
+                return;
+            }
             if (*l->ptr == '\n') {
                 l->lineno++;
             }
-            if (*l->ptr == '*' && *(l->ptr + 1) == '/') {
-                //while (*l->ptr != '\n') {
-                //    l->ptr++;
-                //}
-                l->ptr += 2;
-                break;
-            }
             l->ptr++;
         }
+        /* Walked off EOF without seeing the closing delimiter.
+         * Bail here rather than silently returning, which leaves
+         * the parser staring at an empty token stream and crashing
+         * on the next peek. */
+        loggerPanic("line %d: unterminated block comment\n", start_line);
     }
 }
 

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -1243,6 +1243,15 @@ Ast *parseUnaryExpr(Cctrl *cc) {
             operand = parseExpr(cc,16);
         } else {
             operand = parseUnaryExpr(cc);
+            /* parsePrimary returns NULL when it sees a punct that
+             * can't start an expression. Such as a stray
+             * slash left over from a malformed block-comment close.
+             * Bail with a real error rather than dereffing `NULL`. */
+            if (!operand) {
+                cctrlRaiseException(cc,
+                    "Expected expression after unary '%s'",
+                    lexemePunctToString(tok->i64));
+            }
             peek = cctrlTokenPeek(cc);
             if (tokenPunctIs(peek, '[') && (operand->kind == AST_CLASS_REF ||
                                             operand->type->kind == AST_TYPE_ARRAY)) {


### PR DESCRIPTION
Fixes where the following would cause a segmentation fault.
```holyc
U0 Main()
{
   /*
}
```
Or

```holyc
U0 Main()
{
   /* */ */
}
```
Closes https://github.com/Jamesbarford/holyc-lang/issues/172