### PR TITLE
Fix: FnPtr failing to get id

### DIFF
--- a/src/ir-regalloc.c
+++ b/src/ir-regalloc.c
@@ -666,11 +666,7 @@ void irCgBindAstLoffs(IrRaCtx *ra, Ast *ast_func) {
                 continue;
             }
 
-            u32 param_id;
-            if (p->kind == AST_DEFAULT_PARAM) param_id = p->declvar->lvar_id;
-            else if (p->kind == AST_FUNPTR)   param_id = p->fn_ptr_id;
-            else                              param_id = p->lvar_id;
-            IrValue *iv = irFnGetVar(ra->func, param_id);
+            IrValue *iv = irFnGetVar(ra->func, irGetParamId(p));
             /* Pinned param: no slot. */
             if (iv && iv->pinned_reg) continue;
             if (iv) irCgSetLoff(ra, iv->as.var.id, p->loff);
@@ -679,11 +675,7 @@ void irCgBindAstLoffs(IrRaCtx *ra, Ast *ast_func) {
 
     listForEach(ast_func->locals) {
         Ast *l = (Ast *)it->value;
-        u32 id;
-        if (l->kind == AST_DEFAULT_PARAM) id = l->declvar->lvar_id;
-        else if (l->kind == AST_FUNPTR)   id = l->fn_ptr_id;
-        else                              id = l->lvar_id;
-        IrValue *iv = irFnGetVar(ra->func, id);
+        IrValue *iv = irFnGetVar(ra->func, irGetParamId(l));
         /* Register-pinned locals have no slot - the codegen reads /
          * writes the named register directly. */
         if (iv && iv->pinned_reg) continue;
@@ -708,19 +700,15 @@ int irCgComputeAstLayout(Ast *ast_func, IrFunction *ir_func) {
 
     listForEach(ast_func->locals) {
         Ast *l = (Ast *)it->value;
-        u32 id;
         int size;
         if (l->kind == AST_DEFAULT_PARAM) {
-            id = l->declvar->lvar_id;
             size = l->declvar->type->size;
         } else if (l->kind == AST_FUNPTR) {
-            id = l->fn_ptr_id;
             size = 8;
         } else {
-            id = l->lvar_id;
             size = l->type->size;
         }
-        IrValue *iv = irFnGetVar(ir_func, id);
+        IrValue *iv = irFnGetVar(ir_func, irGetParamId(l));
         int promoted = iv && iv->kind == IR_VAL_TMP &&
                        !setHas(surviving, (void *)(u64)iv->as.var.id);
         if (promoted)

--- a/src/ir-types.c
+++ b/src/ir-types.c
@@ -316,6 +316,19 @@ IrValueType irConvertType(AstType *type) {
     }
 }
 
+/* Identity used to key an IR slot for an AST param-or-local. AST_FUNPTR
+ * carries its id on `fn_ptr_id`; AST_LVAR on `lvar_id`. AST_DEFAULT_PARAM
+ * is a wrapper - the real id lives on its inner `declvar`. */
+u32 irGetParamId(Ast *param) {
+    if (param->kind == AST_DEFAULT_PARAM) {
+        return param->declvar->kind == AST_FUNPTR
+            ? param->declvar->fn_ptr_id
+            : param->declvar->lvar_id;
+    }
+    if (param->kind == AST_FUNPTR) return param->fn_ptr_id;
+    return param->lvar_id;
+}
+
 int irValueIsVariable(IrValue *value) {
     return value->kind == IR_VAL_LOCAL ||
            value->kind == IR_VAL_PARAM ||

--- a/src/ir-types.h
+++ b/src/ir-types.h
@@ -387,6 +387,7 @@ int irGetIntSize(IrValueType ir_value_type);
 IrBlock *irInstrEvalConstBranch(IrInstr *ir_cmp, IrInstr *ir_branch);
 u8 irBlocksPointToEachOther(IrFunction *func, IrBlock *prev_block, IrBlock *next_block);
 IrValueType irConvertType(AstType *type);
+u32 irGetParamId(Ast *param);
 
 IrBlock *irInstrGetTargetBlock(IrInstr *instr);
 IrBlock *irInstrGetFallthroughBlock(IrInstr *instr);

--- a/src/ir.c
+++ b/src/ir.c
@@ -2123,17 +2123,13 @@ IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
             irAddStackSpace(ctx, 8);
             break;
         }
-        u32 key = 0;
-        if (ast_param->kind == AST_LVAR) {
-            key = ast_param->lvar_id;
-        } else if (ast_param->kind == AST_FUNPTR) {
-            key = ast_param->fn_ptr_id;
-        } else if (ast_param->kind == AST_DEFAULT_PARAM) {
-            key = ast_param->declvar->lvar_id;
-        } else {
+        if (ast_param->kind != AST_LVAR &&
+            ast_param->kind != AST_FUNPTR &&
+            ast_param->kind != AST_DEFAULT_PARAM) {
             loggerPanic("Unhandled key kind: %s\n",
                     astKindToString(ast_param->kind));
         }
+        u32 key = irGetParamId(ast_param);
         IrValue *ir_tmp_var = irTmp(irConvertType(ast_param->type),
                                     ast_param->type->size);
         ir_tmp_var->kind = IR_VAL_PARAM;


### PR DESCRIPTION
Fix and refactor callsites to use `irGetParamId` to correctly get the variable id