### PR TITLE
Fixes for when linux does not have clang, and ordering of linking

### DIFF
--- a/src/asm/asm_jit.c
+++ b/src/asm/asm_jit.c
@@ -464,6 +464,10 @@ asm_jit_free(AsmJitCode *code)
     code->_mapping_size = 0;
 }
 
+#ifndef RTLD_DEFAULT
+#define RTLD_DEFAULT ((void *) 0)
+#endif
+
 void *
 asm_jit_dlsym_resolver(void *ud, const char *sym)
 {

--- a/src/cli.c
+++ b/src/cli.c
@@ -453,6 +453,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
                     loggerPanic("Invalid target: `%s` valid targets are: %s\n",
                             value.str, valid_targets->data);
                 }
+                args->is_cross_compile = 1;
                 break;
             }
             case CLI_INSTALL_DIR: args->install_dir = value.str; break;

--- a/src/cli.h
+++ b/src/cli.h
@@ -95,6 +95,7 @@ typedef struct CliArgs {
     char *output_filename;
     char *clibs;
     char *install_dir;
+    int is_cross_compile;
     enum CliTarget target;
     List *defines_list;
 } CliArgs;

--- a/src/main.c
+++ b/src/main.c
@@ -259,7 +259,7 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
 
         if (args->clibs) {
             if (hccCanLinkLibTos(cc)) {
-                aoStrCatPrintf(cmd, "%s -L%s/lib %s %s "CLIBS" -ltos -o %s",
+                aoStrCatPrintf(cmd, "%s -L%s/lib %s %s -ltos "CLIBS" -o %s",
                         cc->CC,
                         args->install_dir,
                         ASM_TMP_FILE,args->clibs,args->output_filename);
@@ -274,7 +274,7 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         } else {
             if (hccCanLinkLibTos(cc)) {
                 aoStrCatPrintf(cmd,
-                               "%s -L%s/lib %s "CLIBS" -ltos -o %s",
+                               "%s -L%s/lib %s -ltos "CLIBS" -o %s",
                                cc->CC,
                                args->install_dir,
                                ASM_TMP_FILE,
@@ -287,6 +287,7 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
                                args->output_filename);
             }
         }
+
         safeSystem(cmd->data);
     }
     remove(ASM_TMP_FILE);
@@ -384,14 +385,18 @@ int main(int argc, char **argv) {
 
     /* Plumb in support for cross compiling... currently does nothing :)*/
     const char *str_target = cliTargetToString(args.target);
-    switch (args.target) {
-        /* Let clang do the heavy lifting */
-        case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
-        case TARGET_X86_64_APPLE_DARWIN:
-        case TARGET_X86_64_UNKNOWN_LINUX_GNU:
-        case TARGET_AARCH64_APPLE_DARWIN:
-            cc->CC = mprintf("clang --target=%s", str_target);
-            break;
+    if (args.is_cross_compile) {
+        switch (args.target) {
+            /* Let clang do the heavy lifting */
+            case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
+            case TARGET_X86_64_APPLE_DARWIN:
+            case TARGET_X86_64_UNKNOWN_LINUX_GNU:
+            case TARGET_AARCH64_APPLE_DARWIN:
+                cc->CC = mprintf("clang --target=%s", str_target);
+                break;
+        }
+    } else {
+        cc->CC = mprintf("cc");
     }
 
     if (args.use_legacy_x86) {


### PR DESCRIPTION
- Fix for when linux does not have clang and you are not trying to cross compile
- Fix for the order of the libraries being linked. `-ltos` should happen _before_ `-lm`
- Fix for `RTLD_DEFAULT` constant not being defined.