### PR TITLE
Fix fn pointer type mismatch in fzf.HC and wrong release call in IntSetSymDiff

### DIFF
--- a/src/holyc-lib/fzf.HC
+++ b/src/holyc-lib/fzf.HC
@@ -70,7 +70,7 @@ class FzFString
 
 class FzFTerm
 {
-  FzFResult *(*fn)(FzFResult *res, Bool case_sensitive,
+  U0 (*fn)(FzFResult *res, Bool case_sensitive,
       FzFString *text, FzFString *pattern, FzFPosition *pos, FzFSlab *slab);
   Bool inv;
   U8 *ptr;
@@ -709,7 +709,7 @@ FzFPattern *FzFParsePattern(I32 case_mode, U8 *pattern, Bool fuzzy=TRUE)
   Bool switch_set = FALSE;
   Bool after_bar = FALSE;
   while (ptr != NULL) {
-    FzFResult *(*fn)(FzFResult *res, Bool _case_sensitive,
+    U0 (*fn)(FzFResult *res, Bool _case_sensitive,
         FzFString *_text, FzFString *_pattern,
         FzFPosition *_pos, FzFSlab *_slab) = &FzFFuzzyMatchV1;
 

--- a/src/holyc-lib/set.HC
+++ b/src/holyc-lib/set.HC
@@ -663,8 +663,8 @@ IntSet *IntSetSymDiff(IntSet *s1, IntSet *s2)
     }
   }
 
-  IntSetRelease(i1);
-  IntSetRelease(i2);
+  IntSetIterRelease(i1);
+  IntSetIterRelease(i2);
   return sym_diff_set;
 }
 


### PR DESCRIPTION
Two small bugs in holyc-lib, found while working on an unrelated aarch64 experiment on my fork.

1. `fzf.HC`: `FzFTerm.fn` and the local `fn` pointer in `FzFParsePattern` are declared as `FzFResult *(*fn)(...)`, but both are assigned `&FzFFuzzyMatchV1`, which is declared `U0 FzFFuzzyMatchV1(...)`. Fixed the pointer type to match the actual function signature.

2. `set.HC`: `IntSetSymDiff` releases its two `IntSetIter *` iterators with `IntSetRelease(i1)` / `IntSetRelease(i2)`, which is the release path for `IntSet *`, not iterators. Every other call site in the file correctly uses `IntSetIterRelease`. Fixed to match.

Verified with a clean build and full unit test suite (`make unit-test`), including the FzF fuzzy finding test.