### PR TITLE
hcc -run: forward -clibs to linker

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -225,14 +225,16 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
             AoStr *run_cmd = aoStrNew();
             writeAsmToTmp(asmbuf);
             if (hccCanLinkLibTos(cc)) {
-                aoStrCatPrintf(run_cmd,"%s -L%s/lib %s "CLIBS" -ltos && ./a.out && rm ./a.out",
+                aoStrCatPrintf(run_cmd,"%s -L%s/lib %s %s "CLIBS" -ltos && ./a.out && rm ./a.out",
                         cc->CC,
                         args->install_dir,
-                        ASM_TMP_FILE);
+                        ASM_TMP_FILE,
+                        args->clibs ? args->clibs : "");
             } else {
-                aoStrCatPrintf(run_cmd,"%s %s "CLIBS" && ./a.out && rm ./a.out",
+                aoStrCatPrintf(run_cmd,"%s %s %s "CLIBS" && ./a.out && rm ./a.out",
                         cc->CC,
-                        ASM_TMP_FILE);
+                        ASM_TMP_FILE,
+                        args->clibs ? args->clibs : "");
             }
             /* Don't use 'safeSystem' else anything other than a '0' exit
              * code will cause a panic which is incorrect... This is a bit of a


### PR DESCRIPTION
`hcc -run` ignores `-clibs`, causing linker errors when the program uses external C libraries.

  ## Steps to reproduce

  ```hc
  // test.HC
  extern "c" I32 XOpenDisplay(U8 *name);
  U0 Main() { XOpenDisplay(NULL); }
  Main;

  hcc -run test.HC -clibs="-lX11"   # undefined reference to XOpenDisplay
  hcc test.HC -o test -clibs="-lX11"  # works fine

  Root cause

  The -run code path in emitFile() builds the linker command without args->clibs, unlike the -o path which includes it.

  Fix

  Two-line change in src/main.c — forward args->clibs to the linker invocation in both -run branches (with and without libtos).
  ```