### PR TITLE
Chore: Remove `cast<...>` as a construct, postfix typecasting only

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,6 @@ options can be displayed by running `hcc --help`
   to write code.
 - Range based for loops can be used with static arrays and structs with 
   an `entries` field with an accompanying `size` field: `for (auto it : <var>)`
-- `cast<type>` can be used for casting as well as post-fix type casting.
-- `break` and `continue` allowed in loops.
 - You can call any libc code by declaring the prototype with 
   `extern "c" <type> <function_name>`. Then call the function as you usually
   would. See [here](https://holyc-lang.com/docs/language-spec/learn-functions) for examples.

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -162,7 +162,6 @@ static LexerType lexer_types[] = {
     {"#error",   KW_PP_ERROR},
     {"#include", KW_PP_INCLUDE},
 
-    {"cast",     KW_CAST},
     {"sizeof",   KW_SIZEOF},
     {"inline",   KW_INLINE},
     {"atomic",   KW_ATOMIC},
@@ -526,7 +525,6 @@ AoStr *lexemeToAoStr(Lexeme *tok) {
                 case KW_ATOMIC:      aoStrCatPrintf(str,"atomic");  break;
                 case KW_DEFINE:      aoStrCatPrintf(str,"define");  break;
                 case KW_PP_INCLUDE:     aoStrCatPrintf(str,"include"); break;
-                case KW_CAST:        aoStrCatPrintf(str,"cast"); break;
                 case KW_SIZEOF:      aoStrCatPrintf(str,"sizeof");  break;
                 case KW_RETURN:      aoStrCatPrintf(str,"return");  break;
                 case KW_TRY:         aoStrCatPrintf(str,"try");     break;

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -81,7 +81,6 @@
 #define KW_ATOMIC       8
 #define KW_DEFINE       10
 #define KW_PP_INCLUDE   12
-#define KW_CAST  14
 #define KW_SIZEOF       16
 #define KW_RETURN       18
 #define KW_SWITCH       20

--- a/src/parser.c
+++ b/src/parser.c
@@ -1480,18 +1480,6 @@ Ast *parseStatement(Cctrl *cc) {
                 return ret;
             }
 
-            /**
-             * XXX: DELETE cast<>
-             * It is possible to do: 
-             * cast<Obj *>(_ptr)->x = 10;
-             * */
-            case KW_CAST: {
-                cctrlTokenRewind(cc);
-                ast = parseExpr(cc,16);
-                tok = cctrlTokenGet(cc);
-                assertTokenIsTerminator(cc,tok,PUNCT_TERM_SEMI|PUNCT_TERM_COMMA);
-                return ast;
-            }
             default: {
                 cctrlTokenRewind(cc);
                 cctrlRaiseException(cc,"Keyword '%.*s' cannot be used in this context",

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -1166,20 +1166,6 @@ Ast *parseExpr(Cctrl *cc, int prec) {
     }
 }
 
-static Ast *parseCast(Cctrl *cc) {
-    Ast *ast;
-    AstType *cast_type;
-
-    cctrlTokenExpect(cc,'<');
-    cast_type = parseDeclSpec(cc);
-    cctrlTokenExpect(cc,'>');
-    cctrlTokenExpect(cc,'(');
-    ast = parseExpr(cc,16);
-    cctrlTokenExpect(cc,')');
-    ast = astCast(ast,cast_type);
-    return ast;
-}
-
 Ast *parseSizeof(Cctrl *cc) {
     Lexeme *tok = cctrlTokenGet(cc);
     Lexeme *peek = cctrlTokenPeek(cc);
@@ -1304,7 +1290,6 @@ Ast *parseUnaryExpr(Cctrl *cc) {
     if (tok->tk_type == TK_KEYWORD) {
         switch (tok->i64) {
             case KW_SIZEOF: return parseSizeof(cc);
-            case KW_CAST:   return parseCast(cc);
             case KW_DEFINED: {
                 cctrlTokenExpect(cc,'(');
                 tok = cctrlTokenGet(cc);

--- a/src/tests/17_varargs.HC
+++ b/src/tests/17_varargs.HC
@@ -4,7 +4,7 @@ I64 Add(...)
 {
   I64 acc = 0, arg;
   for (I64 i = 0; i < argc; ++i) {
-    arg = cast<I64>(argv[i]);
+    arg = argv[i](I64);
     acc += argv[i];
   }
   return acc;
@@ -14,7 +14,7 @@ I64 Arg2(I64 i1, ...)
 {
   I64 arg,acc = 0;
   for (I64 i = 0; i < argc; ++i) {
-    arg = cast<I64>(argv[i]);
+    arg = argv[i](I64);
     acc += arg;
   }
   return i1+acc;
@@ -25,7 +25,7 @@ I64 Arg3(I64 i1, I64 i2, ...)
   I64 arg,acc;
   acc = 0;
   for (I64 i = 0; i < argc; ++i) {
-    arg = cast<I64>(argv[i]);
+    arg = argv[i](I64);
     acc += argv[i];
   }
   return i1+i2+acc;
@@ -49,7 +49,7 @@ U8 *Concat(...)
   I64 len;
   len = 0;
   for (I64 i = 0; i < argc; ++i) {
-    arg = cast<U8*>(argv[i]);
+    arg = argv[i](U8 *);
     for (U8 *ptr = arg;*ptr;++ptr) {
       buf[len++] = *ptr;
     }

--- a/src/tests/18_type_casting.HC
+++ b/src/tests/18_type_casting.HC
@@ -1,9 +1,7 @@
 #include "testhelper.HC"
 
 /**
- * Type casting can be a postfix cast of a functional style `cast<TYPE>`.
- * the result is the same.
- */
+ * Type casting is a postfix cast of a functional style. */
 
 class Foo
 {
@@ -29,7 +27,7 @@ I64 PtrCast(U0 *ptr)
 
 I64 I64ToI8Cast(I64 ll)
 { // down cast
-  return cast<I8>(ll) == 'h'; 
+  return ll(U8) == 'h'; 
 }
 
 I64 I64ToU8Cast(I64 ll)
@@ -39,7 +37,7 @@ I64 I64ToU8Cast(I64 ll)
 
 I64 U8ToI64(U8 ch)
 { // Upcast
-  return cast<I64>(ch) == 99;
+  return ch(I64) == 99;
 }
 
 I64 Varadic(...)

--- a/src/tests/27_auto.HC
+++ b/src/tests/27_auto.HC
@@ -35,7 +35,7 @@ Bool VariableAutos()
   auto x = 1<<2,
        f = 4.5,
        ch = 'hello', 
-       p = cast<Person *>(MAlloc(sizeof(Person)));
+       p = MAlloc(sizeof(Person))(Person *);
   if (x + 4 == 8)    correct++;
   if (f + 4.5 == 9)  correct++;
   if (ch == 'hello') correct++;


### PR DESCRIPTION
Removing `cast<...>` it was easier to implement this at the time however postfix is now fully working so no need to have it lying around.