### PR TITLE
Fix: floating point exception when modulo by zero

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -348,6 +348,7 @@ u32 CalcClassSize(List *fields) {
         if (type->size < MAX_ALIGN) size = type->size;
         else                        size = MAX_ALIGN;
 
+        if (size == 0) continue;
         if (offset % size != 0) {
             offset += size - offset % size;
         }


### PR DESCRIPTION
- Would cause the tests in the suite requiring `U0` as a class member to fail