### PR TITLE
Feat: rough and ready repl

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ A holyc compiler built from scratch in C. Basic optimisations like constant,
 folding and some dead code elimination occurs. But broadly it should be easy
 to see how the assembly maps to the source code. It works by creating an AST,
 lowering to an SSA based IR and emitting x86_64/AArch64 assembly code as text
-which is fed into gcc to assemble. Floating point arithmetic is supported as
-are most of the major language features. There is experimental support for
-transpiling HolyC to C, which is in varying states of broken and not properly
-supported.
+which is fed into gcc to assemble. Alternatively a JIT can be invoked which
+maps machine code to executable memory and then runs it, this is done with a
+builtin assembler. Floating point arithmetic is supported as are most of the
+major language features. There is experimental support for transpiling HolyC to
+C, which is in varying states of broken and not properly supported.
 
 ## Example
 Below is a snippet of code showing some of the features supported by this holyc
@@ -70,8 +71,6 @@ ExampleFunction;
 Currently this holyc compiler will compile holyc source code to an
 x86_64/AArch64 compatible binary which has been tested on amd linux and an
 intel mac. An M1 mac and fedora linux on an M4 using QEMU.
-
-Assembly is not yet supported in AArch64.
 
 ## Building
 ### Operating Systems:
@@ -132,17 +131,73 @@ to either the Makefile or when configuring cmake.
 Once the compiler has been compiled, aside from compiling `.HC` files, more 
 options can be displayed by running `hcc --help`
 
+For an interactive session run `hcc -repl` (requires a JIT-enabled build,
+which is the Makefile default). Functions, classes, globals and `#define`s
+accumulate as you type, statements execute immediately and the value of a
+trailing expression is echoed. Line editing, persistent history
+(`~/.hcc_repl_history`) and tab completion over everything you've defined
+are built in. `Uf("Name");` disassembles a JIT-compiled function and
+`ReplDel("name");` removes a global, function, class, union or `#define`
+from the session so the name can be redefined from scratch. An `rc` file
+can be placed in `~/.hcc_rc.HC` with any HolyC functions you may want for the
+repl. To silence the welcome message use `#define HCC_NO_REPL_HELLO` in the rc
+file. Memory in this state is semi-managed in a best effort way to prevent
+crashes. The shell can be invoked by calling `Sh(...)` or `@ <shell commands>`.
+Where the `@ ` prefix denotes the syntax for invoking your environments shell.
+
+### Linking against shared libraries
+The `#link` directive records a shared library dependency in the source
+itself, so neither the compile command nor the REPL needs extra flags:
+
+```hc
+#link "./mylib.so"   /* literal path, relative to the working directory */
+#link <sdl2>         /* library name, like a linker's -lsdl2 */
+
+extern "c" I64 MyLibAdd(I64 a, I64 b);
+```
+
+For AOT builds the path form is passed to the linker verbatim and the name
+form becomes `-l<name>` (with `-L` for Homebrew/`/usr/local` added when
+present). In the JIT and the REPL the library is `dlopen`'d - the name form
+probes `lib<name>.{dylib,so}` in the dynamic linker's default paths, the
+configured install prefix, `/opt/homebrew/lib`, `/usr/local/lib` and the
+system lib dirs. Duplicate `#link`s are ignored, so headers can `#link`
+the library they wrap. Note the JIT can only load shared libraries -
+`.o` files still have to go on an AOT command line.
+
+### Conditional compilation on the execution mode
+`#ifjit` / `#ifaot` select code depending on whether the program is being
+JIT-compiled (`hcc -jit`, the REPL) or built ahead-of-time - shorthand for
+`#ifdef __HCC_JIT__` / `#ifdef __HCC_AOT__`, exactly one of which is always
+defined. They compose with `#else` / `#endif` like any other conditional:
+
+```hc
+U8 *Mode()
+{
+#ifjit
+  return "jit";
+#else
+  return "aot";
+#endif
+}
+```
+
 ## Key Differences between this and TempleOS Holy
 - `F32` data type, TempleOS only supports `F64` however a lot of C libraries,
-  like sdl or raylib require `float`. So it's very hand to be able to use
-  these libraries from HolyC code.
+  like sdl or raylib require `float`. It's very handy to be able to use these
+  libraries from HolyC code. Hence `F32` exists.
 - `auto` key word for type inference, an addition which makes it easier
   to write code.
+- `typeof(<type or expr>)` folds, at compile time, to a string literal
+  naming the type: `typeof(1+1)` is `"I64"`, `typeof(&x)` is `"I64 *"`.
+  The operand is only type-checked, never evaluated.
 - Range based for loops can be used with static arrays and structs with 
   an `entries` field with an accompanying `size` field: `for (auto it : <var>)`
 - You can call any libc code by declaring the prototype with 
   `extern "c" <type> <function_name>`. Then call the function as you usually
   would. See [here](https://holyc-lang.com/docs/language-spec/learn-functions) for examples.
+- `#link` for shared objects and libraries, useful to be able to use things like
+   curl, psql etc... in the JIT, repl and AOT.
 
 
 ## Control Flow Graph Example
@@ -281,6 +336,7 @@ and resources that I have found particularly useful for learning.
 - [cc65](https://cc65.github.io/)
 - [shecc](https://github.com/sysprog21/shecc/tree/master)
 - [JS c compiler](https://github.com/Captainarash/CaptCC)
+- [linenoise](https://github.com/antirez/linenoise)
 
 ### Want to ask questions?
 Find me on twitch: https://www.twitch.tv/Jamesbarford

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,8 +107,13 @@ add_subdirectory(asm)
 
 option(HCC_ENABLE_JIT "Build the optional in-process JIT (aarch64 & x86_64)" OFF)
 if (HCC_ENABLE_JIT)
-    list(APPEND SOURCES jit-common.c aarch64-jit.c x86_64-jit.c)
-    list(APPEND HEADERS jit-common.h aarch64-jit.h x86_64-jit.h)
+    list(APPEND SOURCES jit-common.c aarch64-jit.c x86_64-jit.c repl.c
+         memsafe.c linenoise/linenoise.c)
+    list(APPEND HEADERS jit-common.h aarch64-jit.h x86_64-jit.h repl.h
+         memsafe.h linenoise/linenoise.h)
+    # Vendored (antirez/linenoise) - don't hold it to our warning bar.
+    set_source_files_properties(linenoise/linenoise.c
+                                PROPERTIES COMPILE_FLAGS "-w")
 endif()
 
 add_executable(hcc ${SOURCES} ${HEADERS})

--- a/src/aarch64-jit.c
+++ b/src/aarch64-jit.c
@@ -24,6 +24,7 @@
 #if !defined(__aarch64__)
 
 HccJit *aarch64JitCompile(Cctrl *cc) { (void)cc; return NULL; }
+const HccJitBackend *aarch64JitBackend(void) { return NULL; }
 
 #else /* __aarch64__ && HCC_ENABLE_JIT */
 
@@ -1453,7 +1454,13 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                 if (irIsFloat(instr->dst->type)) jitLoadFirstSrcFpr(ctx, instr->dst);
                 else                              jitLoadFirstSrc(ctx, instr->dst);
             }
-            jitEmitBranchLocal(ctx, hccJitEpilogueLocalNum(jit, ctx->fn));
+            /* The epilogue label is defined straight after the last block,
+             * so a ret ending that block falls through to it. */
+            if (ctx->next_block != NULL ||
+                ctx->cur_block->instructions->prev->value != (void *)instr)
+            {
+                jitEmitBranchLocal(ctx, hccJitEpilogueLocalNum(jit, ctx->fn));
+            }
             break;
 
         case IR_TRUNC: case IR_ZEXT: case IR_SEXT:
@@ -1763,6 +1770,10 @@ static const HccJitBackend aarch64_jit_backend = {
 
 HccJit *aarch64JitCompile(Cctrl *cc) {
     return hccJitCompile(cc, &aarch64_jit_backend);
+}
+
+const HccJitBackend *aarch64JitBackend(void) {
+    return &aarch64_jit_backend;
 }
 
 #endif /* __aarch64__ && HCC_ENABLE_JIT */

--- a/src/aarch64-jit.h
+++ b/src/aarch64-jit.h
@@ -18,4 +18,8 @@
  * hccJitLookup / hccJitFree on the result. */
 HccJit *aarch64JitCompile(Cctrl *cc);
 
+/* The backend vtable, for incremental compilation via hccJitNew /
+ * hccJitCompileChunk (the REPL). NULL on non-aarch64 hosts. */
+const HccJitBackend *aarch64JitBackend(void);
+
 #endif

--- a/src/asm/CMakeLists.txt
+++ b/src/asm/CMakeLists.txt
@@ -2,6 +2,8 @@ set(TASM_SOURCES
     asm.c
     asm_enc.c
     asm_jit.c
+    dis_arm64.c
+    dis_x86_64.c
     enc_arm64.c
     enc_x86_64.c
     target.c
@@ -13,6 +15,8 @@ set(TASM_HEADERS
     asm.h
     asm_enc.h
     asm_jit.h
+    dis_arm64.h
+    dis_x86_64.h
     enc_arm64.h
     enc_x86_64.h
     target.h

--- a/src/asm/Makefile
+++ b/src/asm/Makefile
@@ -11,7 +11,12 @@ LIB_OBJS = $(OUT)/asm.o $(OUT)/asm_enc.o $(OUT)/asm_jit.o $(OUT)/enc_arm64.o \
 		   $(OUT)/enc_x86_64.o $(OUT)/macho.o $(OUT)/target.o \
 		   $(OUT)/tasm_util.o $(OUT)/tasm_debug.o $(OUT)/test-helper.o
 
-$(OUT)/%.o: %.c
+# Every object depends on every header: cheap at this size, and a
+# changed struct layout (e.g. AsmJitCode) must rebuild the test .o's
+# too or they smash the stack with the old sizeof.
+HDRS := $(wildcard *.h)
+
+$(OUT)/%.o: %.c $(HDRS)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 test_aarch64: $(LIB_OBJS) $(OUT)/test_aarch64.o
@@ -31,20 +36,6 @@ SRC_ALL = asm.c asm_enc.c asm_jit.c enc_arm64.c enc_x86_64.c macho.c \
           target.c tasm_util.c tasm_debug.c test_jit.c test-helper.c
 test_jit_x86: $(SRC_ALL)
 	$(CC) -arch x86_64 $(CFLAGS) -o $@ $(SRC_ALL)
-
-$(OUT)/asm.o: asm.c asm.h
-$(OUT)/asm_enc.o: asm_enc.c asm_enc.h
-$(OUT)/asm_jit.o: asm_jit.c asm_jit.h
-$(OUT)/enc_arm64.o: enc_arm64.c enc_arm64.h
-$(OUT)/enc_x86_64.o: enc_x86_64.c enc_x86_64.h
-$(OUT)/macho.o: macho.c macho.h
-$(OUT)/target.o: target.c target.h
-$(OUT)/tasm_util.o: tasm_util.c tasm_util.h
-$(OUT)/tasm_debug.o: tasm_debug.c
-$(OUT)/test_aarch64.o: test_aarch64.c
-$(OUT)/test_x86_64.o: test_x86_64.c
-$(OUT)/test_jit.o: test_jit.c
-$(OUT)/test_helper.o: test_helper.c
 
 clean:
 	rm -rf *.o

--- a/src/asm/asm_jit.c
+++ b/src/asm/asm_jit.c
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
 #include <sys/mman.h>
@@ -248,6 +249,22 @@ x86_64_emit_veneer(uint8_t *p, void *target)
     p[12] = 0xE3; /* modrm: mod=3 reg=4 rm=3 (r11&7) */
 }
 
+/* One veneer per distinct out-of-range target per mapping: every call
+ * site branching to the same symbol (printf, memcpy, ...) shares a
+ * trampoline. Linear scan - fixup counts are small. */
+struct VeneerSlot {
+    void *target;
+    void *veneer;
+};
+
+static void *
+veneer_lookup(const struct VeneerSlot *vmap, int n, void *target)
+{
+    for (int i = 0; i < n; i++)
+        if (vmap[i].target == target) return vmap[i].veneer;
+    return NULL;
+}
+
 int
 asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
                  AsmJitCode *out)
@@ -256,6 +273,7 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
 
     out->code = NULL;
     out->size = 0;
+    out->veneer_size = 0;
     out->_mapping = NULL;
     out->_mapping_size = 0;
     if (enc->len == 0) return 0;
@@ -301,6 +319,15 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
     uint8_t *buf = (uint8_t *)mem;
     size_t veneer_off = enc->len; /* next free veneer slot */
     int rc = 0;
+
+    /* Dedup table, sized for the worst case of one veneer per fixup.
+     * A failed allocation just disables sharing - veneers are then
+     * emitted per call site, which is correct, only bigger. */
+    struct VeneerSlot *vmap = NULL;
+    int n_vmap = 0;
+    if (max_a64_veneers + max_x86_veneers > 0)
+        vmap = calloc((size_t)(max_a64_veneers + max_x86_veneers),
+                      sizeof(*vmap));
 
     for (int i = 0; i < enc->n_fixups; i++) {
         AsmFixup *f = &enc->fixups[i];
@@ -367,13 +394,20 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
                 int is_bl = (f->reloc == AFR_AARCH64_CALL26);
                 prc = aarch64_patch_branch26(buf, f->patch_offset, target, is_bl);
                 if (prc != 0) {
-                    /* Target out of +/-128MB. Emit a veneer at the end of
-                     * the mapping that loads the full 64-bit target into
-                     * x16 and `br`s to it; then re-patch the original
-                     * BL/B to jump to the veneer instead. */
-                    void *vp = buf + veneer_off;
-                    aarch64_emit_veneer(vp, target);
-                    veneer_off += AARCH64_VENEER_BYTES;
+                    /* Target out of +/-128MB. Re-point the BL/B at a
+                     * veneer at the end of the mapping that loads the
+                     * full 64-bit target into x16 and `br`s to it -
+                     * reusing an already-emitted one for this target. */
+                    void *vp = vmap ? veneer_lookup(vmap, n_vmap, target)
+                                    : NULL;
+                    if (vp == NULL) {
+                        vp = buf + veneer_off;
+                        aarch64_emit_veneer(vp, target);
+                        veneer_off += AARCH64_VENEER_BYTES;
+                        if (vmap)
+                            vmap[n_vmap++] =
+                                (struct VeneerSlot){ target, vp };
+                    }
                     prc = aarch64_patch_branch26(buf, f->patch_offset, vp, is_bl);
                 }
                 break;
@@ -393,15 +427,23 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
             case AFR_X86_64_SIGNED:
                 prc = x86_64_patch_rel32(buf, f->patch_offset, target);
                 if (prc != 0 && f->reloc != AFR_X86_64_SIGNED) {
-                    /* Target out of +/-2GB. Emit a movabs+jmp veneer and
-                     * redirect the CALL/JMP/Jcc to it.
+                    /* Target out of +/-2GB. Redirect the CALL/JMP/Jcc to
+                     * a movabs+jmp veneer, reusing an already-emitted
+                     * one for this target.
                      *
                      * SIGNED (LEA RIP-rel) can't go through a veneer -
                      * we'd be loading the wrong address - so we surface
                      * that error directly to the caller. */
-                    void *vp = buf + veneer_off;
-                    x86_64_emit_veneer(vp, target);
-                    veneer_off += X86_64_VENEER_BYTES;
+                    void *vp = vmap ? veneer_lookup(vmap, n_vmap, target)
+                                    : NULL;
+                    if (vp == NULL) {
+                        vp = buf + veneer_off;
+                        x86_64_emit_veneer(vp, target);
+                        veneer_off += X86_64_VENEER_BYTES;
+                        if (vmap)
+                            vmap[n_vmap++] =
+                                (struct VeneerSlot){ target, vp };
+                    }
                     prc = x86_64_patch_rel32(buf, f->patch_offset, vp);
                 }
                 break;
@@ -417,6 +459,7 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
             break;
         }
     }
+    free(vmap);
 
 #if APPLE_SILICON_JIT
     pthread_jit_write_protect_np(1);
@@ -448,6 +491,7 @@ asm_jit_finalize(AsmEnc *enc, asm_jit_resolver_fn resolver, void *ud,
 
     out->code = mem;
     out->size = enc->len;
+    out->veneer_size = veneer_off - enc->len;
     out->_mapping = mem;
     out->_mapping_size = map_size;
     return 0;
@@ -460,6 +504,7 @@ asm_jit_free(AsmJitCode *code)
     munmap(code->_mapping, code->_mapping_size);
     code->code = NULL;
     code->size = 0;
+    code->veneer_size = 0;
     code->_mapping = NULL;
     code->_mapping_size = 0;
 }
@@ -468,32 +513,65 @@ asm_jit_free(AsmJitCode *code)
 #define RTLD_DEFAULT ((void *) 0)
 #endif
 
+/* PRINTREG's runtime helpers live in tasm_debug.c. Nothing in hcc calls
+ * them, so without a direct reference the linker drops that archive
+ * member and the JIT can never resolve `PRINTREG`'s BL. Referencing them
+ * here both keeps them in the binary and resolves them directly - no
+ * dlsym/symtab scan, and platform-independent. The asm emitter branches
+ * to `_tasm_print_*` (Mach-O) or `tasm_print_*` (ELF), so match on the
+ * underscore-stripped C name. */
+void tasm_print_x(uint64_t, int);
+void tasm_print_w(uint32_t, int);
+void tasm_print_s(float, int);
+void tasm_print_d(double, int);
+void tasm_print_v(const void *, int, int, int, int);
+
+static void *jit_builtin_lookup(const char *sym) {
+    if (sym[0] == '_') sym++;
+    if (!strcmp(sym, "tasm_print_x")) return (void *)tasm_print_x;
+    if (!strcmp(sym, "tasm_print_w")) return (void *)tasm_print_w;
+    if (!strcmp(sym, "tasm_print_s")) return (void *)tasm_print_s;
+    if (!strcmp(sym, "tasm_print_d")) return (void *)tasm_print_d;
+    if (!strcmp(sym, "tasm_print_v")) return (void *)tasm_print_v;
+    return NULL;
+}
+
 void *
 asm_jit_dlsym_resolver(void *ud, const char *sym)
 {
     (void)ud;
     if (!sym) return NULL;
-    /* Try the name exactly as emitted first. On ELF/Linux a leading
-     * underscore can be part of the real symbol name - e.g. libtos's
+    void *builtin = jit_builtin_lookup(sym);
+    if (builtin) return builtin;
+#if defined(__APPLE__)
+    /* Mach-O mangles C names with a leading underscore, so the emitted
+     * `sym` is an ASM name whose C-level name is sym+1 - that's the
+     * form dlsym wants, so try it first. Querying dlsym with the exact
+     * form asks for a DIFFERENT C symbol that merely looks like the
+     * mangled spelling: dlsym("_Exit") finds C99 _Exit() in libSystem
+     * (terminate WITHOUT flushing stdio), shadowing libtos's Exit()
+     * and silently dropping buffered output on `Exit(0)` under the
+     * JIT. Hence exact-form dlsym is the LAST resort here, after the
+     * raw symbol-table scan that handles underscore-less Mach-O names
+     * (e.g. libtos's `Fs`). A deliberate `extern "c" _Exit` arrives
+     * already re-mangled as `__Exit`, so the first probe still
+     * resolves it correctly. */
+    void *p;
+    if (sym[0] == '_' && (p = dlsym(RTLD_DEFAULT, sym + 1))) return p;
+    if ((p = jit_macho_symtab_lookup(sym))) return p;
+    if (sym[0] == '_' && (p = jit_macho_symtab_lookup(sym + 1))) return p;
+    return dlsym(RTLD_DEFAULT, sym);
+#else
+    /* ELF: the name as emitted IS the real symbol name - e.g. libtos's
      * hand-rolled `_MALLOC`/`_FREE` trampolines are exported as
-     * `_MALLOC`/`_FREE` - so stripping it up front would break the
-     * lookup. */
+     * `_MALLOC`/`_FREE` - so try it verbatim first and only then the
+     * stripped form. */
     void *p = dlsym(RTLD_DEFAULT, sym);
     if (p) return p;
-    /* macOS emits C symbols with a leading underscore in asm while the
-     * matching dlsym lookup wants the unprefixed name, so fall back to
-     * the stripped form. */
     if (sym[0] == '_') {
         p = dlsym(RTLD_DEFAULT, sym + 1);
         if (p) return p;
     }
-#if defined(__APPLE__)
-    /* dlsym can't see underscore-less Mach-O names (e.g. hcc's global
-     * variables like libtos's `Fs`). Fall back to a raw symbol-table
-     * scan, trying the name as emitted and the unprefixed form. */
-    p = jit_macho_symtab_lookup(sym);
-    if (!p && sym[0] == '_') p = jit_macho_symtab_lookup(sym + 1);
-    if (p) return p;
-#endif
     return NULL;
+#endif
 }

--- a/src/asm/asm_jit.h
+++ b/src/asm/asm_jit.h
@@ -24,6 +24,9 @@ void *asm_jit_dlsym_resolver(void *ud, const char *sym);
 typedef struct {
     void *code;
     size_t size;
+    /* Bytes of out-of-range branch veneers emitted after `size` (the
+     * region [code+size, code+size+veneer_size) is live executable code). */
+    size_t veneer_size;
     void *_mapping;
     size_t _mapping_size;
 } AsmJitCode;

--- a/src/asm/dis_arm64.c
+++ b/src/asm/dis_arm64.c
@@ -1780,7 +1780,7 @@ aarch64_disasm(uint32_t insn, char *out, size_t outsz)
 }
 
 void
-aarch64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
+aarch64_disasm_buf_at(const uint8_t *bytes, size_t len, uint64_t base, FILE *f)
 {
     if (!f) f = stdout;
     for (size_t off = 0; off + 4 <= len; off += 4) {
@@ -1790,6 +1790,16 @@ aarch64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
                         ((uint32_t)bytes[off + 3] << 24);
         char text[128];
         aarch64_disasm(insn, text, sizeof(text));
-        fprintf(f, "%4zu: %08x  %s\n", off, insn, text);
+        if (base)
+            fprintf(f, "0x%llx: %08x  %s\n",
+                    (unsigned long long)(base + off), insn, text);
+        else
+            fprintf(f, "%4zu: %08x  %s\n", off, insn, text);
     }
+}
+
+void
+aarch64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
+{
+    aarch64_disasm_buf_at(bytes, len, 0, f);
 }

--- a/src/asm/dis_arm64.h
+++ b/src/asm/dis_arm64.h
@@ -23,4 +23,10 @@ int aarch64_disasm(uint32_t insn, char *out, size_t outsz);
  * instruction, prefixed with byte offset and raw hex word. */
 void aarch64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f);
 
+/* Same, but a non-zero `base` replaces the offset column with the
+ * absolute address `base + off` (hex) - pass the buffer's runtime
+ * address to label JIT code with real addresses. base 0 == offsets. */
+void aarch64_disasm_buf_at(const uint8_t *bytes, size_t len, uint64_t base,
+                           FILE *f);
+
 #endif

--- a/src/asm/dis_x86_64.c
+++ b/src/asm/dis_x86_64.c
@@ -842,7 +842,7 @@ x86_64_disasm(const uint8_t *bytes, size_t len, char *out, size_t outsz)
 }
 
 void
-x86_64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
+x86_64_disasm_buf_at(const uint8_t *bytes, size_t len, uint64_t base, FILE *f)
 {
     if (!f) f = stdout;
     size_t off = 0;
@@ -850,11 +850,21 @@ x86_64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
         char text[128];
         int n = x86_64_disasm(bytes + off, len - off, text, sizeof(text));
         if (n <= 0) n = 1;
-        /* Print byte offset, the raw bytes, then the mnemonic. */
-        fprintf(f, "%4zu:", off);
+        /* Print byte offset (or base+off when a base is given), the raw
+         * bytes, then the mnemonic. */
+        if (base)
+            fprintf(f, "0x%llx:", (unsigned long long)(base + off));
+        else
+            fprintf(f, "%4zu:", off);
         for (int i = 0; i < n; i++) fprintf(f, " %02x", bytes[off + i]);
         for (int i = n; i < 8; i++) fputs("   ", f);
         fprintf(f, "  %s\n", text);
         off += (size_t)n;
     }
+}
+
+void
+x86_64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f)
+{
+    x86_64_disasm_buf_at(bytes, len, 0, f);
 }

--- a/src/asm/dis_x86_64.h
+++ b/src/asm/dis_x86_64.h
@@ -25,4 +25,10 @@ int x86_64_disasm(const uint8_t *bytes, size_t len, char *out, size_t outsz);
  * prefixed with byte offset and raw hex. */
 void x86_64_disasm_buf(const uint8_t *bytes, size_t len, FILE *f);
 
+/* Same, but a non-zero `base` replaces the offset column with the
+ * absolute address `base + off` (hex) - pass the buffer's runtime
+ * address to label JIT code with real addresses. base 0 == offsets. */
+void x86_64_disasm_buf_at(const uint8_t *bytes, size_t len, uint64_t base,
+                          FILE *f);
+
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -2,6 +2,7 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <unistd.h>
 
 #include "aostr.h"
@@ -927,6 +928,13 @@ int astIsIntrinsicClass(AstType *ty) {
     return ty && ty->kind == AST_TYPE_CLASS && ty->is_intrinsic;
 }
 
+int astIsFnLike(Ast *maybe_fn) {
+    return maybe_fn && (maybe_fn->kind == AST_FUNC ||
+                        maybe_fn->kind == AST_ASM_FUNCDEF ||
+                        maybe_fn->kind == AST_FUN_PROTO ||
+                        maybe_fn->kind == AST_EXTERN_FUNC);
+}
+
 /* This is pretty gross to look at but, eliminated recursion */
 AstType *astGetResultType(AstBinOp op, AstType *a, AstType *b) {
     AstType *tmp;
@@ -1487,7 +1495,7 @@ AoStr *astTypeToColorAoStr(AstType *type) {
         str->data[str->len] = '\0';
     }
 
-    aoStrCatPrintf(buf,"\033[0;34m%s\033[0m",str->data);
+    aoStrCatPrintf(buf,ESC_BLUE"%s"ESC_RESET,str->data);
     if (star_count) {
         aoStrPutChar(buf, ' ');
         while (star_count > 0) {
@@ -1531,16 +1539,35 @@ static char *astParamsToString(Vec *params) {
             int is_last = i+1 == params->size;
             if (!param) break;
             if (param->kind == AST_VAR_ARGS) {
-                if (!is_last) aoStrCatPrintf(str,"..., ");
-                else          aoStrCatPrintf(str,"..."); 
+                if (!is_last) aoStrCatFmt(str,"..., ");
+                else          aoStrCatFmt(str,"..."); 
             } else {
-                tmp = astTypeToString(param->type);
-                if (!is_last) aoStrCatPrintf(str,"%s, ",tmp);
-                else          aoStrCatPrintf(str,"%s",tmp); 
+                char *label = astLValueToString(param,0);
+                AoStr *tmp = astTypeToColorAoStr(param->type);
+                if (astTypeIsPtr(param->type)) {
+                    /* We don't want spaces between the stars */
+                    if (!is_last && label) aoStrCatFmt(str,"%S%s, ",tmp, label);
+                    else if (!is_last && !label) aoStrCatFmt(str,"%S, ",tmp);
+                    else if (label)              aoStrCatFmt(str,"%S%s",tmp, label);     
+                    else                         aoStrCatFmt(str,"%S",tmp); 
+                } else {
+                    if (!is_last && label) aoStrCatFmt(str,"%S %s, ",tmp, label);
+                    else if (!is_last && !label) aoStrCatFmt(str,"%S, ",tmp);
+                    else if (label)              aoStrCatFmt(str,"%S% s",tmp, label);     
+                    else                         aoStrCatFmt(str,"%S",tmp); 
+                }
             }
         }
     }
     return aoStrMove(str);
+}
+
+static char *astExternCToString(void) {
+    if (!isatty(STDOUT_FILENO)) {
+        return "extern \"c\"";
+    } else {
+        return ESC_BLUE"extern"ESC_RESET ESC_GREEN" \"c\""ESC_RESET;
+    }
 }
 
 static char *astFunctionToStringInternal(Ast *func, AstType *type) {
@@ -1548,6 +1575,9 @@ static char *astFunctionToStringInternal(Ast *func, AstType *type) {
     char *strparams = NULL;
 
     AoStr *tmp = astTypeToColorAoStr(type);
+    if (func->kind == AST_EXTERN_FUNC) {
+        aoStrCatPrintf(str,"%s ", astExternCToString());
+    }
     if (tmp->data[tmp->len - 1] == '*') {
         aoStrCatPrintf(str,"%s%s",tmp->data,func->fname->data);
     } else {
@@ -1563,6 +1593,7 @@ static char *astFunctionToStringInternal(Ast *func, AstType *type) {
 
         case AST_FUNC:
         case AST_FUN_PROTO:
+        case AST_EXTERN_FUNC:
             strparams = astParamsToString(func->params);
             break;
         default:
@@ -1571,9 +1602,9 @@ static char *astFunctionToStringInternal(Ast *func, AstType *type) {
     }
 
     if (strparams) {
-        aoStrCatPrintf(str,"(%s)",strparams);
+        aoStrCatPrintf(str,"(%s);",strparams);
     } else {
-        aoStrCatPrintf(str,"(U0)");
+        aoStrCatPrintf(str,"(U0);");
     }
     return aoStrMove(str);
 }
@@ -2617,4 +2648,76 @@ const char *astKindToHumanReadable(Ast *ast) {
         case AST_UNOP: return "unary op";
         default: return "unknown AST kind";
     }
+}
+
+static void astClassFieldsToString(Map *fields,
+                                   Set *seen,
+                                   char *clsname,
+                                   AoStr *buf,
+                                   s64 *indent)
+{
+    /* Fields */
+    MapIter it;
+    mapIterInit(fields, &it);
+    while (mapIterNext(&it)) {
+        MapNode *n = it.node;
+        AstType *field = n->value;
+        char *field_name = n->key;
+        
+        /* So we do not double up. This code is very similar to that in
+         * transpile.c */
+        if (setHasLen(seen,n->key,n->key_len))
+            continue;
+
+        aoStrCatRepeat(buf, " ", *indent);
+        if (!strncmp(field_name, str_lit("cls_label "))) {
+            if (field->kind == AST_TYPE_UNION) {
+                aoStrCatFmt(buf, "%sunion {%s\n", clr(ESC_BLUE), clr(ESC_RESET));
+            } else {
+                aoStrCatFmt(buf, "%sclass%s {\n", clr(ESC_BLUE), clr(ESC_RESET));
+            }
+            *indent += 2;
+            astClassFieldsToString(field->fields,seen,clsname,buf,indent);
+            *indent -= 2;
+            aoStrCatRepeat(buf, " ", *indent);
+            aoStrCatLen(buf, str_lit("};\n"));
+        } else {
+            AoStr *ty_str = astTypeToColorAoStr(field);
+            if (astTypeIsPtr(field)) {
+                aoStrCatFmt(buf, "%S%s;\n", ty_str, field_name);
+            } else {
+                aoStrCatFmt(buf, "%S %s;\n", ty_str, field_name);
+            }
+            aoStrRelease(ty_str);
+        }
+        setAdd(seen, field_name);
+    }
+}
+
+/* An accurate HolyC printing of a class i.e;
+ * ```
+ * class Foo
+ * {
+ *   I64 x;
+ *   I64 y;
+ * };
+ * ```
+ * Can't preserve commas for definitions of fields.
+ * */
+AoStr *astClassToAoStr(AstType *cls) {
+    AoStr *s = aoStrNew();
+    if (cls->kind == AST_TYPE_UNION) {
+        aoStrCatFmt(s, "%sunion%s %S\n", clr(ESC_BLUE), clr(ESC_RESET), cls->clsname);
+    } else {
+        aoStrCatFmt(s, "%sclass%s %S\n", clr(ESC_BLUE), clr(ESC_RESET), cls->clsname);
+    }
+    aoStrCatFmt(s, "{\n");
+    /* Due to our rather hammer approach to parsing classes we will never have
+     * a nested class or struct with duplicate field names. So one `Set` will
+     * suffice. Else we'd need one set for each depth. */
+    Set *seen = setNew(16,&set_cstring_type);
+    s64 indent = 2;
+    astClassFieldsToString(cls->fields,seen,cls->clsname->data,s,&indent);
+    aoStrCatFmt(s, "};");
+    return s;
 }

--- a/src/ast.h
+++ b/src/ast.h
@@ -583,6 +583,8 @@ int astIsBinOpKind(Ast *ast, AstBinOp op);
 
 int astIsBinOpCmp(Ast *ast);
 
+int astIsFnLike(Ast *maybe_fn);
+
 AoStr *astMakeLabel(void);
 AoStr *astMakeTmpName(void);
 Ast *astGlobalCmdArgs(void);
@@ -612,6 +614,7 @@ char *astToString(Ast *ast);
 AoStr *astToAoStr(Ast *ast);
 char *astLValueToString(Ast *ast, u64 lexme_flags);
 AoStr *astLValueToAoStr(Ast *ast, u64 lexeme_flags);
+AoStr *astClassToAoStr(AstType *cls);
 void astPrint(Ast *ast);
 void astTypePrint(AstType *type);
 void astKindPrint(int kind);

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -140,6 +140,11 @@ static void cctrlAddMacOsDefines(Cctrl *cc, Lexeme *le) {
     mapAdd(cc->macro_defs,"IS_MACOS",le);
 }
 
+void cctrlAddDefine(Cctrl *cc, char *name) {
+    Lexeme *le = lexemeSentinal();
+    mapAdd(cc->macro_defs,name,le);
+}
+
 static void cctrlAddBuiltinMacros(Cctrl *cc) {
     s64 bufsize = sizeof(char)*128;
     Lexeme *le = lexemeSentinal();
@@ -266,10 +271,16 @@ Cctrl *cctrlNew(enum CliTarget target) {
     cc->tmp_loop_begin = NULL;
     cc->tmp_loop_end = NULL;
     cc->tmp_func = NULL;
+    cc->tmp_gvar_decl = NULL;
     cc->token_buffer = NULL;
     cc->diagnostics = vecNew(&vec_diagnostic_type);
     cc->n_errors = 0;
     cc->current_recovery = NULL;
+    /* main() overwrites the first two with the CLI's lists; `#link`
+     * appends to all three during lexing (creating on demand). */
+    cc->object_files = NULL;
+    cc->shared_object_files = NULL;
+    cc->link_libs = NULL;
 
     int len;
     AoStr **str_array = aoStrSplit(x86_registers,',',&len);
@@ -776,10 +787,18 @@ void cctrlInfo(Cctrl *cc, char *fmt, ...) {
 void cctrlWarning(Cctrl *cc, char *fmt, ...) {
     va_list ap;
     va_start(ap,fmt);
-    AoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_WARN);
+    /* If we are in a repl we are super conservative and treat warnings
+     * as errors. This is so the reepl is _less_ likey to crash.
+     * A bit like -Werror in C */
+    int is_werror = cc->flags & (CCTRL_WERROR);
+    int severity = is_werror ? CCTRL_ERROR : CCTRL_WARN;
+    AoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,severity);
     va_end(ap);
-    CctrlDiagnostic *d = cctrlMakeDiag(cc, CCTRL_WARN, buf, NULL);
+    CctrlDiagnostic *d = cctrlMakeDiag(cc, severity, buf, NULL);
     cctrlDiagPush(cc, d);
+    if (severity == CCTRL_ERROR) {
+        cctrlTerminate(cc);
+    }
 }
 
 /* Like cctrlWarning, but anchored at an explicit (line, col) instead of
@@ -794,12 +813,14 @@ void cctrlWarningAt(Cctrl *cc, s64 lineno, s64 col, s64 len, char *fmt, ...) {
     va_end(ap);
     AoStr *bold_msg = aoStrNew();
     aoStrCatColoured(bold_msg, ESC_BOLD, msg);
+    int is_werror = cc->flags & (CCTRL_WERROR);
+    int severity = is_werror ? CCTRL_ERROR : CCTRL_WARN;
     AoStr *rendered = cctrlCreateErrorLineAt(cc, lineno, col, len,
-                                             bold_msg->data, CCTRL_WARN, NULL);
+                                             bold_msg->data, severity, NULL);
     aoStrRelease(bold_msg);
 
     CctrlDiagnostic *d = (CctrlDiagnostic *)calloc(1, sizeof(CctrlDiagnostic));
-    d->severity = CCTRL_WARN;
+    d->severity = severity;
     d->message = rendered;
     d->suggestion = NULL;
     d->file = cc->lexer_ ? cc->lexer_->cur_file : NULL;
@@ -808,6 +829,9 @@ void cctrlWarningAt(Cctrl *cc, s64 lineno, s64 col, s64 len, char *fmt, ...) {
     d->end_line = (int)lineno;
     d->end_col = (int)(col + (len > 0 ? len : 1));
     cctrlDiagPush(cc, d);
+    if (severity == CCTRL_ERROR) {
+        cctrlTerminate(cc);
+    }
 }
 
 CctrlDiagnostic *cctrlMakeDiag(Cctrl *cc,
@@ -861,6 +885,35 @@ int cctrlDiagFlush(Cctrl *cc) {
         }
     }
     return cc->n_errors;
+}
+
+/* Drop all queued diagnostics and reset the error count. The REPL
+ * calls this between inputs so one bad line doesn't poison (or
+ * re-print with) the next. */
+void cctrlDiagClear(Cctrl *cc) {
+    if (!cc) return;
+    if (cc->diagnostics) vecClear(cc->diagnostics);
+    cc->n_errors = 0;
+}
+
+/* Empty the token ring buffer. After an errored parse the buffer can
+ * still hold tokens from the abandoned input; a fresh REPL parse must
+ * not see them. The freed slots are filled with a sentinel rather
+ * than NULL: parsePrimary rewinds one token to inspect what preceded
+ * an expression, and when the expression opens the input that step
+ * walks into the ring's history - which must therefore always hold
+ * valid lexemes. */
+void cctrlResetTokenBuffer(Cctrl *cc) {
+    TokenRingBuffer *ring = cc->token_buffer;
+    if (!ring) return;
+    static Lexeme *filler = NULL;
+    if (filler == NULL) filler = lexemeSentinal();
+    ring->tail = 0;
+    ring->head = 0;
+    ring->size = 0;
+    for (s64 i = 0; i < ring->capacity; ++i) {
+        ring->entries[i] = filler;
+    }
 }
 
 __noreturn void cctrlTerminate(Cctrl *cc) {
@@ -1014,9 +1067,15 @@ void cctrlRewindUntilPunctMatch(Cctrl *cc, s64 ch, int *_count) {
 void cctrlRewindUntilStrMatch(Cctrl *cc, char *str, int len, int *_count) {
     int count = 0;
     Lexeme *peek = cctrlTokenPeek(cc);
-    while (!(peek->len == len && memcmp(peek->start,str,len) == 0)) {
+    /* `peek` is NULL when the ring is fully drained. A single line
+     * input will hit this when the error fires at the end of a statement.
+     * */
+    while (peek == NULL ||
+           !(peek->len == len && memcmp(peek->start,str,len) == 0)) {
         cctrlTokenRewind(cc);
-        peek = cctrlTokenPeek(cc);
+        Lexeme *new_peek = cctrlTokenPeek(cc);
+        if (new_peek == peek) break;
+        peek = new_peek;
         count++;
         if (count > 5) break; // has to be some limit
     }
@@ -1122,15 +1181,20 @@ void cctrlRaiseExceptionFromTo(Cctrl *cc, char *suggestion, char from, char to, 
 void cctrlWarningFromTo(Cctrl *cc, char *suggestion, char from, char to, char *fmt, ...) {
     va_list ap;
     va_start(ap,fmt);
-    AoStr *buf = cctrlRaiseFromTo(cc,CCTRL_WARN,suggestion,from,to,fmt,ap);
+    int is_werror = cc->flags & (CCTRL_WERROR);
+    int severity = is_werror ? CCTRL_ERROR : CCTRL_WARN;
+    AoStr *buf = cctrlRaiseFromTo(cc,severity,suggestion,from,to,fmt,ap);
     va_end(ap);
 
     /* Warnings accumulate but never longjmp as the parser keeps going.
      * `cctrlDiagFlush(...)` prints them alongside the errors at the end of
      * compilation. */
     AoStr *sug = suggestion ? aoStrPrintf("%s", suggestion) : NULL;
-    CctrlDiagnostic *d = cctrlMakeDiag(cc, CCTRL_WARN, buf, sug);
+    CctrlDiagnostic *d = cctrlMakeDiag(cc, severity, buf, sug);
     cctrlDiagPush(cc, d);
+    if (severity == CCTRL_ERROR) {
+        cctrlTerminate(cc);
+    }
 }
 
 /* Get variable either from the local or global scope */
@@ -1215,24 +1279,4 @@ Ast *cctrlGetOrSetString(Cctrl *cc, char *str, int len, s64 real_len) {
         ast_str = astString(str,len,real_len);
     }
     return ast_str;
-}
-
-int cctrlfPIC(Cctrl *cc) {
-    return cc->is_pic;
-}
-
-int cctrlTargetLinux(Cctrl *cc) {
-    static int is_linux = -1;
-    if (is_linux != -1) return is_linux;
-    switch (cc->target) {
-        case TARGET_AARCH64_APPLE_DARWIN:
-        case TARGET_X86_64_APPLE_DARWIN:
-            is_linux = 0;
-            break;
-        case TARGET_AARCH64_UNKNOWN_LINUX_GNU:
-        case TARGET_X86_64_UNKNOWN_LINUX_GNU:
-            is_linux = 1;
-            break;
-    }
-    return is_linux;
 }

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -25,6 +25,16 @@
  * legacy path will be deleted once the IR backend has full unit-
  * test coverage; until then this flag stays as a debugging tool. */
 #define CCTRL_USE_LEGACY_X86       (1<<5)
+/* REPL mode: re-defining a function replaces the previous definition
+ * instead of raising "Cannot redefine function", and floating
+ * expressions (`2+2;`, `(x*3);`) are legal at the top level so they
+ * can be evaluated and echoed. */
+#define CCTRL_REPL                 (1<<6)
+/* Treat warnings as errors */
+#define CCTRL_WERROR               (1<<7)
+/* Create wrappers over MAlloc/Free and friends for tracking allocations
+ * JIT only presently */
+#define CCTRL_MEMSAFE              (1<<8)
 
 /* For messages */
 #define CCTRL_ICE   0
@@ -134,6 +144,12 @@ typedef struct Cctrl {
     /* Function being parsed */
     Ast *tmp_func;
 
+    /* Global variable whose declaration is mid-parse. If the
+     * initialiser errors, top-level recovery unregisters it from
+     * global_env. Otherwise later code could name a variable whose
+     * storage (the AST_DECL) was rolled back. */
+    Ast *tmp_gvar_decl;
+
     /* When parsing & converting to assembly these keep a reference to the
      * current loop's labels */
     AoStr *tmp_loop_begin;
@@ -186,12 +202,18 @@ typedef struct Cctrl {
     /* Are we compiling position independent code? */
     int is_pic;
 
-    /* .so files that may have been passed on the commandline, these should
-     * be usable with the JIT */
+    /* .so files that may have been passed on the commandline or recorded
+     * by a `#link "<path>"` directive, these should be usable with the
+     * JIT */
     List *shared_object_files;
 
     /* .o files that may have been passed on the commandline */
     List *object_files;
+
+    /* Library names recorded by `#link <name>` directives. AOT passes
+     * each as `-l<name>` to the linker; the JIT probes
+     * lib<name>.{dylib,so} with dlopen. */
+    List *link_libs;
 } Cctrl;
 
 /* Instantiate a new compiler control struct */
@@ -243,6 +265,11 @@ void cctrlDiagPush(Cctrl *cc, CctrlDiagnostic *d);
 /* prints every queued diagnostic to stderr (in source order) and returns the
  * number of CCTRL_ERROR entries. */
 int cctrlDiagFlush(Cctrl *cc);
+/* Drop queued diagnostics and reset the error count (REPL: between inputs). */
+void cctrlDiagClear(Cctrl *cc);
+/* Empty the token ring buffer so a fresh parse doesn't consume tokens
+ * left over from a previous (possibly errored) one. */
+void cctrlResetTokenBuffer(Cctrl *cc);
 
 /* Build a CctrlDiagnostic from a pre-rendered message and the current source
  * position. Takes ownership of `rendered` and `suggestion`. */
@@ -274,9 +301,6 @@ void cctrlSyncStatement(Cctrl *cc);
 
 Map *cctrlCreateAstMap(Map *parent);
 Map *cctrlCreateLexemeMap(void);
-/* True/False for whether this is position independent code */
-int cctrlfPIC(Cctrl *cc);
-/* Are we targeting linux? */
-int cctrlTargetLinux(Cctrl *cc);
+void cctrlAddDefine(Cctrl *cc, char *name);
 
 #endif // !CCTRL_H

--- a/src/cli.c
+++ b/src/cli.c
@@ -103,6 +103,7 @@ static CliParser parsers[] = {
     {str_lit("-cfg-png"),   0, CLI_CFG_CREATE_PNG, "-cfg-svg", "Create graphviz control flow graph as a PNG", &cliParseNop},
     {str_lit("-cfg-svg"),   0, CLI_CFG_CREATE_SVG, "-cfg-png", "Create graphviz control flow graph as a SVG", &cliParseNop},
     {str_lit("-tokens"),    0, CLI_PRINT_TOKENS, "-tokens", "Print the tokens and exit", &cliParseNop},
+    CliNopParser("-Werror", CLI_WERROR, "-Werror all warnings are treated as errors"),
     {str_lit("-S"),         0, CLI_ASSEMBLE_ONLY, "-S", "Emit assembly only", &cliParseNop},
     {str_lit("-obj"),       0, CLI_EMIT_OBJECT, "DEPRICATED use `-c` instead! -obj", "Emit an objectfile", &cliParseNop},
     {str_lit("-c"),         0, CLI_EMIT_OBJECT, "-o", "Emit an objectfile", &cliParseNop},
@@ -111,6 +112,8 @@ static CliParser parsers[] = {
     {str_lit("-clibs"),     1, CLI_CLIBS, "-clibs", "Link c libraries like: -clibs=`-lSDL2 -lxml2 -lcurl...`", &cliParseString},
     {str_lit("-run"),       0, CLI_RUN, "-run", "Immediately run the file (not JIT)", &cliParseNop},
     {str_lit("-jit"),       0, CLI_JIT, "-jit", "JIT-compile and run main() in-process (aarch64 & x86_64)", &cliParseNop},
+    {str_lit("-Memsafe"),   0, CLI_MEMSAFE, "-Memsafe", "With -jit: track MAlloc/Free, report double/wild frees and leaks at exit (the REPL always tracks)", &cliParseNop},
+    {str_lit("-repl"),      0, CLI_REPL, "-repl", "Start an interactive HolyC REPL on top of the JIT (aarch64 & x86_64)", &cliParseNop},
     {str_lit("-o"),         1, CLI_OUTPUT_FILENAME, "-o <binary_name>", "Output filename: `-o <name> ./<file>.HC`", &cliParseString},
     {str_lit("-o-"),        0, CLI_TO_STDOUT, "-o-", "Output assembly to stdout, only for use with -S", &cliParseNop},
     {str_lit("-transpile"), 0, CLI_TRANSPILE, "-transpile", "Transpile the code to C, this is best effort", &cliParseNop},
@@ -321,6 +324,10 @@ enum CliFileType cliGetFileType(char *filename, u64 filename_len) {
         return HC_OBJECT;
     } else if (tolower(*end) == 'o' && *(end-1) == 's' && *(end-2) == '.') {
         return HC_SHARED_OBJECT;
+    } else if (filename_len >= 7 && *(end-5) == '.' && *(end-4) == 'd' &&
+                                    *(end-3) == 'y' && *(end-2) == 'l' && 
+                                    *(end-1) == 'i' && *end     == 'b') {
+        return HC_SHARED_OBJECT;
     } else {
         return HC_INVALID;
     }
@@ -432,6 +439,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
             case CLI_CFG_CREATE_SVG:     args->cfg_create_svg = 1; break;
             case CLI_ASM_DEBUG_COMMENTS: args->asm_debug_comments = 1; break;
             case CLI_ASSEMBLE_ONLY:      args->assemble_only = 1; break;
+            case CLI_WERROR:             args->werror = 1; break;
             case CLI_EMIT_DYLIB: {
                 args->emit_dylib = 1;
                 args->lib_name = mprintf("%s",value.str);
@@ -441,6 +449,8 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
             case CLI_fPIC:               args->fPIC = 1; break;
             case CLI_RUN:                args->run = 1; break;
             case CLI_JIT:                args->jit = 1; break;
+            case CLI_MEMSAFE:            args->memsafe = 1; break;
+            case CLI_REPL:               args->repl = 1; break;
             case CLI_ASSEMBLE:           args->assemble = 1; break;
             case CLI_TRANSPILE:          args->transpile = 1; break;
             case CLI_TO_STDOUT:          args->to_stdout = 1; break;
@@ -497,7 +507,8 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
                  "printing assembly to stdout\n");
     }
 
-    if (args->infile == NULL) {
+    /* The REPL reads from stdin - it's the one mode with no input file. */
+    if (args->infile == NULL && !args->repl) {
         cliNoInputFiles();
     }
     return 1;

--- a/src/cli.h
+++ b/src/cli.h
@@ -37,10 +37,12 @@ enum CliArgType {
     CLI_HELP,
     CLI_INSTALL_DIR,
     CLI_JIT,
+    CLI_MEMSAFE,
     CLI_MEM_STATS,
     CLI_OUTPUT_FILENAME,
     CLI_PRINT_AST,
     CLI_PRINT_TOKENS,
+    CLI_REPL,
     CLI_RUN,
     CLI_TARGET,
     CLI_TERRY,
@@ -48,6 +50,7 @@ enum CliArgType {
     CLI_TRANSPILE,
     CLI_USE_LEGACY_X86,
     CLI_VERSION,
+    CLI_WERROR,
 };
 
 typedef struct CliValue {
@@ -84,11 +87,14 @@ typedef struct CliArgs {
     int emit_object;
     int run;
     int jit;
+    int memsafe;
+    int repl;
     int assemble;
     int transpile;
     int to_stdout;
     int use_legacy_x86;
     int fPIC;
+    int werror;
     char *infile;
     char *infile_no_ext;
     char *asm_outfile;

--- a/src/containers.c
+++ b/src/containers.c
@@ -53,9 +53,17 @@ static int vecAoStrMatch(void *s1, void *s2) {
     return aoStrEq((AoStr *)s1, (AoStr *)s2);
 }
 
-static void vecAoStrRelease(void *s) {
+static int vecAoStrRelease(void *s) {
     aoStrRelease((AoStr *)s);
+    return 1;
 }
+
+VecType vec_aostr_owned_type = {
+    .stringify = vecAoStrToString,
+    .match     = vecAoStrMatch,
+    .release   = vecAoStrRelease,
+    .type_str  = "`AoStr *",
+};
 
 /* `Vec<AoStr *>` opaque-ownership; backend retains the storage. */
 VecType vec_aostr_type = {
@@ -63,6 +71,39 @@ VecType vec_aostr_type = {
     .match     = vecAoStrMatch,
     .release   = NULL,
     .type_str  = "AoStr *",
+};
+
+int vecCStringMatch(void *_s1, void *_s2) {
+    char *s1 = (char *)_s1;
+    char *s2 = (char *)_s2;
+    long s1len = strlen(s1);
+    long s2len = strlen(s2);
+    return s1len == s2len && !memcmp(s1,s2,s1len);
+}
+
+static void vecCStringToString(AoStr *buf, void *_s) {
+    if (_s) aoStrCat(buf, (char *)_s);
+}
+
+/* `Vec<char *>` opaque-ownership; backend retains the storage. */
+VecType vec_cstring_type = {
+    .stringify = vecCStringToString,
+    .match     = vecCStringMatch,
+    .release   = NULL,
+    .type_str  = "char *",
+};
+
+int vecCStringFree(void *ptr) {
+    free(ptr);
+    return 1;
+}
+
+/* `Vec<char *>` opaque-ownership; backend retains the storage. */
+VecType vec_cstring_owned_type = {
+    .stringify = &vecCStringToString,
+    .match     = &vecCStringMatch,
+    .release   = &vecCStringFree,
+    .type_str  = "char *",
 };
 
 Vec *vecNew(VecType *type) {

--- a/src/containers.h
+++ b/src/containers.h
@@ -62,6 +62,8 @@ void vecPrint(Vec *vec);
 extern VecType vec_long_type;
 extern VecType vec_unsigned_long_type;
 extern VecType vec_aostr_type;
+extern VecType vec_cstring_type;
+extern VecType vec_cstring_owned_type;
 
 /*================== Generic MAP =============================================*/
 
@@ -207,6 +209,8 @@ struct SetNode {
 extern SetType set_aostr_type;
 extern SetType set_int_type;
 extern SetType set_uint_type;
+extern SetType set_cstring_type;
+extern SetType set_cstring_owned_type;
 
 struct Set {
     u64 size;

--- a/src/holyc-lib/date.HC
+++ b/src/holyc-lib/date.HC
@@ -209,3 +209,44 @@ CDate Now()
   cdt=Struct2Date(&ds);
   return cdt;
 }
+
+U0 CivilFromDays(I64 z, I64 *y, I64 *m, I64 *d)
+{
+  z += 719468; // shift epoch to 0000-03-01
+  I64 era;
+
+  if (z >= 0) {
+    era = z / 146097;
+  } else {
+    era = (z - 146096) / 146097;
+  }
+
+  I64 doe = z - era * 146097; // [0, 146096]
+  I64 yoe = (doe - doe/1460 + doe/36524 - doe/146096) / 365;
+  I64 yr  = yoe + era * 400;
+  I64 doy = doe - (365*yoe + yoe/4 - yoe/100); // [0, 365]
+  I64 mp  = (5*doy + 2) / 153;
+  *d = doy - (153*mp + 2)/5 + 1; // [1, 31]
+  // [1, 12]
+  if (mp < 10) {
+    *m = mp + 3;
+  } else {
+    *m = mp - 9;
+  }
+  *y = yr + (*m <= 2);
+}
+
+// Writes e.g. 2026-07-05T14:30:00.123456789Z  (UTC)
+U0 IsoFromTimespec(cTimespec *ts, U8 *buf)
+{
+  I64 sec = ts->tv_sec, nsec = ts->tv_nsec;
+  I64 days = sec / 86400, rem = sec % 86400;
+  if (rem < 0) {
+    rem += 86400;
+    days--;
+  }// floored div, for pre-1970
+  I64 hh = rem/3600, mm = rem%3600/60, ss = rem%60;
+  I64 y, mo, d;
+  CivilFromDays(days, &y, &mo, &d);
+  StrPrint(buf, "%04d-%02d-%02dT%02d:%02d:%02d.%09dZ", y, mo, d, hh, mm, ss, nsec);
+}

--- a/src/holyc-lib/io.HC
+++ b/src/holyc-lib/io.HC
@@ -76,6 +76,9 @@ extern "c" I64 read(I32 __fd, U0 *__buf, U64 __nbyte);
 extern "c" I64 write(I32 __fd, U0 *__buf, U64 __nbyte);
 extern "c" I64 lseek(I32 __fd, I64 __offset, I32 __whence);
 extern "c" I32 chdir(U8 *path);
+extern "c" I8 *getcwd(U8 *buf, U64 size);
+extern "c" I8 *getenv(U8 *buf);
+extern "c" I32 isatty(I32 fd);
 
 class iovec
 {
@@ -83,6 +86,83 @@ class iovec
   U64 iov_len;
 };
 
+/* Stantardise the stat function, though `tos.HH` also allows 
+ * calling the libc version. This is just much easier to use.
+ * With the added benifit of including when a file was created 
+ * for linux, which mac includes with `st_birthtimespec` */
+I32 Stat(Fstat *fst, U8 *pathname)
+{
+#if IS_LINUX
+  Statx stx;
+
+  #define AT_FDCWD -100
+  #define AT_STATX_SYNC_AS_STAT 0x0000
+  #define STATX_BTIME 0x0800U
+  #define STATX_ATIME 0x0020U
+  #define STATX_MTIME 0x0040U
+  #define STATX_CTIME 0x0080U
+
+  if (I32 ret = statx(AT_FDCWD, pathname, AT_STATX_SYNC_AS_STAT,
+        STATX_BTIME, &stx); ret != 0) {
+    return ret;
+  }
+
+  U64 st_dev = (stx.stx_dev_minor & 0xFF)           |
+               ((stx.stx_dev_major & 0xFFF) << 8)   |
+               ((stx.stx_dev_minor & ~0xFF)  << 12) |
+               ((stx.stx_dev_major & ~0xFFF) << 32);
+
+  U64 st_rdev = (stx.stx_rdev_minor & 0xFF)           |
+                ((stx.stx_rdev_major & 0xFFF) << 8)   |
+                ((stx.stx_rdev_minor & ~0xFF)  << 12) |
+                ((stx.stx_rdev_major & ~0xFFF) << 32);
+
+  fst->st_dev     = st_dev;
+  fst->st_ino     = stx.stx_ino;
+  fst->st_nlink   = stx.stx_nlink;
+  fst->st_mode    = stx.stx_mode;
+  fst->st_uid     = stx.stx_uid;
+  fst->st_gid     = stx.stx_gid;
+  fst->st_rdev    = st_rdev;
+  fst->st_size    = stx.stx_size;
+  fst->st_blksize = stx.stx_blksize;
+  fst->st_blocks  = stx.stx_blocks;
+  /* statx_timestamp's tv_nsec is a U32 followed by padding - copy
+   * field-wise rather than struct-wise into cTimespec. */
+  fst->st_atim.tv_sec  = stx.stx_atime.tv_sec;
+  fst->st_atim.tv_nsec = stx.stx_atime.tv_nsec;
+  fst->st_mtim.tv_sec  = stx.stx_mtime.tv_sec;
+  fst->st_mtim.tv_nsec = stx.stx_mtime.tv_nsec;
+  fst->st_ctim.tv_sec  = stx.stx_ctime.tv_sec;
+  fst->st_ctim.tv_nsec = stx.stx_ctime.tv_nsec;
+  fst->st_btim.tv_sec  = stx.stx_btime.tv_sec;
+  fst->st_btim.tv_nsec = stx.stx_btime.tv_nsec;
+
+#elif IS_MACOS
+  cStat st;
+  if (I32 ret = stat(pathname, &st); ret != 0) {
+    return ret;
+  }
+
+  fst->st_dev = st.st_dev;
+  fst->st_ino = st.st_ino;
+  fst->st_nlink = st.st_nlink;
+  fst->st_mode = st.st_mode;
+  fst->st_uid = st.st_uid;
+  fst->st_gid = st.st_gid;
+  fst->st_rdev = st.st_rdev;
+  fst->st_size = st.st_size;
+  fst->st_blksize = st.st_blksize;
+  fst->st_blocks = st.st_blocks;
+  fst->st_atim = st.st_atimespec;
+  fst->st_mtim = st.st_mtimespec;
+  fst->st_ctim = st.st_ctimespec;
+  fst->st_btim = st.st_birthtimespec;
+#else
+#error "Unknown platform"
+#endif
+  return 0;
+}
 
 public U8 *FileRead(U8 *path, I64 *_size=NULL)
 {
@@ -154,5 +234,159 @@ public Bool FileWrite(U8 *filename, U8 *buf, I64 size,
 
 public I32 Cd(U8 *path)
 {
-  return chdir(path);
+  U8 *new_path = NULL;
+  U64 len = StrLen(path);
+  if ((len == 1 && path[0] == '~') ||
+      (len == 2 && path[0] == '~' && path[1] == '/')) {
+    U8 *home = getenv("HOME");
+    home = StrNew(home);
+    new_path = home;
+  } else if (len >= 3 && path[0] == '~' && path[1] == '/') {
+    U8 *home = getenv("HOME");
+    U8 *p = path;
+    if (*(p + 2) != '\0') {
+      new_path = StrPrint(,"%s/%s",home,p+2);
+    } else {
+      new_path = StrPrint(,"%s",home);
+    }
+  } else {
+    new_path = path;
+  }
+  I32 ret_val = chdir(new_path);
+  if (new_path != path) {
+    Free(new_path);
+  }
+  return ret_val;
+}
+
+public U8 *Pwd(U8 *buf=NULL, U64 buf_size=0)
+{
+  return getcwd(buf, buf_size);
+}
+
+/* `ls`-style entry colours. */
+#define DIR_COL_DIR "\033[1;34m"  /* directory  - bold blue  */
+#define DIR_COL_LNK "\033[1;36m"  /* symlink    - bold cyan  */
+#define DIR_COL_EXE "\033[1;32m"  /* executable - bold green */
+#define DIR_COL_END "\033[0m"
+
+class DirHuman
+{
+  U8 *pathname;
+  U32 mode;  /* st_mode: file type + permission bits */
+  U8  type;  /* Dirent type - catches symlinks, which Stat() follows */
+};
+
+DirHuman *DirHumanNew(U8 *pathname, Fstat *fst, U8 type)
+{
+  DirHuman *dh = MAlloc(sizeof(DirHuman));
+  dh->pathname = pathname;
+  dh->mode = fst->st_mode;
+  dh->type = type;
+  return dh;
+}
+
+U0 DirHumanRelease(DirHuman *dh)
+{
+  if (dh) {
+    Free(dh->pathname);
+    Free(dh);
+  }
+}
+
+/* The colour `ls` would paint this entry, or NULL for plain. */
+U8 *DirHumanColor(DirHuman *dh)
+{
+  if (dh->type == DT_LNK) return DIR_COL_LNK;
+  if (dh->type == DT_DIR || (dh->mode & S_IFMT) == S_IFDIR) {
+    return DIR_COL_DIR;
+  }
+  if (dh->mode & (S_IXUSR|S_IXGRP|S_IXOTH)) return DIR_COL_EXE;
+  return NULL;
+}
+
+I64 CmpDirHuman(DirHuman *dh1, DirHuman *dh2)
+{
+  U8 *str1 = dh1->pathname;
+  U8 *str2 = dh2->pathname;
+  if ('0'<=*str1<='9' && '0'<=*str2<='9') {
+    I64 n1 = 0, n2 = 0;
+    while ('0'<=*str1<='9') {
+      n1 = (n1 * 10) + (*str1-'0');
+      str1++;
+    }
+    while ('0'<=*str2<='9') {
+      n2 = (n2 * 10) + (*str2-'0');
+      str2++;
+    }
+    return n2 > n1;
+  }
+  /* Non-numeric names: plain lexicographic order. */
+  return StrCmp(str1,str2) < 0;
+}
+
+U0 QSortDirHuman(U0 **arr, I64 high, I64 low=0)
+{
+  if (low < high) {
+    U0 *pivot = arr[high];
+    I64 idx = low;
+
+    for (I64 i = low; i < high; ++i) {
+      if (CmpDirHuman(arr[i],pivot)) {
+        U0 *tmp = arr[i];
+        arr[i] = arr[idx];
+        arr[idx] = tmp;
+        idx++;
+      }
+    }
+
+    arr[high] = arr[idx];
+    arr[idx] = pivot;
+    QSortDirHuman(arr,high,idx+1);
+    QSortDirHuman(arr,idx-1,low);
+  }
+}
+
+public I64 Dir(U8 *pathname = "./")
+{
+  auto dir = opendir(pathname);
+  if (!dir) return 0;
+  auto vec = PtrVecNew();
+  /* Strip a trailing '/' on a copy - the argument is often a string
+   * literal (the default!), and literals live in read-only memory. */
+  U8 *path = StrNew(pathname);
+  U64 len = StrLen(path);
+  if (len > 0 && path[len-1] == '/') {
+    path[len-1] = '\0';
+  }
+  Dirent *ent;
+  while ((ent = readdir(dir)) != NULL) {
+    if (!StrCmp(ent->name,".") || !StrCmp(ent->name,"..")) continue;
+    auto str = StrNew(ent->name);
+    auto full_path = StrPrint(,"%s/%s",path,ent->name);
+    Fstat fst;
+    if (Stat(&fst,full_path) == 0) {
+      DirHuman *dh = DirHumanNew(str, &fst, ent->type);
+      PtrVecPush(vec,dh);
+    } else {
+      Free(str);
+    }
+    Free(full_path);
+  }
+  Free(path);
+  QSortDirHuman(vec->entries(U0 **), vec->size-1);
+  closedir(dir);
+  Bool colors = isatty(1) != 0;
+  for (DirHuman *dh : vec) {
+    U8 *col = NULL;
+    if (colors) col = DirHumanColor(dh);
+    if (col) {
+      "%s%s"DIR_COL_END"\n", col, dh->pathname;
+    } else {
+      "%s\n", dh->pathname;
+    }
+  }
+  I64 nfiles = vec->size;
+  PtrVecRelease(vec,&DirHumanRelease);
+  return nfiles;
 }

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -730,18 +730,23 @@ U8 *MPrintQ(U8 *ptr,I64 flags = 0)
 U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
 {// @TempleOS - Not a 1:1 yet
   if (!fmt) return NULL;
-  U64 uintarg, curlen = 0, memsize;
+  U64 uintarg, curlen = 0;
   F64 farg;
   I64 ch, sp = 0, intarg, U8arg, len, flags, tlen,dec_len,aux_fmt_num;
   U8 *ptr, *strarg, *tmp, *dst, buf[256];
+  U8 **grow;
   CDate cdt;
 
+  /* Growth (SPutChar's MSize/Free dance) is only legal on a buffer WE
+   * MAlloc'd. A caller-provided dst may live on the stack or mid-array,
+   * where MSize reads garbage and Free aborts - so, as in TempleOS, the
+   * caller's buffer is trusted to be big enough and never grown. */
   if (_dst == NULL) {
     dst = MAlloc(STR_LEN);
-    memsize = STR_LEN;
+    grow = &dst;
   } else {
-    memsize = MSize(_dst);
     dst = _dst;
+    grow = NULL;
   }
 
   ptr = dst;
@@ -781,7 +786,7 @@ U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
 
       switch (*fmt++) {
         case '%': {
-          SPutChar(&ptr,'%',&dst);
+          SPutChar(&ptr,'%',grow);
           break;
         }
 
@@ -862,10 +867,10 @@ U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
           } while (k<sizeof(buf)-8);
 
           if (flags & PRTF_NEG) {
-            SPutChar(&ptr,'-',&dst);
+            SPutChar(&ptr,'-',grow);
           }
           for (I64 i = k-1;i>=0;--i) {
-            SPutChar(&ptr,buf[i],&dst);
+            SPutChar(&ptr,buf[i],grow);
           }
           break;
         }
@@ -929,21 +934,21 @@ U8 *StrPrintJoin(U8 *_dst, U8 *fmt,I64 argc,I64 *argv)
 
           if (flags & PRTF_PAD_ZERO) {
             if (flags & PRTF_NEG) {
-              SPutChar(&ptr,'-',&dst);
+              SPutChar(&ptr,'-',grow);
             }
             for (;idx < tlen-len; ++idx) {
-              SPutChar(&ptr,'0',&dst);
+              SPutChar(&ptr,'0',grow);
             }
           } else {
             for (;idx < tlen-len; ++idx) {
-              SPutChar(&ptr,CH_SPACE,&dst);
+              SPutChar(&ptr,CH_SPACE,grow);
             }
             if (flags&PRTF_NEG) {
-              SPutChar(&ptr,'-',&dst);
+              SPutChar(&ptr,'-',grow);
             }
           }
           for (idx = len - 1; idx >= 0; --idx) {
-            SPutChar(&ptr,buf[idx],&dst);
+            SPutChar(&ptr,buf[idx],grow);
           }
           break;
         }
@@ -972,15 +977,15 @@ place_hex:
 
           if (flags & PRTF_PAD_ZERO) {
             for (I64 idx = 0; idx < tlen-len; ++idx) {
-              SPutChar(&ptr,'0',&dst);
+              SPutChar(&ptr,'0',grow);
             }
           } else {
             for (I64 idx = 0; idx < tlen-len; ++idx) {
-              SPutChar(&ptr,CH_SPACE,&dst);
+              SPutChar(&ptr,CH_SPACE,grow);
             }
           }
           for (I64 idx = len - 1; idx >= 0; --idx) {
-            SPutChar(&ptr,buf[idx],&dst);
+            SPutChar(&ptr,buf[idx],grow);
           }
           break;
         }
@@ -994,11 +999,11 @@ place_hex:
 
         default:
           "Invalid format char: '%c'\n",*fmt;
-          SPutChar(&ptr,ch,&dst);
+          SPutChar(&ptr,ch,grow);
           break;
       }
     } else {
-      SPutChar(&ptr,ch,&dst);
+      SPutChar(&ptr,ch,grow);
     }
   }
   return dst;

--- a/src/holyc-lib/system.HC
+++ b/src/holyc-lib/system.HC
@@ -46,3 +46,33 @@ public I64 System(U8 *command)
   return system(command);
 }
 #endif
+
+/* Call the shell with `printf`-like formatting */
+public I32 Sh(U8 *fmt, ...)
+{
+  if (!fmt) return -1;
+  if (argc == 0) return System(fmt);
+  U8 *cmd = StrPrintJoin(NULL,fmt,argc,argv);
+  I32 retval = System(cmd);
+  Free(cmd);
+  return retval;
+}
+
+/* Capture whatever is printed to stdout in to a heap allocated buffer */
+public U8 *Shlurp(U8 *fmt, ...)
+{
+  if (!fmt) return -1;
+  if (argc == 0) return System(fmt);
+  /* We redirect stdout to a temporary file, read it and then return the
+   * contents */
+  U8 *cmd = StrPrintJoin(NULL,fmt,argc,argv);
+  cmd = StrPrint(,"%s > /tmp/__hcc_shell_out.txt",cmd);
+  I32 retval = System(cmd);
+  Free(cmd);
+  U64 len = 0;
+  U8 *output = FileRead("/tmp/__hcc_shell_out.txt", &len);
+  if (output[len-1] == '\n') {
+    output[len-1] = '\0';
+  }
+  return output;
+}

--- a/src/holyc-lib/tos.HH
+++ b/src/holyc-lib/tos.HH
@@ -81,6 +81,13 @@ public I64 CsvParse(CsvParser *p, CsvSlice *s);
 #define CDATE_YEAR_DAYS_INT    36524225
 #define CDATE_BASE_DAY_OF_WEEK 0
 
+/* XXX: Normalise stat ? */
+public class cTimespec
+{
+  I64 tv_sec;
+  I64 tv_nsec;
+};
+
 public class timeval
 { // c compatability
   I64 tv_sec;        /* seconds since Jan. 1, 1970 */
@@ -127,6 +134,7 @@ public I64 LastDayOfMon(I64 i);
 public I32 FirstDayOfYear(I64 i);
 public I64 LastDayOfYear(I64 i);
 public CDate Now();
+public U0 IsoFromTimespec(cTimespec *ts, U8 *buf);
 
 #define HT_LOAD  0.60
 #define HT_DELETED 0x7fffffffffffffff
@@ -474,6 +482,9 @@ public U0 Exit(I64 exit_code = EXIT_FAIL);
 public I64 Write(I64 fd, U8 *buf, I64 len);
 public I64 System(U8 *command);
 #endif
+
+public I32 Sh(U8 *fmt, ...);
+public U8 *Shlurp(U8 *fmt, ...);
 
 /* TempleOS-style try/catch/throw. CatchFrame is 256 bytes (matches
  * what the compiler reserves per `try` block); the runtime stores its
@@ -844,12 +855,6 @@ public extern "c" I32 closedir(cDIR *dir);
 public extern "c" U0 rewinddir(cDIR *dir);
 public extern "c" U0 seekdir(cDIR *dir, I64 pos);
 public extern "c" I64 telldir(cDIR *dir);
-/* XXX: Normalise stat ? */
-public class cTimespec
-{
-  I64 tv_sec;
-  I64 tv_nsec;
-};
 
 #ifdef IS_MACOS
 public class cStat {
@@ -892,6 +897,89 @@ class cStat
   I64 __glibc_reserved[3];
 };
 
+class statx_timestamp
+{
+  I64  tv_sec;
+  U32  tv_nsec;
+  I32  __reserved;
+};
+
+class Statx
+{
+  U32 stx_mask;
+  U32 stx_blksize;
+  U64 stx_attributes;
+  U32 stx_nlink;
+  U32 stx_uid;
+  U32 stx_gid;
+  U16 stx_mode;
+  U16 __spare0[1];
+  U64 stx_ino;
+  U64 stx_size;
+  U64 stx_blocks;
+  U64 stx_attributes_mask;
+  statx_timestamp  stx_atime;
+  statx_timestamp  stx_btime;
+  statx_timestamp  stx_ctime;
+  statx_timestamp  stx_mtime;
+  U32 stx_rdev_major;
+  U32 stx_rdev_minor;
+  U32 stx_dev_major;
+  U32 stx_dev_minor;
+  U64 stx_mnt_id;
+  U32 stx_dio_mem_align;
+  U32 stx_dio_offset_align;
+  U64 stx_subvol;
+  U32 stx_atomic_write_unit_min;
+  U32 stx_atomic_write_unit_max;
+  U32 stx_atomic_write_segments_max;
+  U32 stx_dio_read_offset_align;
+  U32 stx_atomic_write_unit_max_opt;
+  U32 __spare2[1];
+  U64 __spare3[8];
+};
+
+#define STATX_TYPE           0x00000001
+#define STATX_MODE           0x00000002
+#define STATX_NLINK          0x00000004
+#define STATX_UID            0x00000008
+#define STATX_GID            0x00000010
+#define STATX_ATIME          0x00000020
+#define STATX_MTIME          0x00000040
+#define STATX_CTIME          0x00000080
+#define STATX_INO            0x00000100
+#define STATX_SIZE           0x00000200
+#define STATX_BLOCKS         0x00000400
+#define STATX_BASIC_STATS    0x000007ff
+#define STATX_BTIME          0x00000800
+#define STATX_MNT_ID         0x00001000
+#define STATX_DIOALIGN       0x00002000
+#define STATX_MNT_ID_UNIQUE  0x00004000
+#define STATX_SUBVOL         0x00008000
+#define STATX_WRITE_ATOMIC   0x00010000
+#define STATX_DIO_READ_ALIGN 0x00020000
+
+#define STATX__RESERVED             0x80000000
+#define STATX_ALL                   0x00000fff
+#define STATX_ATTR_COMPRESSED       0x00000004
+#define STATX_ATTR_IMMUTABLE        0x00000010
+#define STATX_ATTR_APPEND           0x00000020
+#define STATX_ATTR_NODUMP           0x00000040
+#define STATX_ATTR_ENCRYPTED        0x00000800
+#define STATX_ATTR_AUTOMOUNT        0x00001000
+#define STATX_ATTR_MOUNT_ROOT       0x00002000
+#define STATX_ATTR_VERITY           0x00100000
+#define STATX_ATTR_DAX              0x00200000
+#define STATX_ATTR_WRITE_ATOMIC     0x00400000
+#define STAT_X_AT_FDCWD       -100
+#define AT_STATX_SYNC_AS_STAT 0x0000
+#define STATX_BTIME           0x00000800
+
+public extern "c" I32 statx(I32 __dirfd,
+                            I8 *__path,
+                            I32 __flags,
+                            U32 __mask,
+                            Statx *stx);
 public extern "c" I32 stat(U8 *pathname, cStat *st);
 public extern "c" I32 lstat(U8 *pathname, cStat *st);
 public extern "c" I32 fstat(I32 fd, cStat *st);
@@ -910,6 +998,29 @@ public _extern _stat I32 stat(U8 *pathname, cStat *st);
 public _extern _lstat I32 lstat(U8 *pathname, cStat *st);
 public _extern _fstat I32 fstat(I32 fd, cStat *st);
 #endif
+
+/* Portable (across MacOS and Linux) stat structure */
+class Fstat
+{
+  U64 st_dev;
+  U64 st_ino;
+  U64 st_nlink;
+  U32 st_mode;
+  U32 st_uid;
+  U32 st_gid;
+  U64 st_rdev;
+  I64 st_size;
+  I64 st_blksize;
+  I64 st_blocks;
+  cTimespec st_atim;
+  cTimespec st_mtim;
+  cTimespec st_ctim;
+  cTimespec st_btim;
+};
+
+public I32 Stat(Fstat *fst, U8 *pathname);
+public I64 Dir(U8 *pathname = "./");
+public U8 *Pwd(U8 *buf=NULL, U64 buf_size=0);
 
 public extern "c" I32 mkdir(U8 *dirname, I32 mode = 438);
 public extern "c" I32 unlink(U8 *pathname);

--- a/src/ir-optimise.c
+++ b/src/ir-optimise.c
@@ -325,6 +325,8 @@ static int irValMatchesSlot(IrValue *v, IrValue *slot) {
            irVarId(v) == irVarId(slot);
 }
 
+static int irLocIsScratchClobbered(IrValue *v);
+
 static int irRewriteOperands(IrInstr *I, IrValue *slot, IrValue *source) {
     int changed = 0;
     /* IR_LEA / IR_GEP / IR_LOAD / IR_STORE_DEREF (address operand) all
@@ -333,11 +335,25 @@ static int irRewriteOperands(IrInstr *I, IrValue *slot, IrValue *source) {
      * (e.g. a param's arrive value) can't satisfy that. */
     if (I->op == IR_LEA || I->op == IR_GEP || I->op == IR_LOAD)
         return 0;
-    if (irValMatchesSlot(I->r1, slot) && I->r1 != source) {
+    /* A source living in a backend scratch register (a param's arrive
+     * reg overlapping x0/x1/x2 on AArch64) only survives until the
+     * consumer's OWN operand materialisation starts writing scratch
+     * regs. r1 of a simple op is loaded first, so it may read the
+     * home reg; r2 is loaded after r1 already landed in scratch 0 -
+     * `D(I64 x){ 10/x }` emitted `mov x0,#10` over the param then
+     * computed 10/10. STORE_DEREF / RMW_DEREF load their value operand
+     * LAST (after address/idx hit x1/x2), so even r1 is unsafe there.
+     * Refuse the hazardous positions; the read then stays on the slot
+     * and the spilling store stays live. */
+    int scratch_src = irLocIsScratchClobbered(source);
+    int r1_loads_first = I->op != IR_STORE_DEREF && I->op != IR_RMW_DEREF;
+    if ((!scratch_src || r1_loads_first) &&
+        irValMatchesSlot(I->r1, slot) && I->r1 != source)
+    {
         I->r1 = source;
         changed = 1;
     }
-    if (irValMatchesSlot(I->r2, slot) && I->r2 != source) {
+    if (!scratch_src && irValMatchesSlot(I->r2, slot) && I->r2 != source) {
         I->r2 = source;
         changed = 1;
     }
@@ -367,7 +383,10 @@ static int irRewriteOperands(IrInstr *I, IrValue *slot, IrValue *source) {
             }
         }
     }
-    if (I->op == IR_PHI && I->extra.phi_pairs) {
+    /* Phi values materialise at the predecessor's terminator - AFTER a
+     * CMP_BR terminator's compare has already run r1/r2 through the
+     * scratch regs - so a scratch-homed source is stale by then. */
+    if (I->op == IR_PHI && I->extra.phi_pairs && !scratch_src) {
         for (u64 i = 0; i < I->extra.phi_pairs->size; ++i) {
             IrPair *p = vecGet(IrPair *, I->extra.phi_pairs, i);
             if (p && irValMatchesSlot(p->ir_value, slot) &&

--- a/src/jit-common.c
+++ b/src/jit-common.c
@@ -9,10 +9,12 @@
 #include "aostr.h"
 #include "asm.h"
 #include "cli.h"
+#include "config.h"
 #include "prsasm.h"
 #include "ir-optimise.h"
 #include "jit-common.h"
 #include "list.h"
+#include "memsafe.h"
 #include "util.h"
 
 /* Internal labels (cross-function calls within this TU) are matched
@@ -47,8 +49,10 @@ int hccJitFreshLocalNum(HccJit *jit) {
 }
 
 int hccJitIsInternalFunc(HccJit *jit, const char *sym) {
-    /* Stored as cstring -> any-nonnull-pointer in `symbols`. */
-    return mapGet(jit->symbols, (void *)sym) != NULL;
+    /* "Internal" means defined in the chunk currently being emitted -
+     * those calls route through label fixups. Functions from earlier
+     * chunks resolve through host_symbols like any other host address. */
+    return mapGet(jit->chunk_fns, (void *)sym) != NULL;
 }
 
 /* ---------------- fixup helpers ---------------- */
@@ -185,28 +189,42 @@ int hccJitAssembleText(HccJit *jit, AoStr *text, int src_line) {
 
 /* ---------------- globals layout ---------------- */
 
-/* Estimate the size needed for all globals + string literals. */
-static size_t jitGlobalsSize(Cctrl *cc) {
+/* The mangled arena label of a global decl, or NULL if it doesn't get
+ * a slot (extern, typeless, ...). */
+static AoStr *jitGlobalLabel(Ast *ast) {
+    if (ast->kind != AST_DECL && ast->kind != AST_GVAR) return NULL;
+    Ast *dv = ast->declvar;
+    if (!dv || !dv->type) return NULL;
+    if (ast->flags & AST_FLAG_EXTERN) return NULL;
+    if (dv->flags & AST_FLAG_EXTERN) return NULL;
+    return dv->is_static ? dv->glabel : dv->gname;
+}
+
+/* Estimate the size needed for the not-yet-allocated globals in
+ * (from, sentinel] + string literals. Entries already registered in
+ * host_symbols (allocated by a previous chunk) are skipped. */
+static size_t jitGlobalsSize(HccJit *jit, List *from) {
+    Cctrl *cc = jit->cc;
     size_t total = 0;
-    listForEach(cc->ast_list) {
+    for (List *it = from; it != cc->ast_list; it = it->next) {
         Ast *ast = it->value;
-        if (ast->kind != AST_DECL && ast->kind != AST_GVAR) continue;
-        Ast *dv = ast->declvar;
-        if (!dv || !dv->type) continue;
-        if (ast->flags & AST_FLAG_EXTERN) continue;
-        if (dv->flags & AST_FLAG_EXTERN) continue;
-        total += (dv->type->size + 7) & ~7;  /* 8-byte align */
+        AoStr *label = jitGlobalLabel(ast);
+        if (!label) continue;
+        if (mapGet(jit->host_symbols, (void *)label->data)) continue;
+        total += (ast->declvar->type->size + 7) & ~7;  /* 8-byte align */
     }
-    /* String literals are stored in cc->strs. */
+    /* String literals are stored in cc->strs (accumulates across
+     * chunks; the host_symbols check skips already-laid-out ones). */
     if (cc->strs) {
         MapIter mi; mapIterInit(cc->strs, &mi);
         while (mapIterNext(&mi)) {
             Ast *ast = (Ast *)mi.node->value;
             if (ast->kind != AST_STRING) continue;
+            if (mapGet(jit->host_symbols, (void *)ast->slabel->data)) continue;
             total += ((size_t)ast->sval->len + 1 + 7) & ~7;
         }
     }
-    return total + 64; /* slack */
+    return total;
 }
 
 /* Walk an initialiser AST and write its byte image to `addr`.
@@ -256,16 +274,18 @@ static size_t jitWriteInit(HccJit *jit, uint8_t *addr, Ast *init) {
     return 0;
 }
 
-/* Lay out strings + globals into the arena; register each by its
- * mangled name so the backends' global-address emitters can find them
- * via host_symbols. Strings come first so that AST_ARRAY_INIT
- * initialisers in globals can reference them by their already-known
- * addresses. */
-static int jitAllocateGlobals(HccJit *jit) {
-    size_t sz = jitGlobalsSize(jit->cc);
+/* Lay out the (from, sentinel] range's new strings + globals into a
+ * fresh arena; register each by its mangled name so the backends'
+ * global-address emitters can find them via host_symbols. Strings come
+ * first so that AST_ARRAY_INIT initialisers in globals can reference
+ * them by their already-known addresses. Anything a previous chunk
+ * already laid out keeps its old (registered) address. */
+static int jitAllocateGlobals(HccJit *jit, List *from) {
+    size_t sz = jitGlobalsSize(jit, from);
     if (sz == 0) return 0;
-    jit->globals = calloc(1, sz);
-    jit->globals_size = sz;
+    sz += 64; /* slack */
+    uint8_t *globals = calloc(1, sz);
+    listAppend(jit->globals_arenas, globals);
     size_t off = 0;
 
     if (jit->cc->strs) {
@@ -273,7 +293,8 @@ static int jitAllocateGlobals(HccJit *jit) {
         while (mapIterNext(&mi)) {
             Ast *ast = (Ast *)mi.node->value;
             if (ast->kind != AST_STRING) continue;
-            char *addr = (char *)(jit->globals + off);
+            if (mapGet(jit->host_symbols, (void *)ast->slabel->data)) continue;
+            char *addr = (char *)(globals + off);
             /* The lexer stores escape sequences in their textual form
              * (`\n` is two bytes `\\` `n`). The asm path lets the
              * assembler decode them; we have to do it ourselves here
@@ -338,19 +359,15 @@ static int jitAllocateGlobals(HccJit *jit) {
 
     /* Globals. Strings are now addressable, so AST_ARRAY_INIT
      * containing AST_STRING elements can resolve element addresses. */
-    listForEach(jit->cc->ast_list) {
+    for (List *it = from; it != jit->cc->ast_list; it = it->next) {
         Ast *ast = it->value;
-        if (ast->kind != AST_DECL && ast->kind != AST_GVAR) continue;
-        Ast *dv = ast->declvar;
-        if (!dv || !dv->type) continue;
-        if (ast->flags & AST_FLAG_EXTERN) continue;
-        if (dv->flags & AST_FLAG_EXTERN) continue;
-        AoStr *label = dv->is_static ? dv->glabel : dv->gname;
+        AoStr *label = jitGlobalLabel(ast);
         if (!label) continue;
-        uint8_t *addr = jit->globals + off;
+        if (mapGet(jit->host_symbols, (void *)label->data)) continue;
+        uint8_t *addr = globals + off;
         mapAdd(jit->host_symbols, strdup(label->data), addr);
         jitWriteInit(jit, addr, ast->declinit);
-        off += (dv->type->size + 7) & ~7;
+        off += (ast->declvar->type->size + 7) & ~7;
     }
     return 0;
 }
@@ -397,116 +414,214 @@ static void jitLoadLibtos(Cctrl *cc) {
      * with a precise name if they do. */
 }
 
+/* dlopen one library, making its exports visible to
+ * asm_jit_dlsym_resolver. `name_form` entries came from `#link <name>`
+ * and are probed with the linker's lib prefix + both platforms'
+ * suffixes (dlopen inspects the file, not the extension, so trying
+ * both is harmless); paths load verbatim. Returns 1 on success. */
+static int jitDlopenLib(Cctrl *cc, const char *name, int name_form) {
+    if (!name_form) {
+        return dlopen(name, RTLD_LAZY | RTLD_GLOBAL) != NULL;
+    }
+
+    /* Bare names first: dyld / ld.so search their own default paths
+     * (DYLD_LIBRARY_PATH / LD_LIBRARY_PATH, the dyld shared cache,
+     * the ldconfig cache, ...). */
+    static const char *const fmts[] = { "lib%s.dylib", "lib%s.so", "%s" };
+    char buf[1024];
+    for (size_t i = 0; i < sizeof(fmts)/sizeof(fmts[0]); ++i) {
+        snprintf(buf, sizeof(buf), fmts[i], name);
+        if (dlopen(buf, RTLD_LAZY | RTLD_GLOBAL)) return 1;
+    }
+
+    /* Then the places libraries commonly live that the dynamic linker
+     * does NOT search for bare names: the configured install prefix
+     * (mirrors the AOT `-L<prefix>/lib`), Homebrew (dlopen never
+     * searches /opt/homebrew/lib on Apple Silicon), the classic system
+     * dirs and Debian/Fedora arch dirs. */
+    char prefix_lib[1024];
+    const char *dirs[8];
+    size_t ndirs = 0;
+    if (cc->install_dir && *cc->install_dir) {
+        snprintf(prefix_lib, sizeof(prefix_lib), "%s/lib", cc->install_dir);
+        dirs[ndirs++] = prefix_lib;
+    }
+#ifdef __APPLE__ 
+    dirs[ndirs++] = "/opt/homebrew/lib";
+#endif
+
+    dirs[ndirs++] = "/usr/local/lib";
+    dirs[ndirs++] = "/usr/lib";
+
+#if defined(__x86_64__)
+    dirs[ndirs++] = "/usr/lib/x86_64-linux-gnu";
+#elif defined(__aarch64__) || defined(__arm64__)
+    dirs[ndirs++] = "/usr/lib/aarch64-linux-gnu";
+#endif
+
+    dirs[ndirs++] = "/usr/lib64";
+
+    for (size_t d = 0; d < ndirs; ++d) {
+        char *lib = tprintf("%s/lib%s.dylib", dirs[d], name);
+        if (dlopen(lib, RTLD_LAZY | RTLD_GLOBAL)) return 1;
+        lib = tprintf("%s/lib%s.so", dirs[d], name);
+        if (dlopen(lib, RTLD_LAZY | RTLD_GLOBAL)) return 1;
+    }
+    return 0;
+}
+
+/* Load every shared object the CLI or a `#link` directive asked for.
+ * Called from hccJitNew AND per chunk compile: in the REPL a `#link`
+ * typed mid-session grows the lists after the JIT already exists.
+ * The `loaded` set makes each entry load (and any failure report)
+ * happen exactly once. */
 static void jitLoadSharedObjects(Cctrl *cc) {
-    static int libs_loaded = 0;
-    if (libs_loaded) return;
-    libs_loaded = 1;
+    static Set *loaded = NULL;
+    if (loaded == NULL) loaded = setNew(32, &set_cstring_type);
 
-    fprintf(stderr, "JIT cannot load in object files at this time\n");
-    
-    // if (cc->object_files) {
-    //     fprintf(stderr, "Ignoring object files, only shared objects can be "
-    //             "loaded by the JIT\n");
-    // }
+    if (!listEmpty(cc->object_files)) {
+        static int warned_object_files = 0;
+        if (!warned_object_files) {
+            warned_object_files = 1;
+            fprintf(stderr, "Ignoring object files, only shared objects "
+                    "can be loaded by the JIT\n");
+        }
+    }
 
-   // if (!listEmpty(cc->shared_object_files)) {
-   //     listForEach(cc->shared_object_files) {
-   //         AoStr *so_file = it->value;
-   //         dlopen(so_file->data, RTLD_LAZY | RTLD_GLOBAL);
-   //     }
-   // }
+    if (!listEmpty(cc->shared_object_files)) {
+        listForEach(cc->shared_object_files) {
+            AoStr *so = it->value;
+            if (setHas(loaded, so->data)) continue;
+            setAdd(loaded, so->data);
+            if (!jitDlopenLib(cc, so->data, 0)) {
+                fprintf(stderr, "hcc: #link: failed to load '%s': %s\n",
+                        so->data, dlerror());
+            }
+        }
+    }
+    if (!listEmpty(cc->link_libs)) {
+        listForEach(cc->link_libs) {
+            AoStr *name = it->value;
+            if (setHas(loaded, name->data)) continue;
+            setAdd(loaded, name->data);
+            if (!jitDlopenLib(cc, name->data, 1)) {
+                fprintf(stderr, "hcc: #link: failed to load library '%s' "
+                        "(probed lib%s.{dylib,so} in the dynamic linker's "
+                        "default paths, %s/lib, /opt/homebrew/lib, "
+                        "/usr/local/lib and the system lib dirs)\n",
+                        name->data, name->data,
+                        cc->install_dir ? cc->install_dir : "");
+            }
+        }
+    }
 }
 
 /* ---------------- compile pipeline ---------------- */
 
-HccJit *hccJitCompile(Cctrl *cc, const HccJitBackend *backend) {
+HccJit *hccJitNew(Cctrl *cc, const HccJitBackend *backend) {
     if (!backend->target_ok(cc->target)) {
         fprintf(stderr, "hcc: JIT only supports %s targets\n", backend->name);
         return NULL;
     }
 
     HccJit *jit = calloc(1, sizeof *jit);
-    jit->cc           = cc;
-    jit->symbols      = mapNew(64, &map_cstring_opaque_type);
-    jit->host_symbols = mapNew(64, &map_cstring_opaque_type);
-    jit->block_local  = mapNew(64, &map_uint_to_uint_type);
-    jit->epi_local    = mapNew(16, &map_uint_to_uint_type);
-    jit->next_local   = 0;
+    jit->cc             = cc;
+    jit->backend        = backend;
+    jit->symbols        = mapNew(64, &map_cstring_opaque_type);
+    jit->host_symbols   = mapNew(64, &map_cstring_opaque_type);
+    jit->chunk_fns      = mapNew(64, &map_cstring_opaque_type);
+    jit->chunks         = listNew();
+    jit->globals_arenas = listNew();
+    jit->block_local    = mapNew(64, &map_uint_to_uint_type);
+    jit->epi_local      = mapNew(16, &map_uint_to_uint_type);
+    jit->next_local     = 0;
+    /* Nothing consumed yet: cursors sit on the sentinels so the first
+     * chunk sweeps the whole lists. */
+    jit->ast_cursor     = cc->ast_list;
+    jit->asm_cursor     = cc->asm_blocks;
 
     asm_enc_init(&jit->enc);
     backend->init_reg_pool();
     jitLoadLibtos(cc);
     jitLoadSharedObjects(cc);
+    return jit;
+}
 
-    if (jitAllocateGlobals(jit) != 0) goto fail;
+/* Register a chunk-internal function name (emit-time calls/IR_LEA to
+ * it route through label fixups instead of host_symbols/dlsym). */
+static void jitChunkFnAdd(HccJit *jit, const char *name) {
+    if (!mapHas(jit->chunk_fns, (void *)name)) {
+        mapAdd(jit->chunk_fns, strdup(name), (void *)(uintptr_t)1);
+    }
+}
 
-    /* HolyC "scripting" mode: statements at file scope land in
-     * cc->initalisers and get wrapped into a synthetic `main`. When
-     * this happens the user-supplied Main is renamed to MainFn (see
-     * asmNormaliseFunctionName). We have to apply the same wrapping
-     * before compiling so the entry point we hand to `hccJitRunMain`
-     * actually runs the init statements. */
-    Ast *synth_main = asmBuildInitialiserMain(cc);
+int hccJitCompileChunk(HccJit *jit, Ast *extra_fn) {
+    Cctrl *cc = jit->cc;
+
+    /* Pick up any `#link` libraries recorded since the last chunk
+     * (REPL inputs can add them at any point). */
+    jitLoadSharedObjects(cc);
+
+    /* Reset the per-chunk encoder + internal-function set. */
+    asm_enc_free(&jit->enc);
+    asm_enc_init(&jit->enc);
+    mapClear(jit->chunk_fns);
+
+    /* First unconsumed nodes. The cursors advance immediately: even if
+     * this chunk fails, the next call must not recompile its ASTs. */
+    List *ast_from = jit->ast_cursor->next;
+    List *asm_from = jit->asm_cursor ? jit->asm_cursor->next : NULL;
+    jit->ast_cursor = cc->ast_list->prev;
+    if (cc->asm_blocks) jit->asm_cursor = cc->asm_blocks->prev;
+
+    if (jitAllocateGlobals(jit, ast_from) != 0) return -1;
 
     /* Pre-register every internal function name so emit-time code
-     * (IR_LEA on a function, IR_CALL to another function in this TU)
-     * can route through label fixups rather than dlsym (which doesn't
-     * see this-TU JIT code). The marker value is overwritten with the
-     * real address post-finalize. */
-    listForEach(cc->ast_list) {
+     * (IR_LEA on a function, IR_CALL to another function in this
+     * chunk) can route through label fixups rather than dlsym (which
+     * doesn't see this-chunk JIT code). */
+    for (List *it = ast_from; it != cc->ast_list; it = it->next) {
         Ast *ast = it->value;
         if (ast->kind != AST_FUNC) continue;
-        char *mangled = asmNormaliseFunctionName(cc, ast->fname);
-        if (!mapHas(jit->symbols, mangled)) {
-            mapAdd(jit->symbols, strdup(mangled), (void *)(uintptr_t)1);
-        }
+        jitChunkFnAdd(jit, asmNormaliseFunctionName(cc, ast->fname));
     }
-    if (synth_main) {
-        char *mangled = asmNormaliseFunctionName(cc, synth_main->fname);
-        if (!mapHas(jit->symbols, mangled)) {
-            mapAdd(jit->symbols, strdup(mangled), (void *)(uintptr_t)1);
-        }
+    if (extra_fn) {
+        jitChunkFnAdd(jit, asmNormaliseFunctionName(cc, extra_fn->fname));
     }
 
     /* `asm {}` functions are internal too: register both the raw label
      * name and its platform-mangled form so calls and IR_LEA route
      * through label fixups (the finalize matcher is underscore-
      * tolerant for the raw/mangled difference). */
-    if (cc->asm_blocks) {
-        listForEach(cc->asm_blocks) {
+    if (asm_from) {
+        for (List *it = asm_from; it != cc->asm_blocks; it = it->next) {
             Ast *asm_block = (Ast *)it->value;
             if (!asm_block->funcs) continue;
             for (List *fl = asm_block->funcs->next; fl != asm_block->funcs;
                  fl = fl->next)
             {
                 Ast *fn = (Ast *)fl->value;
-                char *mangled = asmNormaliseFunctionName(cc, fn->asmfname);
-                if (!mapHas(jit->symbols, fn->asmfname->data)) {
-                    mapAdd(jit->symbols, strdup(fn->asmfname->data),
-                           (void *)(uintptr_t)1);
-                }
-                if (!mapHas(jit->symbols, mangled)) {
-                    mapAdd(jit->symbols, strdup(mangled),
-                           (void *)(uintptr_t)1);
-                }
+                jitChunkFnAdd(jit, fn->asmfname->data);
+                jitChunkFnAdd(jit, asmNormaliseFunctionName(cc, fn->asmfname));
             }
         }
     }
 
     IrCtx *ir_ctx = irCtxNew(cc);
-    listForEach(cc->ast_list) {
+    for (List *it = ast_from; it != cc->ast_list; it = it->next) {
         Ast *ast = it->value;
         if (ast->kind != AST_FUNC) continue;
-        if (backend->compile_function(jit, ast, ir_ctx) != 0) goto fail;
+        if (jit->backend->compile_function(jit, ast, ir_ctx) != 0) return -1;
     }
-    if (synth_main) {
-        if (backend->compile_function(jit, synth_main, ir_ctx) != 0) goto fail;
+    if (extra_fn) {
+        if (jit->backend->compile_function(jit, extra_fn, ir_ctx) != 0)
+            return -1;
     }
 
     /* `asm {}` function bodies: define each public label, then splice
      * the libtasm-encoded bytes in. */
-    if (cc->asm_blocks) {
-        listForEach(cc->asm_blocks) {
+    if (asm_from) {
+        for (List *it = asm_from; it != cc->asm_blocks; it = it->next) {
             Ast *asm_block = (Ast *)it->value;
             if (!asm_block->funcs) continue;
             for (List *fl = asm_block->funcs->next; fl != asm_block->funcs;
@@ -515,10 +630,14 @@ HccJit *hccJitCompile(Cctrl *cc, const HccJitBackend *backend) {
                 Ast *fn = (Ast *)fl->value;
                 asm_define_label(&jit->enc, -1, fn->asmfname->data);
                 if (hccJitAssembleText(jit, fn->body->asm_stmt, 0) != 0)
-                    goto fail;
+                    return -1;
             }
         }
     }
+
+    /* Nothing emitted (e.g. the input only declared a class or a
+     * prototype): success, no mapping needed. */
+    if (jit->enc.len == 0) return 0;
 
     /* Dev hex dump of pre-finalize bytes. Triggered by HCC_JIT_DUMP=1. */
     if (getenv("HCC_JIT_DUMP")) {
@@ -537,22 +656,50 @@ HccJit *hccJitCompile(Cctrl *cc, const HccJitBackend *backend) {
         }
     }
 
-    if (asm_jit_finalize(&jit->enc, jitResolveSymbol, jit, &jit->code) != 0) {
-        goto fail;
+    AsmJitCode *code = calloc(1, sizeof *code);
+    if (asm_jit_finalize(&jit->enc, jitResolveSymbol, jit, code) != 0) {
+        free(code);
+        return -1;
     }
+    listAppend(jit->chunks, code);
 
-    /* Each public label now points at (code base + label byte_offset). */
+    /* Each public label now points at (code base + label byte_offset).
+     * Register in `symbols` (hccJitLookup) and in `host_symbols` so
+     * later chunks' emit-time addressing and finalize-time resolver
+     * both see it. A redefinition overwrites: future chunks bind to
+     * the newest body, already-patched code keeps the old one. */
     for (int i = 0; i < jit->enc.n_labels; ++i) {
         AsmLabelDef *L = &jit->enc.labels[i];
         if (!L->name) continue;
-        void *addr = (uint8_t *)jit->code.code + L->byte_offset;
+        void *addr = (uint8_t *)code->code + L->byte_offset;
         mapAdd(jit->symbols, strdup(L->name), addr);
+        mapAdd(jit->host_symbols, strdup(L->name), addr);
+    }
+    return 0;
+}
+
+HccJit *hccJitCompile(Cctrl *cc, const HccJitBackend *backend) {
+    HccJit *jit = hccJitNew(cc, backend);
+    if (!jit) return NULL;
+
+    /* -Memsafe: install the tracking allocator before the chunk
+     * compiles, so every call site binds to it at finalize. */
+    if (cc->flags & CCTRL_MEMSAFE)
+        memsafeInit(jit);
+
+    /* HolyC "scripting" mode: statements at file scope land in
+     * cc->initalisers and get wrapped into a synthetic `main`. When
+     * this happens the user-supplied Main is renamed to MainFn (see
+     * asmNormaliseFunctionName). We have to apply the same wrapping
+     * before compiling so the entry point we hand to `hccJitRunMain`
+     * actually runs the init statements. */
+    Ast *synth_main = asmBuildInitialiserMain(cc);
+
+    if (hccJitCompileChunk(jit, synth_main) != 0) {
+        hccJitFree(jit);
+        return NULL;
     }
     return jit;
-
-fail:
-    hccJitFree(jit);
-    return NULL;
 }
 
 /* ---------------- public accessors ---------------- */
@@ -570,9 +717,60 @@ void *hccJitLookup(HccJit *jit, const char *name) {
     return NULL;
 }
 
+AsmJitCode *hccJitFindChunk(HccJit *jit, void *pc) {
+    if (!jit || !pc) return NULL;
+    listForEach(jit->chunks) {
+        AsmJitCode *chunk = (AsmJitCode *)it->value;
+        uint8_t *base = (uint8_t *)chunk->code;
+        if ((uint8_t *)pc >= base &&
+            (uint8_t *)pc < base + chunk->size + chunk->veneer_size)
+        {
+            return chunk;
+        }
+    }
+    return NULL;
+}
+
+const char *hccJitFindSymbolForAddr(HccJit *jit, void *pc, size_t *off_out) {
+    if (off_out) *off_out = 0;
+    AsmJitCode *chunk = hccJitFindChunk(jit, pc);
+    if (chunk == NULL) return NULL;
+    /* Veneers belong to the chunk, not to whichever function happens
+     * to be emitted last - don't attribute them. */
+    if ((uint8_t *)pc >= (uint8_t *)chunk->code + chunk->size) return NULL;
+
+    const char *best = NULL;
+    uint8_t *best_addr = NULL;
+    MapIter mi;
+    mapIterInit(jit->symbols, &mi);
+    while (mapIterNext(&mi)) {
+        uint8_t *sym = (uint8_t *)mi.node->value;
+        if (sym <= (uint8_t *)pc && sym >= (uint8_t *)chunk->code &&
+            (best_addr == NULL || sym > best_addr))
+        {
+            best_addr = sym;
+            best = (const char *)mi.node->key;
+        }
+    }
+    if (best && off_out) *off_out = (size_t)((uint8_t *)pc - best_addr);
+    return best;
+}
+
 void hccJitDefineSymbol(HccJit *jit, const char *name, void *addr) {
     if (!jit || !name) return;
+    /* Register BOTH spellings: HolyC-compiled call sites arrive
+     * platform-mangled (`_free` on Mach-O) while `asm {}` blocks emit
+     * the symbol verbatim (`CALL malloc` -> `malloc`). The resolver's
+     * host_symbols lookup is exact, so one spelling would miss the
+     * other's callers. */
     mapAdd(jit->host_symbols, strdup(name), addr);
+    if (name[0] != '_') {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "_%s", name);
+        mapAdd(jit->host_symbols, strdup(buf), addr);
+    } else {
+        mapAdd(jit->host_symbols, strdup(name + 1), addr);
+    }
 }
 
 union JitMainFunction {
@@ -590,10 +788,18 @@ int hccJitRunMain(HccJit *jit, int argc, char **argv) {
 void hccJitFree(HccJit *jit) {
     if (!jit) return;
     asm_enc_free(&jit->enc);
-    asm_jit_free(&jit->code);
-    if (jit->globals) free(jit->globals);
+    if (jit->chunks) {
+        listForEach(jit->chunks) {
+            AsmJitCode *code = (AsmJitCode *)it->value;
+            asm_jit_free(code);
+            free(code);
+        }
+        listRelease(jit->chunks, NULL);
+    }
+    if (jit->globals_arenas) listRelease(jit->globals_arenas, free);
     if (jit->symbols) mapRelease(jit->symbols);
     if (jit->host_symbols) mapRelease(jit->host_symbols);
+    if (jit->chunk_fns) mapRelease(jit->chunk_fns);
     if (jit->block_local) mapRelease(jit->block_local);
     if (jit->epi_local) mapRelease(jit->epi_local);
     free(jit);

--- a/src/jit-common.h
+++ b/src/jit-common.h
@@ -21,19 +21,39 @@
 typedef struct HccJit {
     Cctrl *cc;
 
-    /* Single accumulating encoder. All function bytes land here in
-     * emission order; public labels carry the function name. */
+    /* The arch backend driving compile_function for every chunk. */
+    const struct HccJitBackend *backend;
+
+    /* Per-chunk accumulating encoder. All function bytes of the chunk
+     * being built land here in emission order; public labels carry the
+     * function name. Reset at the start of every hccJitCompileChunk. */
     AsmEnc enc;
 
-    /* name -> entry address inside the RX mapping. Populated post-finalize. */
+    /* name -> entry address inside an RX mapping. Accumulates across
+     * chunks; redefinitions overwrite so lookups see the newest one. */
     Map *symbols;
-    /* User-defined host symbols (printf etc.) - checked before dlsym. */
+    /* User-defined host symbols (printf etc.) - checked before dlsym.
+     * Finalized functions and globals/string arenas are registered
+     * here too so later chunks can address them. */
     Map *host_symbols;
 
-    /* RW arena for globals + string literals; absolute addresses are
-     * registered in host_symbols so the resolver picks them up. */
-    uint8_t *globals;
-    size_t   globals_size;
+    /* Function names defined in the chunk CURRENTLY being emitted.
+     * These route through label fixups; everything else resolves via
+     * host_symbols/dlsym. Reset per chunk. */
+    Map *chunk_fns;
+
+    /* Finalized RX mappings (AsmJitCode *), one per chunk. Old chunks
+     * stay mapped forever - earlier code may hold pointers into them. */
+    List *chunks;
+
+    /* RW arenas for globals + string literals, one per chunk; the
+     * absolute addresses are registered in host_symbols. */
+    List *globals_arenas;
+
+    /* Incremental cursors: last node of cc->ast_list / cc->asm_blocks
+     * already consumed by a chunk. A chunk compiles (cursor, sentinel]. */
+    List *ast_cursor;
+    List *asm_cursor;
 
     /* Per-IrBlock -> AsmEnc local_num.  Key = (fn_uuid<<32) | block_id;
      * value = small int.  Local nums are pulled from `next_local`. */
@@ -41,8 +61,6 @@ typedef struct HccJit {
     /* Per-function epilogue label local_num. Key = fn_uuid. */
     Map *epi_local;
     int  next_local;
-
-    AsmJitCode code;
 } HccJit;
 
 /* What a per-arch backend plugs into the shared compile pipeline. */
@@ -61,10 +79,38 @@ typedef struct HccJitBackend {
  * for every function in `cc` through `backend`. NULL on error. */
 HccJit *hccJitCompile(Cctrl *cc, const HccJitBackend *backend);
 
+/* Create an empty jit (no code compiled yet) for incremental use.
+ * Checks target compatibility, installs the register pool and loads
+ * libtos. NULL on error. */
+HccJit *hccJitNew(Cctrl *cc, const HccJitBackend *backend);
+
+/* Compile everything appended to cc->ast_list / cc->asm_blocks since
+ * the previous chunk - plus `extra_fn` if non-NULL (a synthetic
+ * function that is NOT in ast_list, e.g. the REPL's per-input
+ * wrapper) - into a fresh RX mapping. New globals and string literals
+ * get slots in a new RW arena. Finalized function addresses are
+ * registered so later chunks (and hccJitLookup) can reach them;
+ * redefinitions rebind the name for future chunks while old code
+ * keeps calling the address it was linked against.
+ *
+ * The cursors advance even on failure so a broken input isn't
+ * recompiled by the next call. Non-zero on error. */
+int hccJitCompileChunk(HccJit *jit, Ast *extra_fn);
+
 /* Look up a public function by name (tries the underscore-prefixed
  * macOS mangling too). The returned pointer is owned by the jit and
  * remains valid until hccJitFree. */
 void *hccJitLookup(HccJit *jit, const char *name);
+
+/* Reverse-map a pc: the chunk whose live executable bytes (code +
+ * veneers) contain it, or NULL if it isn't JIT'd code. */
+AsmJitCode *hccJitFindChunk(HccJit *jit, void *pc);
+
+/* Name of the JIT function containing `pc`: the nearest symbol at or
+ * below it within its chunk's code (veneer pcs return NULL - use
+ * hccJitFindChunk to tell "veneer" from "not ours"). *off_out gets
+ * pc - symbol. */
+const char *hccJitFindSymbolForAddr(HccJit *jit, void *pc, size_t *off_out);
 
 /* Register a host-provided symbol (e.g. printf, malloc, a libtos hook)
  * so JITted code can call it. Overrides dlsym for that name. */

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -162,9 +162,13 @@ static LexerType lexer_types[] = {
     {"#undef",   KW_PP_UNDEF},
     {"#error",   KW_PP_ERROR},
     {"#include", KW_PP_INCLUDE},
+    {"#link",    KW_PP_LINK},
+    {"#ifjit",   KW_PP_IF_JIT},
+    {"#ifaot",   KW_PP_IF_AOT},
 
     {"sizeof",   KW_SIZEOF},
     {"alignof",  KW_ALIGNOF},
+    {"typeof",   KW_TYPEOF},
     {"inline",   KW_INLINE},
     {"atomic",   KW_ATOMIC},
     {"volatile", KW_VOLATILE},
@@ -279,6 +283,7 @@ __noreturn static void lexRaise(Lexer *l, const char *fmt, ...) {
     fprintf(stderr, "\033[0;31mERROR: \033[0m");
     va_start(ap, fmt);
     vfprintf(stderr, fmt, ap);
+    fprintf(stderr, "\n");
     va_end(ap);
     exit(EXIT_FAILURE);
 }
@@ -319,6 +324,14 @@ void lexInit(Lexer *l, char *source, int flags) {
         LexerType *bilt = &lexer_types[i]; 
         mapAddLen(l->symbol_table, bilt->name, strlen(bilt->name), bilt);
     }
+}
+
+void lexerRelease(Lexer *l) {
+    if (!l) return;
+    lexReleaseAllFiles(l);
+    mapRelease(l->symbol_table);
+    setRelease(l->seen_files);
+    free(l);
 }
 
 void lexSetBuiltinRoot(Lexer *l, char *root) {
@@ -527,9 +540,9 @@ AoStr *lexemeToAoStr(Lexeme *tok) {
                 case KW_PUBLIC:      aoStrCatPrintf(str,"public");  break;
                 case KW_ATOMIC:      aoStrCatPrintf(str,"atomic");  break;
                 case KW_DEFINE:      aoStrCatPrintf(str,"define");  break;
-                case KW_PP_INCLUDE:     aoStrCatPrintf(str,"include"); break;
                 case KW_SIZEOF:      aoStrCatPrintf(str,"sizeof");  break;
                 case KW_ALIGNOF:     aoStrCatPrintf(str,"alignof"); break;
+                case KW_TYPEOF:      aoStrCatPrintf(str,"typeof");  break;
                 case KW_RETURN:      aoStrCatPrintf(str,"return");  break;
                 case KW_TRY:         aoStrCatPrintf(str,"try");     break;
                 case KW_CATCH:       aoStrCatPrintf(str,"catch");   break;
@@ -563,17 +576,21 @@ AoStr *lexemeToAoStr(Lexeme *tok) {
                 case KW_STATIC:      aoStrCatPrintf(str,"static");  break;
                 case KW_DEFINED:     aoStrCatPrintf(str,"defined"); break;
 
-                case KW_PP_IF: aoStrCatPrintf(str,"#if"); break;   
-                case KW_PP_ELSE: aoStrCatPrintf(str,"#else"); break;   
-                case KW_PP_DEFINE: aoStrCatPrintf(str,"#define"); break;  
-                case KW_PP_IF_NDEF: aoStrCatPrintf(str,"#ifndef"); break; 
-                case KW_PP_IF_DEF: aoStrCatPrintf(str,"#ifdef"); break;
-                case KW_PP_ELIF_DEF:aoStrCatPrintf(str,"#elifdef"); break;
-                case KW_PP_ENDIF: aoStrCatPrintf(str,"#endif"); break;   
-                case KW_PP_ELIF: aoStrCatPrintf(str,"#elif"); break;    
-                case KW_PP_DEFINED: aoStrCatPrintf(str,"#defined"); break; 
-                case KW_PP_UNDEF:  aoStrCatPrintf(str,"#undef"); break;  
-                case KW_PP_ERROR: aoStrCatPrintf(str,"#error"); break;   
+                case KW_PP_INCLUDE:  aoStrCatPrintf(str,"#include"); break;
+                case KW_PP_IF:       aoStrCatPrintf(str,"#if"); break;   
+                case KW_PP_ELSE:     aoStrCatPrintf(str,"#else"); break;   
+                case KW_PP_DEFINE:   aoStrCatPrintf(str,"#define"); break;  
+                case KW_PP_IF_NDEF:  aoStrCatPrintf(str,"#ifndef"); break; 
+                case KW_PP_IF_DEF:   aoStrCatPrintf(str,"#ifdef"); break;
+                case KW_PP_ELIF_DEF: aoStrCatPrintf(str,"#elifdef"); break;
+                case KW_PP_ENDIF:    aoStrCatPrintf(str,"#endif"); break;   
+                case KW_PP_ELIF:     aoStrCatPrintf(str,"#elif"); break;    
+                case KW_PP_DEFINED:  aoStrCatPrintf(str,"#defined"); break; 
+                case KW_PP_UNDEF:    aoStrCatPrintf(str,"#undef"); break;  
+                case KW_PP_ERROR:    aoStrCatPrintf(str,"#error"); break;
+                case KW_PP_LINK:     aoStrCatPrintf(str,"#link"); break;
+                case KW_PP_IF_JIT:   aoStrCatPrintf(str,"#ifjit"); break;
+                case KW_PP_IF_AOT:   aoStrCatPrintf(str,"#ifaot"); break;
 
                 default:
                     loggerPanic("line %d: Keyword %.*s: is not defined\n",
@@ -710,6 +727,36 @@ void lexPushFile(Lexer *l, AoStr *filename) {
     l->start = f->ptr;
 }
 
+/* Push an in-memory buffer as if it were a file. The REPL lexes each
+ * input through here rather than lexInit(l, source, ...) because a
+ * bare string source has no LexFile - and the diagnostic renderer
+ * (and `#include` save/restore) both need `l->cur_file` to be real.
+ * `src` is borrowed; it must outlive the parse of this buffer. */
+void lexPushString(Lexer *l, char *name, char *src, s64 len) {
+    LexFile *f = (LexFile *)malloc(sizeof(LexFile));
+    AoStr *src_code = aoStrNew();
+    src_code->data = src;
+    src_code->len = len;
+    src_code->capacity = 0;
+
+    f->ptr = src_code->data;
+    f->src = src_code;
+    f->lineno = 1;
+    f->line_start_ptr = src_code->data;
+    f->filename = aoStrDupRaw(name, strlen(name));
+    if (l->cur_file) {
+        l->cur_file->ptr = l->ptr;
+        l->cur_file->lineno = l->lineno;
+        l->cur_file->line_start_ptr = l->line_start_ptr;
+        listAppend(l->files,l->cur_file);
+    }
+    l->cur_file = f;
+    l->ptr = f->ptr;
+    l->lineno = f->lineno;
+    l->line_start_ptr = f->line_start_ptr;
+    l->start = f->ptr;
+}
+
 static void lexSkipCodeComment(Lexer *l) {
     if (*l->ptr == '/') {
         while (*l->ptr != '\0') {
@@ -780,7 +827,19 @@ static int countNumberLen(Lexer *l, char *ptr, int *isfloat, int *ishex,
             break;
         /* Anything else is invalid */
         default:
-            if (!isHex(*ptr)) {
+            if (*ptr == 'f') {
+                if (*(ptr+1) != '\0' && *(ptr+1) == '3' && 
+                   *(ptr+2) != '\0' && *(ptr+2) == '2') {
+                    ptr += 2;
+                    *isfloat = 1;
+                    break;
+                } else if (*(ptr+1) != '\0' && *(ptr+1) == '6' && 
+                           *(ptr+2) != '\0' && *(ptr+2) == '4') {
+                    ptr += 2;
+                    *isfloat = 1;
+                    break;
+                }
+            } else if (!isHex(*ptr)) {
                 loggerWarning("line %d: Number errored with char: '%c'\n",l->lineno,*ptr);
                 *err = 1;
                 return -1;
@@ -934,13 +993,23 @@ done:
 u64 lexCharConst(Lexer *l) {
     u64 char_const = 0, idx;
     s64 hex_num = 0;
-    s64 len;
+    s64 len, overflowed = 0;
     char ch;
 
-    for (len = 0; len < LEX_CHAR_CONST_LEN; ++len) {
+    for (len = 0; ; ++len) {
         ch = lexNextChar(l);
         if (!ch || ch == '\'') {
             break;
+        }
+        if (len >= LEX_CHAR_CONST_LEN) {
+            /* Absorb through to the closing quote so the raise below
+             * (or the CCF_PERMISSIVE renderer, which only wants a
+             * syntax-coloured echo) resumes after the constant rather
+             * than in the middle of it. Skip the escaped character so
+             * `\'` cannot end the constant early. */
+            overflowed = 1;
+            if (ch == '\\') lexNextChar(l);
+            continue;
         }
         idx = len * 8;
         if (ch == '\\') {
@@ -961,16 +1030,17 @@ u64 lexCharConst(Lexer *l) {
                 case 'f':  char_const |= (unsigned long)'\f' << ((unsigned long)idx); break;
                 case 'x':
                 case 'X':
+                    hex_num = 0;
                     for (int i = 0; i < 2; ++i) {
-                        ch = toupper(lexNextChar(l));
-                        if (isHex(ch)) {
-                            if (ch <= '9') {
-                                hex_num |= (unsigned long)(hex_num<<4)+ch-'0';
-                            } else {
-                                hex_num |= (unsigned long)(hex_num<<4)+ch-'A'+10;
-                            }
-                        } else {
+                        ch = toupper(lexPeek(l));
+                        if (!isHex(ch)) {
                             break;
+                        }
+                        lexNextChar(l);
+                        if (ch <= '9') {
+                            hex_num = (hex_num<<4)+ch-'0';
+                        } else {
+                            hex_num = (hex_num<<4)+ch-'A'+10;
                         }
                     }
                     char_const |= (unsigned long)hex_num << (unsigned long)(idx);
@@ -984,14 +1054,16 @@ u64 lexCharConst(Lexer *l) {
         }
     }
 
-    if (ch != '\'' && lexPeek(l) != '\'') {
-        lexRaise(l, "Char const limited to 8 characters");
+    if (!(l->flags & CCF_PERMISSIVE)) {
+        if (overflowed) {
+            lexRaise(l, "Char const limited to %d characters",
+                     LEX_CHAR_CONST_LEN);
+        }
+        if (!ch) {
+            lexRaise(l, "Unterminated char const");
+        }
     }
 
-    /* Consume next character if it is the end of the char const */
-    if (lexPeek(l) == '\'') {
-        lexNextChar(l);
-    } 
     l->cur_i64 = char_const;
     l->cur_strlen = len;
     return TK_CHAR_CONST;
@@ -1425,6 +1497,68 @@ void lexInclude(Lexer *l) {
     }
 }
 
+static int listContainsAoStr(List *ll, AoStr *needle) {
+    if (listEmpty(ll)) return 0;
+    listForEach(ll) {
+        if (aoStrEq((AoStr *)it->value, needle)) return 1;
+    }
+    return 0;
+}
+
+/* `#link` records a shared library dependency in the source itself:
+ *   #link "./file.so"   - literal path; spliced into the AOT link
+ *                         command verbatim, dlopen'd by the JIT.
+ *   #link <name>        - library name; `-lname` for the AOT linker,
+ *                         dlopen("lib<name>.{dylib,so}") for the JIT.
+ * Duplicates are dropped so headers can #link freely. */
+static void lexLink(Lexer *l) {
+    Lexeme next;
+    AoStr *name;
+    int is_path = 0;
+
+    if (!lex(l, &next)) {
+        lexRaise(l, "Syntax is: #link \"<path>\" or #link <libname>");
+    }
+    if (tokenPunctIs(&next, '<')) {
+        name = aoStrNew();
+        for (;;) {
+            if (!lex(l, &next)) {
+                lexRaise(l, "Unterminated #link <...>");
+            }
+            if (tokenPunctIs(&next, '>')) break;
+            aoStrCatPrintf(name, "%.*s", next.len, next.start);
+        }
+    } else if (next.tk_type == TK_STR) {
+        name = aoStrDupRaw(next.start, next.len);
+        is_path = 1;
+    } else {
+        lexRaise(l,
+                "Syntax is: #link \"<path>\" or #link <libname> got: %s",
+                lexemeToString(&next));
+    }
+
+    /* Standalone lexers (e.g. the `-tokens` dump) have nothing to
+     * link against; parse and drop. */
+    if (!l->cc) {
+        aoStrRelease(name);
+        return;
+    }
+
+    /* Paths ride the existing shared-object plumbing (same list the
+     * CLI's positional `.so` arguments land in); names get their own
+     * list as they need `-l`/dlopen-probe treatment downstream. */
+    List **libs = is_path ? &l->cc->shared_object_files
+                          : &l->cc->link_libs;
+    if (*libs == NULL) {
+        *libs = listNew();
+    }
+    if (!listContainsAoStr(*libs, name)) {
+        listAppend(*libs, name);
+    } else {
+        aoStrRelease(name);
+    }
+}
+
 Lexeme *lexDefine(Map *macro_defs, Lexer *l) {
     int tk_type,iters;
     Lexeme next,*start,*end,*expanded,*macro;
@@ -1551,25 +1685,23 @@ void lexUndef(Map *macro_defs, Lexer *l) {
 }
 
 int lexPreProcIf(Map *macro_defs, Lexer *l) {
-    int tk_type,iters,should_collect;
+    int tk_type,should_collect,in_defined;
     Vec *macro_tokens;
     Lexeme next,*start,*end,*expanded,*macro;
 
     tk_type = -1;
     should_collect = 0;
+    in_defined = 0;
     macro_tokens = lexemeVecNew();
 
     /* An if must be on one line a \n determines the end of a define */
     l->flags |= CCF_ACCEPT_NEWLINES;
-    iters = 0;
 
     if (!lex(l,&next)) {
         lexRaise(l, "Run out of tokens");
     }
 
     while (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')){ 
-        iters++;
-
         if (tokenPunctIs(&next,'\\')) {
             if (!lex(l,&next)) break;
             if (!tokenPunctIs(&next,'\n')) {
@@ -1581,11 +1713,35 @@ int lexPreProcIf(Map *macro_defs, Lexer *l) {
         } 
 
         if (next.tk_type == TK_IDENT) {
-            if ((macro = mapGetLen(macro_defs,next.start,next.len)) != NULL) {
+            macro = mapGetLen(macro_defs,next.start,next.len);
+            if (in_defined) {
+                /* `defined(X)` works by presence: the parser sees
+                 * `defined()` for an undefined X (the identifier is
+                 * dropped) and `defined(<value>)` for a defined one.
+                 * Don't substitute literals here. */
+                if (macro != NULL) vecPush(macro_tokens,lexemeCopy(macro));
+            } else if (macro != NULL && macro->tk_type != -1) {
                 vecPush(macro_tokens,lexemeCopy(macro));
                 tk_type = macro->tk_type;
+            } else {
+                /* Valueless flag macros (`#define FOO`, the builtin
+                 * platform defines - stored as sentinels) count as 1;
+                 * undefined identifiers count as 0, as in C.
+                 * Substituting a literal keeps the expression
+                 * well-formed either way. */
+                Lexeme *lit = lexemeCopy(&next);
+                lit->tk_type = TK_I64;
+                lit->i64 = (macro != NULL);
+                vecPush(macro_tokens,lit);
+                if (tk_type == -1) tk_type = TK_I64;
             }
             if (!lex(l,&next)) break;
+            /* Re-check the loop condition rather than falling through:
+             * if the identifier was the last token on the line, the
+             * unconditional advance at the bottom of the loop would
+             * swallow the newline and start consuming the NEXT source
+             * line into this expression. */
+            continue;
         }
 
         if (tk_type == -1) {
@@ -1599,25 +1755,47 @@ int lexPreProcIf(Map *macro_defs, Lexer *l) {
         }
         if (!tokenPunctIs(&next,'\n') && !tokenPunctIs(&next,'\0')) {
             vecPush(macro_tokens,lexemeCopy(&next));
+            if (next.tk_type == TK_KEYWORD && next.i64 == KW_DEFINED) {
+                in_defined = 1;
+            } else if (tokenPunctIs(&next,')')) {
+                in_defined = 0;
+            }
         }
         if (!lex(l,&next)) break;
     }
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
-    start = macro_tokens->entries[0];
-    end = macro_tokens->entries[macro_tokens->size-1];
-
-    if (start == end && iters == 1) {
+    /* Guard BEFORE touching entries: `#if` with nothing on the line
+     * used to read entries[0] / entries[-1] of an empty vector. A
+     * single-token expression (`#if 1`, `#if FLAG`) is legal. */
+    if (macro_tokens->size == 0) {
         lexRaise(l, "a #if must evaluate some expression");
         return 0;
     }
+
+    start = macro_tokens->entries[0];
+    end = macro_tokens->entries[macro_tokens->size-1];
     cctrlInitMacroProcessor(macro_proccessor);
-    macro_proccessor->token_buffer->entries = (Lexeme **)macro_tokens->entries;
+    /* Hand the parser a ring padded out with sentinels: parsePrimary
+     * rewinds one slot to inspect the token preceding an expression
+     * (and error paths rewind further), so every slot the ring can
+     * reach must hold a valid lexeme. The +1 also guarantees capacity
+     * exceeds size - with capacity == size the rewind lands on the
+     * expression's own last token. */
+    u64 ring_cap = roundUpToNextPowerOf2(macro_tokens->size + 1);
+    Lexeme **ring = (Lexeme **)malloc(ring_cap * sizeof(Lexeme *));
+    for (u64 i = 0; i < ring_cap; ++i) {
+        ring[i] = i < macro_tokens->size
+                  ? (Lexeme *)macro_tokens->entries[i]
+                  : lexemeSentinal();
+    }
+    macro_proccessor->token_buffer->entries = ring;
     macro_proccessor->token_buffer->size = macro_tokens->size;
-    macro_proccessor->token_buffer->capacity = roundUpToNextPowerOf2(macro_tokens->size);
+    macro_proccessor->token_buffer->capacity = ring_cap;
 
     Ast *ast = parseExpr(macro_proccessor,16);
+    free(ring);
     expanded = lexemeNew(start->start,end->len-start->len);
     expanded->tk_type = tk_type;
 
@@ -1645,6 +1823,13 @@ int lexPreProcIf(Map *macro_defs, Lexer *l) {
 int lexPreProcBoolean(Lexer *l, Map *macro_defs, Lexeme *le) {
     Lexeme next,*macro;
 
+    /* The skip loops feed every token from a dead `#if` region through
+     * here. `i64` only holds a keyword id for TK_KEYWORD tokens - for
+     * identifiers it's whatever was left in the union, which can
+     * collide with a KW_PP_* value and re-trigger directive parsing on
+     * arbitrary skipped text. */
+    if (le->tk_type != TK_KEYWORD) return 0;
+
     switch (le->i64) {
         case KW_PP_IF: {
             int ok = lexPreProcIf(macro_defs,l);
@@ -1664,7 +1849,26 @@ int lexPreProcBoolean(Lexer *l, Map *macro_defs, Lexeme *le) {
                 l->collecting = 1;
                 l->skip_else = 1;
                 return 1;
-            } 
+            }
+
+            l->collecting = 0;
+            l->skip_else = 0;
+            return 0;
+        }
+
+        case KW_PP_IF_JIT:
+        case KW_PP_IF_AOT: {
+            /* `#ifdef` with an implicit identifier: main() defines
+             * exactly one of __HCC_JIT__ / __HCC_AOT__, so each form
+             * is the other's negation and both compose with
+             * #else / #endif through the shared skip machinery. */
+            char *flag = le->i64 == KW_PP_IF_JIT ? "__HCC_JIT__"
+                                                 : "__HCC_AOT__";
+            if (mapGetLen(macro_defs,flag,(s64)strlen(flag)) != NULL) {
+                l->collecting = 1;
+                l->skip_else = 1;
+                return 1;
+            }
 
             l->collecting = 0;
             l->skip_else = 0;
@@ -1752,6 +1956,10 @@ Lexeme *lexToken(Map *macro_defs, Lexer *l) {
                     lexInclude(l);
                     continue;
                 }
+                case KW_PP_LINK: {
+                    lexLink(l);
+                    continue;
+                }
                 case KW_PP_DEFINE: {
                     copy = lexDefine(macro_defs,l);
                     continue;
@@ -1786,6 +1994,8 @@ Lexeme *lexToken(Map *macro_defs, Lexer *l) {
 
                 case KW_PP_IF_DEF:
                 case KW_PP_IF_NDEF:
+                case KW_PP_IF_JIT:
+                case KW_PP_IF_AOT:
                 case KW_PP_IF: {
                     int line = le.line;
                     while ((lexPreProcBoolean(l,macro_defs,&le)) != 1) {

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -8,7 +8,7 @@
 #include "list.h"
 
 #define LEX_MAX_IDENT_LEN  128
-#define LEX_CHAR_CONST_LEN 9
+#define LEX_CHAR_CONST_LEN 8
 
 /* TOKENS */
 #define TK_EOF          0
@@ -136,6 +136,18 @@
 #define KW_F32          85
 /* Compile-time alignment query: `alignof(<type or expr>)`. */
 #define KW_ALIGNOF      86
+/* `#link "<path>"` / `#link <libname>` - record a shared library
+ * dependency in the source itself. AOT passes it to the linker,
+ * the JIT dlopen's it. */
+#define KW_PP_LINK      87
+/* `#ifjit` / `#ifaot` - sugar for `#ifdef __HCC_JIT__` /
+ * `#ifdef __HCC_AOT__` (main() defines exactly one of the two).
+ * Compose with #else / #endif like any other #if. */
+#define KW_PP_IF_JIT    88
+#define KW_PP_IF_AOT    89
+/* Compile-time type query: `typeof(<type or expr>)` folds to a string
+ * literal naming the type, e.g. typeof(1+1) == "I64". */
+#define KW_TYPEOF       90
 
 /* Compiler Flags*/
 #define CCF_MULTI_CHAR_OP     (1<<0)
@@ -231,6 +243,7 @@ typedef struct Lexer {
 void lexemeMemoryInit(void);
 void lexemeMemoryRelease(void);
 void lexemeMemoryStats(void);
+void lexerRelease(Lexer *l);
 
 Lexeme *lexemeTokNew(char *start, int len, int line, s64 ch);
 Lexeme *lexemeNew(char *start, int len);
@@ -238,6 +251,9 @@ Lexeme *lexemeSentinal(void);
 void lexSetBuiltinRoot(Lexer *l, char *root);
 void lexInit(Lexer *l, char *source, int flag);
 void lexPushFile(Lexer *l, AoStr *filename);
+/* Push an in-memory buffer as if it were a file (REPL input). `src`
+ * is borrowed and must outlive the parse of this buffer. */
+void lexPushString(Lexer *l, char *name, char *src, s64 len);
 int lex(Lexer *l, Lexeme *le);
 Lexeme *lexToken(Map *macro_defs, Lexer *l);
 void lexemePrint(Lexeme *le);

--- a/src/linenoise/LICENSE
+++ b/src/linenoise/LICENSE
@@ -1,0 +1,25 @@
+Copyright (c) 2010-2014, Salvatore Sanfilippo <antirez at gmail dot com>
+Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/linenoise/linenoise.c
+++ b/src/linenoise/linenoise.c
@@ -1,0 +1,2384 @@
+/* linenoise.c -- guerrilla line editing library against the idea that a
+ * line editing lib needs to be 20,000 lines of C code.
+ *
+ * You can find the latest source code at:
+ *
+ *   http://github.com/antirez/linenoise
+ *
+ * Does a number of crazy assumptions that happen to be true in 99.9999% of
+ * the 2010 UNIX computers around.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * Copyright (c) 2010-2023, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * References:
+ * - http://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+ * - http://www.3waylabs.com/nw/WWW/products/wizcon/vt220.html
+ *
+ * Todo list:
+ * - Filter bogus Ctrl+<char> combinations.
+ * - Win32 support
+ *
+ * Bloat:
+ * - History search like Ctrl+r in readline?
+ *
+ * List of escape sequences used by this program, we do everything just
+ * with three sequences. In order to be so cheap we may have some
+ * flickering effect with some slow terminal, but the lesser sequences
+ * the more compatible.
+ *
+ * EL (Erase Line)
+ *    Sequence: ESC [ n K
+ *    Effect: if n is 0 or missing, clear from cursor to end of line
+ *    Effect: if n is 1, clear from beginning of line to cursor
+ *    Effect: if n is 2, clear entire line
+ *
+ * CUF (CUrsor Forward)
+ *    Sequence: ESC [ n C
+ *    Effect: moves cursor forward n chars
+ *
+ * CUB (CUrsor Backward)
+ *    Sequence: ESC [ n D
+ *    Effect: moves cursor backward n chars
+ *
+ * The following is used to get the terminal width if getting
+ * the width with the TIOCGWINSZ ioctl fails
+ *
+ * DSR (Device Status Report)
+ *    Sequence: ESC [ 6 n
+ *    Effect: reports the current cusor position as ESC [ n ; m R
+ *            where n is the row and m is the column
+ *
+ * When multi line mode is enabled, we also use an additional escape
+ * sequence. However multi line editing is disabled by default.
+ *
+ * CUU (Cursor Up)
+ *    Sequence: ESC [ n A
+ *    Effect: moves cursor up of n chars.
+ *
+ * CUD (Cursor Down)
+ *    Sequence: ESC [ n B
+ *    Effect: moves cursor down of n chars.
+ *
+ * When linenoiseClearScreen() is called, two additional escape sequences
+ * are used in order to clear the screen and position the cursor at home
+ * position.
+ *
+ * CUP (Cursor position)
+ *    Sequence: ESC [ H
+ *    Effect: moves the cursor to upper left corner
+ *
+ * ED (Erase display)
+ *    Sequence: ESC [ 2 J
+ *    Effect: clear the whole screen
+ *
+ */
+
+#include <termios.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "linenoise.h"
+
+#define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
+#define LINENOISE_MAX_LINE (1024*1024)      // That will get dynamically allocated
+#define LINENOISE_INITIAL_BUFLEN 4096
+#define PASTE_FOLD_THRESHOLD 200            // Min bytes to fold a single-line paste.
+#define PASTE_FOLD_CONTEXT 8                // Context chars kept around generic folds.
+#define PASTE_MAX_BYTES LINENOISE_MAX_LINE
+static char *unsupported_term[] = {"dumb","cons25","emacs",NULL};
+static linenoiseCompletionCallback *completionCallback = NULL;
+static linenoiseHintsCallback *hintsCallback = NULL;
+static linenoiseFreeHintsCallback *freeHintsCallback = NULL;
+static char *linenoiseReadLine(FILE *fp, int *err);
+static char *linenoiseNoTTY(void);
+static void refreshLineWithCompletion(struct linenoiseState *ls, linenoiseCompletions *lc, int flags);
+static void refreshLineWithFlags(struct linenoiseState *l, int flags);
+static void linenoiseFoldClear(struct linenoiseState *l);
+
+static struct termios orig_termios; /* In order to restore at exit.*/
+static int maskmode = 0; /* Show "***" instead of input. For passwords. */
+static int rawmode = 0; /* For atexit() function to check if restore is needed*/
+static int rawmode_output = STDOUT_FILENO; /* fd used for terminal escapes. */
+static int mlmode = 0;  /* Multi line mode. Default is single line. */
+static int atexit_registered = 0; /* Register atexit just 1 time. */
+static int history_max_len = LINENOISE_DEFAULT_HISTORY_MAX_LEN;
+static int history_len = 0;
+static char **history = NULL;
+
+/* =========================== UTF-8 support ================================ */
+
+/* Return the number of bytes that compose the UTF-8 character starting at
+ * 'c'. This function assumes a valid UTF-8 encoding and handles the four
+ * standard byte patterns:
+ *   0xxxxxxx -> 1 byte (ASCII)
+ *   110xxxxx -> 2 bytes
+ *   1110xxxx -> 3 bytes
+ *   11110xxx -> 4 bytes */
+static int utf8ByteLen(char c) {
+    unsigned char uc = (unsigned char)c;
+    if ((uc & 0x80) == 0)    return 1;   /* 0xxxxxxx: ASCII */
+    if ((uc & 0xE0) == 0xC0) return 2;   /* 110xxxxx: 2-byte seq */
+    if ((uc & 0xF0) == 0xE0) return 3;   /* 1110xxxx: 3-byte seq */
+    if ((uc & 0xF8) == 0xF0) return 4;   /* 11110xxx: 4-byte seq */
+    return 1; /* Fallback for invalid encoding, treat as single byte. */
+}
+
+/* Decode a UTF-8 sequence starting at 's' into a Unicode codepoint.
+ * Returns the codepoint value. Assumes valid UTF-8 encoding. */
+static uint32_t utf8DecodeChar(const char *s, size_t *len) {
+    unsigned char *p = (unsigned char *)s;
+    uint32_t cp;
+
+    if ((*p & 0x80) == 0) {
+        *len = 1;
+        return *p;
+    } else if ((*p & 0xE0) == 0xC0) {
+        *len = 2;
+        cp = (*p & 0x1F) << 6;
+        cp |= (p[1] & 0x3F);
+        return cp;
+    } else if ((*p & 0xF0) == 0xE0) {
+        *len = 3;
+        cp = (*p & 0x0F) << 12;
+        cp |= (p[1] & 0x3F) << 6;
+        cp |= (p[2] & 0x3F);
+        return cp;
+    } else if ((*p & 0xF8) == 0xF0) {
+        *len = 4;
+        cp = (*p & 0x07) << 18;
+        cp |= (p[1] & 0x3F) << 12;
+        cp |= (p[2] & 0x3F) << 6;
+        cp |= (p[3] & 0x3F);
+        return cp;
+    }
+    *len = 1;
+    return *p; /* Fallback for invalid sequences. */
+}
+
+/* Check if codepoint is a variation selector (emoji style modifiers). */
+static int isVariationSelector(uint32_t cp) {
+    return cp == 0xFE0E || cp == 0xFE0F;  /* Text/emoji style */
+}
+
+/* Check if codepoint is a skin tone modifier. */
+static int isSkinToneModifier(uint32_t cp) {
+    return cp >= 0x1F3FB && cp <= 0x1F3FF;
+}
+
+/* Check if codepoint is Zero Width Joiner. */
+static int isZWJ(uint32_t cp) {
+    return cp == 0x200D;
+}
+
+/* Check if codepoint is a Regional Indicator (for flag emoji). */
+static int isRegionalIndicator(uint32_t cp) {
+    return cp >= 0x1F1E6 && cp <= 0x1F1FF;
+}
+
+/* Check if codepoint is a combining mark or other zero-width character. */
+static int isCombiningMark(uint32_t cp) {
+    return (cp >= 0x0300 && cp <= 0x036F) ||   /* Combining Diacriticals */
+           (cp >= 0x1AB0 && cp <= 0x1AFF) ||   /* Combining Diacriticals Extended */
+           (cp >= 0x1DC0 && cp <= 0x1DFF) ||   /* Combining Diacriticals Supplement */
+           (cp >= 0x20D0 && cp <= 0x20FF) ||   /* Combining Diacriticals for Symbols */
+           (cp >= 0xFE20 && cp <= 0xFE2F);     /* Combining Half Marks */
+}
+
+/* Check if codepoint extends the previous character (doesn't start a new grapheme). */
+static int isGraphemeExtend(uint32_t cp) {
+    return isVariationSelector(cp) || isSkinToneModifier(cp) ||
+           isZWJ(cp) || isCombiningMark(cp);
+}
+
+/* Decode the UTF-8 codepoint ending at position 'pos' (exclusive) and
+ * return its value. Also sets *cplen to the byte length of the codepoint. */
+static uint32_t utf8DecodePrev(const char *buf, size_t pos, size_t *cplen) {
+    if (pos == 0) {
+        *cplen = 0;
+        return 0;
+    }
+    /* Scan backwards to find the start byte. */
+    size_t i = pos;
+    do {
+        i--;
+    } while (i > 0 && (pos - i) < 4 && ((unsigned char)buf[i] & 0xC0) == 0x80);
+    *cplen = pos - i;
+    size_t dummy;
+    return utf8DecodeChar(buf + i, &dummy);
+}
+
+/* Given a buffer and a position, return the byte length of the grapheme
+ * cluster before that position. A grapheme cluster includes:
+ * - The base character
+ * - Any following variation selectors, skin tone modifiers
+ * - ZWJ sequences (emoji joined by Zero Width Joiner)
+ * - Regional indicator pairs (flag emoji) */
+static size_t utf8PrevCharLen(const char *buf, size_t pos) {
+    if (pos == 0) return 0;
+
+    size_t total = 0;
+    size_t curpos = pos;
+
+    /* First, get the last codepoint. */
+    size_t cplen;
+    uint32_t cp = utf8DecodePrev(buf, curpos, &cplen);
+    if (cplen == 0) return 0;
+    total += cplen;
+    curpos -= cplen;
+
+    /* If we're at an extending character, we need to find what it extends.
+     * Keep going back through the grapheme cluster. */
+    while (curpos > 0) {
+        size_t prevlen;
+        uint32_t prevcp = utf8DecodePrev(buf, curpos, &prevlen);
+        if (prevlen == 0) break;
+
+        if (isZWJ(prevcp)) {
+            /* ZWJ joins two emoji. Include the ZWJ and continue to get
+             * the preceding character. */
+            total += prevlen;
+            curpos -= prevlen;
+            /* Now get the character before ZWJ. */
+            prevcp = utf8DecodePrev(buf, curpos, &prevlen);
+            if (prevlen == 0) break;
+            total += prevlen;
+            curpos -= prevlen;
+            cp = prevcp;
+            continue;  /* Check if there's more extending before this. */
+        } else if (isGraphemeExtend(cp)) {
+            /* Current cp is an extending character; include previous. */
+            total += prevlen;
+            curpos -= prevlen;
+            cp = prevcp;
+            continue;
+        } else if (isRegionalIndicator(cp) && isRegionalIndicator(prevcp)) {
+            /* Two regional indicators form a flag. But we need to be careful:
+             * flags are always pairs, so only join if we're at an even boundary.
+             * For simplicity, just join one pair. */
+            total += prevlen;
+            curpos -= prevlen;
+            break;
+        } else {
+            /* No more extending; we've found the start of the cluster. */
+            break;
+        }
+    }
+
+    return total;
+}
+
+/* Given a buffer, position and total length, return the byte length of the
+ * grapheme cluster at the current position. */
+static size_t utf8NextCharLen(const char *buf, size_t pos, size_t len) {
+    if (pos >= len) return 0;
+
+    size_t total = 0;
+    size_t curpos = pos;
+
+    /* Get the first codepoint. */
+    size_t cplen;
+    uint32_t cp = utf8DecodeChar(buf + curpos, &cplen);
+    total += cplen;
+    curpos += cplen;
+
+    int isRI = isRegionalIndicator(cp);
+
+    /* Consume any extending characters that follow. */
+    while (curpos < len) {
+        size_t nextlen;
+        uint32_t nextcp = utf8DecodeChar(buf + curpos, &nextlen);
+
+        if (isZWJ(nextcp) && curpos + nextlen < len) {
+            /* ZWJ: include it and the following character. */
+            total += nextlen;
+            curpos += nextlen;
+            /* Get the character after ZWJ. */
+            nextcp = utf8DecodeChar(buf + curpos, &nextlen);
+            total += nextlen;
+            curpos += nextlen;
+            continue;  /* Check for more extending after the joined char. */
+        } else if (isGraphemeExtend(nextcp)) {
+            /* Variation selector, skin tone, combining mark, etc. */
+            total += nextlen;
+            curpos += nextlen;
+            continue;
+        } else if (isRI && isRegionalIndicator(nextcp)) {
+            /* Second regional indicator for a flag pair. */
+            total += nextlen;
+            curpos += nextlen;
+            isRI = 0;  /* Only pair once. */
+            continue;
+        } else {
+            break;
+        }
+    }
+
+    return total;
+}
+
+/* Return the display width of a Unicode codepoint. This is a heuristic
+ * that works for most common cases:
+ * - Control chars and zero-width: 0 columns
+ * - Grapheme-extending chars (VS, skin tone, ZWJ): 0 columns
+ * - ASCII printable: 1 column
+ * - Wide chars (CJK, emoji, fullwidth): 2 columns
+ * - Everything else: 1 column
+ *
+ * This is not a full wcwidth() implementation, but a minimal heuristic
+ * that handles emoji and CJK characters reasonably well. */
+static int utf8CharWidth(uint32_t cp) {
+    /* Control characters and combining marks: zero width. */
+    if (cp < 32 || (cp >= 0x7F && cp < 0xA0)) return 0;
+    if (isCombiningMark(cp)) return 0;
+
+    /* Grapheme-extending characters: zero width.
+     * These modify the preceding character rather than taking space. */
+    if (isVariationSelector(cp)) return 0;
+    if (isSkinToneModifier(cp)) return 0;
+    if (isZWJ(cp)) return 0;
+
+    /* Wide character ranges - these display as 2 columns:
+     * - CJK Unified Ideographs and Extensions
+     * - Fullwidth forms
+     * - Various emoji ranges */
+    if (cp >= 0x1100 &&
+        (cp <= 0x115F ||                      /* Hangul Jamo */
+         cp == 0x2329 || cp == 0x232A ||      /* Angle brackets */
+         (cp >= 0x231A && cp <= 0x231B) ||    /* Watch, Hourglass */
+         (cp >= 0x23E9 && cp <= 0x23F3) ||    /* Various symbols */
+         (cp >= 0x23F8 && cp <= 0x23FA) ||    /* Various symbols */
+         (cp >= 0x25AA && cp <= 0x25AB) ||    /* Small squares */
+         (cp >= 0x25B6 && cp <= 0x25C0) ||    /* Play/reverse buttons */
+         (cp >= 0x25FB && cp <= 0x25FE) ||    /* Squares */
+         (cp >= 0x2600 && cp <= 0x26FF) ||    /* Misc Symbols (sun, cloud, etc) */
+         (cp >= 0x2700 && cp <= 0x27BF) ||    /* Dingbats (❤, ✂, etc) */
+         (cp >= 0x2934 && cp <= 0x2935) ||    /* Arrows */
+         (cp >= 0x2B05 && cp <= 0x2B07) ||    /* Arrows */
+         (cp >= 0x2B1B && cp <= 0x2B1C) ||    /* Squares */
+         cp == 0x2B50 || cp == 0x2B55 ||      /* Star, circle */
+         (cp >= 0x2E80 && cp <= 0xA4CF &&
+          cp != 0x303F) ||                    /* CJK ... Yi */
+         (cp >= 0xAC00 && cp <= 0xD7A3) ||    /* Hangul Syllables */
+         (cp >= 0xF900 && cp <= 0xFAFF) ||    /* CJK Compatibility Ideographs */
+         (cp >= 0xFE10 && cp <= 0xFE1F) ||    /* Vertical forms */
+         (cp >= 0xFE30 && cp <= 0xFE6F) ||    /* CJK Compatibility Forms */
+         (cp >= 0xFF00 && cp <= 0xFF60) ||    /* Fullwidth Forms */
+         (cp >= 0xFFE0 && cp <= 0xFFE6) ||    /* Fullwidth Signs */
+         (cp >= 0x1F1E6 && cp <= 0x1F1FF) ||  /* Regional Indicators (flags) */
+         (cp >= 0x1F300 && cp <= 0x1F64F) ||  /* Misc Symbols and Emoticons */
+         (cp >= 0x1F680 && cp <= 0x1F6FF) ||  /* Transport and Map Symbols */
+         (cp >= 0x1F900 && cp <= 0x1F9FF) ||  /* Supplemental Symbols */
+         (cp >= 0x1FA00 && cp <= 0x1FAFF) ||  /* Chess, Extended-A */
+         (cp >= 0x20000 && cp <= 0x2FFFF)))   /* CJK Extension B and beyond */
+        return 2;
+
+    return 1; /* Default: single width */
+}
+
+/* If s[] points at an ANSI CSI escape sequence (e.g. a color change like
+ * ESC [ 1 ; 32 m), return its length in bytes. Otherwise return 0.
+ *
+ * The caller must have already verified that s[0] == ESC (0x1b). The
+ * sequence layout follows ECMA-48: ESC '[' , parameter bytes (0x30-0x3f),
+ * intermediate bytes (0x20-0x2f), and a final byte (0x40-0x7e). */
+static size_t ansiEscapeLen(const char *s, size_t len) {
+    size_t i;
+    if (len < 2 || s[1] != '[') return 0;
+    i = 2;
+    while (i < len && (unsigned char)s[i] >= 0x30 && (unsigned char)s[i] <= 0x3f) i++;
+    while (i < len && (unsigned char)s[i] >= 0x20 && (unsigned char)s[i] <= 0x2f) i++;
+    if (i >= len || (unsigned char)s[i] < 0x40 || (unsigned char)s[i] > 0x7e) return 0;
+    return i + 1;
+}
+
+/* Calculate the display width of a UTF-8 string of 'len' bytes.
+ * This is used for cursor positioning in the terminal.
+ * Handles grapheme clusters: characters joined by ZWJ contribute 0 width
+ * after the first character in the sequence.
+ * ANSI CSI escape sequences (e.g. color codes in the prompt) are treated
+ * as zero-width. */
+static size_t utf8StrWidth(const char *s, size_t len) {
+    size_t width = 0;
+    size_t i = 0;
+    int after_zwj = 0;  /* Track if previous char was ZWJ */
+
+    while (i < len) {
+        size_t clen;
+        uint32_t cp = utf8DecodeChar(s + i, &clen);
+
+        /* Skip ANSI CSI escape sequences entirely: they produce no
+         * glyph, so they must not contribute to the display width.
+         * Checked before the ZWJ state so a stray ZWJ immediately
+         * followed by ESC cannot swallow the ESC byte. */
+        if (cp == 0x1b) {
+            size_t skip = ansiEscapeLen(s + i, len - i);
+            if (skip > 0) {
+                i += skip;
+                continue;
+            }
+        }
+
+        if (after_zwj) {
+            /* Character after ZWJ: don't add width, it's joined.
+             * But do check for extending chars after it. */
+            after_zwj = 0;
+        } else {
+            width += utf8CharWidth(cp);
+        }
+
+        /* Check if this is a ZWJ - next char will be joined. */
+        if (isZWJ(cp)) {
+            after_zwj = 1;
+        }
+
+        i += clen;
+    }
+    return width;
+}
+
+/* Return the display width of a single UTF-8 character at position 's'. */
+static int utf8SingleCharWidth(const char *s, size_t len) {
+    if (len == 0) return 0;
+    size_t clen;
+    uint32_t cp = utf8DecodeChar(s, &clen);
+    return utf8CharWidth(cp);
+}
+
+enum KEY_ACTION{
+	KEY_NULL = 0,	    /* NULL */
+	CTRL_A = 1,         /* Ctrl+a */
+	CTRL_B = 2,         /* Ctrl-b */
+	CTRL_C = 3,         /* Ctrl-c */
+	CTRL_D = 4,         /* Ctrl-d */
+	CTRL_E = 5,         /* Ctrl-e */
+	CTRL_F = 6,         /* Ctrl-f */
+	CTRL_H = 8,         /* Ctrl-h */
+	TAB = 9,            /* Tab */
+	CTRL_K = 11,        /* Ctrl+k */
+	CTRL_L = 12,        /* Ctrl+l */
+	ENTER = 13,         /* Enter */
+	CTRL_N = 14,        /* Ctrl-n */
+	CTRL_P = 16,        /* Ctrl-p */
+	CTRL_T = 20,        /* Ctrl-t */
+	CTRL_U = 21,        /* Ctrl+u */
+	CTRL_W = 23,        /* Ctrl+w */
+	ESC = 27,           /* Escape */
+	BACKSPACE =  127    /* Backspace */
+};
+
+static void linenoiseAtExit(void);
+int linenoiseHistoryAdd(const char *line);
+#define REFRESH_CLEAN (1<<0)    // Clean the old prompt from the screen
+#define REFRESH_WRITE (1<<1)    // Rewrite the prompt on the screen.
+#define REFRESH_ALL (REFRESH_CLEAN|REFRESH_WRITE) // Do both.
+static void refreshLine(struct linenoiseState *l);
+
+/* Debugging macro. */
+#if 0
+FILE *lndebug_fp = NULL;
+#define lndebug(...) \
+    do { \
+        if (lndebug_fp == NULL) { \
+            lndebug_fp = fopen("/tmp/lndebug.txt","a"); \
+            fprintf(lndebug_fp, \
+            "[%d %d %d] p: %d, rows: %d, rpos: %d, max: %d, oldmax: %d\n", \
+            (int)l->len,(int)l->pos,(int)l->oldpos,plen,rows,rpos, \
+            (int)l->oldrows,old_rows); \
+        } \
+        fprintf(lndebug_fp, ", " __VA_ARGS__); \
+        fflush(lndebug_fp); \
+    } while (0)
+#else
+#define lndebug(fmt, ...)
+#endif
+
+/* ======================= Low level terminal handling ====================== */
+
+/* Enable "mask mode". When it is enabled, instead of the input that
+ * the user is typing, the terminal will just display a corresponding
+ * number of asterisks, like "****". This is useful for passwords and other
+ * secrets that should not be displayed. */
+void linenoiseMaskModeEnable(void) {
+    maskmode = 1;
+}
+
+/* Disable mask mode. */
+void linenoiseMaskModeDisable(void) {
+    maskmode = 0;
+}
+
+/* Set if to use or not the multi line mode. */
+void linenoiseSetMultiLine(int ml) {
+    mlmode = ml;
+}
+
+/* Return true if the terminal name is in the list of terminals we know are
+ * not able to understand basic escape sequences. */
+static int isUnsupportedTerm(void) {
+    char *term = getenv("TERM");
+    int j;
+
+    if (term == NULL) return 0;
+    for (j = 0; unsupported_term[j]; j++)
+        if (!strcasecmp(term,unsupported_term[j])) return 1;
+    return 0;
+}
+
+/* Raw mode: 1960 magic shit. */
+static int enableRawMode(int fd) {
+    struct termios raw;
+
+    /* Test mode: when LINENOISE_ASSUME_TTY is set, skip terminal setup.
+     * This allows testing via pipes without a real terminal. */
+    if (getenv("LINENOISE_ASSUME_TTY")) {
+        rawmode = 1;
+        return 0;
+    }
+
+    if (!isatty(STDIN_FILENO)) goto fatal;
+    if (!atexit_registered) {
+        atexit(linenoiseAtExit);
+        atexit_registered = 1;
+    }
+    if (tcgetattr(fd,&orig_termios) == -1) goto fatal;
+
+    raw = orig_termios;  /* modify the original mode */
+    /* input modes: no break, no CR to NL, no parity check, no strip char,
+     * no start/stop output control. */
+    raw.c_iflag &= ~(BRKINT | ICRNL | INPCK | ISTRIP | IXON);
+    /* output modes - disable post processing */
+    raw.c_oflag &= ~(OPOST);
+    /* control modes - set 8 bit chars */
+    raw.c_cflag |= (CS8);
+    /* local modes - choing off, canonical off, no extended functions,
+     * no signal chars (^Z,^C) */
+    raw.c_lflag &= ~(ECHO | ICANON | IEXTEN | ISIG);
+    /* control chars - set return condition: min number of bytes and timer.
+     * We want read to return every single byte, without timeout. */
+    raw.c_cc[VMIN] = 1; raw.c_cc[VTIME] = 0; /* 1 byte, no timer */
+
+    /* Put the terminal in raw mode. hcc local patch: TCSADRAIN, not
+     * TCSAFLUSH - FLUSH discards queued input, so anything typed (or
+     * PASTED) while the REPL was compiling the previous line would be
+     * silently dropped when the next prompt re-enables raw mode. */
+    if (tcsetattr(fd,TCSADRAIN,&raw) < 0) goto fatal;
+    rawmode = 1;
+    /* Ask the terminal to wrap paste input between ESC[200~ and ESC[201~. */
+    if (write(rawmode_output, "\x1b[?2004h", 8) == -1) {}
+    return 0;
+
+fatal:
+    errno = ENOTTY;
+    return -1;
+}
+
+static void disableRawMode(int fd) {
+    /* Test mode: nothing to restore. */
+    if (getenv("LINENOISE_ASSUME_TTY")) {
+        rawmode = 0;
+        return;
+    }
+    /* Don't even check the return value as it's too late. */
+    /* hcc local patch: TCSADRAIN (see enableRawMode). */
+    if (rawmode && tcsetattr(fd,TCSADRAIN,&orig_termios) != -1) {
+        /* Leave bracketed paste mode when leaving raw mode. */
+        if (write(rawmode_output, "\x1b[?2004l", 8) == -1) {}
+        rawmode = 0;
+    }
+}
+
+/* Use the ESC [6n escape sequence to query the horizontal cursor position
+ * and return it. On error -1 is returned, on success the position of the
+ * cursor. */
+static int getCursorPosition(int ifd, int ofd) {
+    char buf[32];
+    int cols, rows;
+    unsigned int i = 0;
+
+    /* Report cursor location */
+    if (write(ofd, "\x1b[6n", 4) != 4) return -1;
+
+    /* Read the response: ESC [ rows ; cols R */
+    while (i < sizeof(buf)-1) {
+        if (read(ifd,buf+i,1) != 1) break;
+        if (buf[i] == 'R') break;
+        i++;
+    }
+    buf[i] = '\0';
+
+    /* Parse it. */
+    if (buf[0] != ESC || buf[1] != '[') return -1;
+    if (sscanf(buf+2,"%d;%d",&rows,&cols) != 2) return -1;
+    return cols;
+}
+
+/* Try to get the number of columns in the current terminal, or assume 80
+ * if it fails. */
+static int getColumns(int ifd, int ofd) {
+    struct winsize ws;
+
+    /* Test mode: use LINENOISE_COLS env var for fixed width. */
+    char *cols_env = getenv("LINENOISE_COLS");
+    if (cols_env) return atoi(cols_env);
+
+    if (ioctl(1, TIOCGWINSZ, &ws) == -1 || ws.ws_col == 0) {
+        /* ioctl() failed. Try to query the terminal itself. */
+        int start, cols;
+
+        /* Get the initial position so we can restore it later. */
+        start = getCursorPosition(ifd,ofd);
+        if (start == -1) goto failed;
+
+        /* Go to right margin and get position. */
+        if (write(ofd,"\x1b[999C",6) != 6) goto failed;
+        cols = getCursorPosition(ifd,ofd);
+        if (cols == -1) goto failed;
+
+        /* Restore position. */
+        if (cols > start) {
+            char seq[32];
+            snprintf(seq,32,"\x1b[%dD",cols-start);
+            if (write(ofd,seq,strlen(seq)) == -1) {
+                /* Can't recover... */
+            }
+        }
+        return cols;
+    } else {
+        return ws.ws_col;
+    }
+
+failed:
+    return 80;
+}
+
+/* Clear the screen. Used to handle ctrl+l */
+void linenoiseClearScreen(void) {
+    if (write(STDOUT_FILENO,"\x1b[H\x1b[2J",7) <= 0) {
+        /* nothing to do, just to avoid warning. */
+    }
+}
+
+/* Beep, used for completion when there is nothing to complete or when all
+ * the choices were already shown. */
+static void linenoiseBeep(void) {
+    fprintf(stderr, "\x7");
+    fflush(stderr);
+}
+
+/* ============================== Completion ================================ */
+
+/* Free a list of completion option populated by linenoiseAddCompletion(). */
+static void freeCompletions(linenoiseCompletions *lc) {
+    size_t i;
+    for (i = 0; i < lc->len; i++)
+        free(lc->cvec[i]);
+    if (lc->cvec != NULL)
+        free(lc->cvec);
+}
+
+/* Called by completeLine() and linenoiseShow() to render the current
+ * edited line with the proposed completion. If the current completion table
+ * is already available, it is passed as second argument, otherwise the
+ * function will use the callback to obtain it.
+ *
+ * Flags are the same as refreshLine*(), that is REFRESH_* macros. */
+static void refreshLineWithCompletion(struct linenoiseState *ls, linenoiseCompletions *lc, int flags) {
+    /* Obtain the table of completions if the caller didn't provide one. */
+    linenoiseCompletions ctable = { 0, NULL };
+    if (lc == NULL) {
+        completionCallback(ls->buf,&ctable);
+        lc = &ctable;
+    }
+
+    /* Show the edited line with completion if possible, or just refresh. */
+    if (ls->completion_idx < lc->len) {
+        struct linenoiseState saved = *ls;
+        ls->len = ls->pos = strlen(lc->cvec[ls->completion_idx]);
+        ls->buf = lc->cvec[ls->completion_idx];
+        ls->fold_count = 0;
+        refreshLineWithFlags(ls,flags);
+        ls->len = saved.len;
+        ls->pos = saved.pos;
+        ls->buf = saved.buf;
+        ls->fold_count = saved.fold_count;
+    } else {
+        refreshLineWithFlags(ls,flags);
+    }
+
+    /* Free the completions table if needed. */
+    if (lc != &ctable) freeCompletions(&ctable);
+}
+
+/* This is an helper function for linenoiseEdit*() and is called when the
+ * user types the <tab> key in order to complete the string currently in the
+ * input.
+ *
+ * The state of the editing is encapsulated into the pointed linenoiseState
+ * structure as described in the structure definition.
+ *
+ * If the function returns non-zero, the caller should handle the
+ * returned value as a byte read from the standard input, and process
+ * it as usually: this basically means that the function may return a byte
+ * read from the termianl but not processed. Otherwise, if zero is returned,
+ * the input was consumed by the completeLine() function to navigate the
+ * possible completions, and the caller should read for the next characters
+ * from stdin. */
+static int completeLine(struct linenoiseState *ls, int keypressed) {
+    linenoiseCompletions lc = { 0, NULL };
+    int nwritten;
+    char c = keypressed;
+
+    completionCallback(ls->buf,&lc);
+    if (lc.len == 0) {
+        linenoiseBeep();
+        ls->in_completion = 0;
+        c = 0;
+    } else {
+        switch(c) {
+            case 9: /* tab */
+                if (ls->in_completion == 0) {
+                    ls->in_completion = 1;
+                    ls->completion_idx = 0;
+                } else {
+                    ls->completion_idx = (ls->completion_idx+1) % (lc.len+1);
+                    if (ls->completion_idx == lc.len) linenoiseBeep();
+                }
+                c = 0;
+                break;
+            case 27: /* escape */
+                /* Re-show original buffer */
+                if (ls->completion_idx < lc.len) refreshLine(ls);
+                ls->in_completion = 0;
+                c = 0;
+                break;
+            default:
+                /* Update buffer and return */
+                if (ls->completion_idx < lc.len) {
+                    nwritten = snprintf(ls->buf,ls->buflen,"%s",
+                        lc.cvec[ls->completion_idx]);
+                    ls->len = ls->pos = nwritten;
+                    linenoiseFoldClear(ls);
+                }
+                ls->in_completion = 0;
+                break;
+        }
+
+        /* Show completion or original buffer */
+        if (ls->in_completion && ls->completion_idx < lc.len) {
+            refreshLineWithCompletion(ls,&lc,REFRESH_ALL);
+        } else {
+            refreshLine(ls);
+        }
+    }
+
+    freeCompletions(&lc);
+    return c; /* Return last read character */
+}
+
+/* Register a callback function to be called for tab-completion. */
+void linenoiseSetCompletionCallback(linenoiseCompletionCallback *fn) {
+    completionCallback = fn;
+}
+
+/* Register a hits function to be called to show hits to the user at the
+ * right of the prompt. */
+void linenoiseSetHintsCallback(linenoiseHintsCallback *fn) {
+    hintsCallback = fn;
+}
+
+/* Register a function to free the hints returned by the hints callback
+ * registered with linenoiseSetHintsCallback(). */
+void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *fn) {
+    freeHintsCallback = fn;
+}
+
+/* This function is used by the callback function registered by the user
+ * in order to add completion options given the input string when the
+ * user typed <tab>. See the example.c source code for a very easy to
+ * understand example. */
+void linenoiseAddCompletion(linenoiseCompletions *lc, const char *str) {
+    size_t len = strlen(str);
+    char *copy, **cvec;
+
+    copy = malloc(len+1);
+    if (copy == NULL) return;
+    memcpy(copy,str,len+1);
+    cvec = realloc(lc->cvec,sizeof(char*)*(lc->len+1));
+    if (cvec == NULL) {
+        free(copy);
+        return;
+    }
+    lc->cvec = cvec;
+    lc->cvec[lc->len++] = copy;
+}
+
+/* =========================== Line editing ================================= */
+
+/* We define a very simple "append buffer" structure, that is an heap
+ * allocated string where we can append to. This is useful in order to
+ * write all the escape sequences in a buffer and flush them to the standard
+ * output in a single call, to avoid flickering effects. */
+struct abuf {
+    char *b;
+    int len;
+};
+
+static void abInit(struct abuf *ab) {
+    ab->b = NULL;
+    ab->len = 0;
+}
+
+static void abAppend(struct abuf *ab, const char *s, int len) {
+    char *new = realloc(ab->b,ab->len+len);
+
+    if (new == NULL) return;
+    memcpy(new+ab->len,s,len);
+    ab->b = new;
+    ab->len += len;
+}
+
+static void abFree(struct abuf *ab) {
+    free(ab->b);
+}
+
+/* A fold is a display-only replacement for a range in l->buf. The edited
+ * buffer always keeps the real bytes; refresh code asks linenoiseRenderBuffer()
+ * for a temporary printable version plus the cursor position inside it. */
+struct linenoiseFold {
+    size_t start;
+    size_t end;
+    char display[64];
+    size_t displaylen;
+};
+
+struct linenoiseFolds {
+    int count;
+    struct linenoiseFold fold[LINENOISE_MAX_FOLDS];
+};
+
+/* Return the number of logical lines in the range. */
+static size_t foldCountLines(const char *buf, size_t len) {
+    size_t lines = 1, j;
+    for (j = 0; j < len; j++) {
+        if (buf[j] == '\n') lines++;
+    }
+    return lines;
+}
+
+/* Return true if the text should be folded: if it contains newlines or is at
+ * least PASTE_FOLD_THRESHOLD bytes long. */
+static int shouldFoldText(const char *buf, size_t len) {
+    return memchr(buf, '\n', len) != NULL || len >= PASTE_FOLD_THRESHOLD;
+}
+
+/* Fill f->display with the text shown instead of the folded range. */
+static void foldSetRenderedText(struct linenoiseFold *f, const char *buf) {
+    size_t hidden = f->end - f->start;
+    size_t lines = foldCountLines(buf + f->start, hidden);
+    int n;
+
+    if (lines > 1)
+        n = snprintf(f->display,sizeof(f->display),"[... %zu pasted lines ...]",lines);
+    else
+        n = snprintf(f->display,sizeof(f->display),"[... %zu pasted chars ...]",hidden);
+    if (n < 0) n = 0;
+    f->displaylen = (size_t)n;
+}
+
+/* Populate f with one fold reconstructed from a history entry. History stores
+ * the real text, but not the original paste boundaries, so we reconstruct
+ * an approximation of text we want to hide on the fly: if it is long or
+ * contains newlines. */
+static int linenoiseBuildHistoryFold(struct linenoiseState *l, struct linenoiseFold *f) {
+    f->start = f->end = f->displaylen = 0;
+    if (l->len == 0 || maskmode) return 0;
+    if (!shouldFoldText(l->buf,l->len)) return 0;
+
+    f->start = 0;
+    f->end = l->len;
+    if (l->len > PASTE_FOLD_CONTEXT*2) {
+        size_t pos = 0, chars = 0;
+        int nl = 0;
+
+        /* We leave (if possible) a few chars on
+         * the start before the fold, to give context. */
+        while (pos < l->len && chars < PASTE_FOLD_CONTEXT) {
+            size_t step = utf8NextCharLen(l->buf,pos,l->len);
+            if (step == 0 || pos + step > l->len) break;
+            if (l->buf[pos] == '\n') nl = 1;
+            pos += step;
+            chars++;
+        }
+        f->start = nl ? 0 : pos;
+
+        /* And also on the end side. */
+        pos = l->len;
+        chars = 0;
+        nl = 0;
+        while (pos > 0 && chars < PASTE_FOLD_CONTEXT) {
+            size_t step = utf8PrevCharLen(l->buf,pos);
+            if (step == 0 || step > pos) break;
+            pos -= step;
+            if (l->buf[pos] == '\n') nl = 1;
+            chars++;
+        }
+        f->end = nl ? l->len : pos;
+        if (f->start >= f->end) {
+            f->start = 0;
+            f->end = l->len;
+        }
+    }
+    foldSetRenderedText(f,l->buf);
+    return 1;
+}
+
+/* Populate fs with the folds to render for the current buffer. As a side
+ * effect, the rendered text of each fold is updated. Return 1 if folding
+ * should be used, or 0 if the buffer should be rendered as-is. */
+static int linenoiseGetRenderFolds(struct linenoiseState *l, struct linenoiseFolds *fs) {
+    int j;
+
+    fs->count = 0;
+    if (l->len == 0 || maskmode) return 0;
+
+    for (j = 0; j < l->fold_count; j++) {
+        struct linenoiseFold *f;
+        size_t start = l->fold_start[j];
+        size_t end = l->fold_end[j];
+
+        if (start >= end || end > l->len) continue;
+        f = fs->fold + fs->count++;
+        f->start = start;
+        f->end = end;
+        foldSetRenderedText(f,l->buf);
+    }
+    return fs->count != 0;
+}
+
+/* Return the freshly allocated string content that is actually displayed in
+ * the user prompt. It can be the actual edited line, or a special version
+ * where pasted or multiline history ranges are replaced by their folded
+ * "[...]" style versions. outpos is l->pos translated into this rendered
+ * buffer. */
+static int linenoiseRenderBuffer(struct linenoiseState *l, char **out, size_t *outlen, size_t *outpos) {
+    struct linenoiseFolds fs;
+    size_t len, pos, src, dst;
+    char *r;
+    int j, pos_set = 0;
+
+    if (!linenoiseGetRenderFolds(l,&fs)) {
+        /* Keep the refresh code simple: it always owns a temporary render
+         * buffer, even when the render is identical to the real edit buffer. */
+        r = malloc(l->len+1);
+        if (r == NULL) return -1;
+        memcpy(r,l->buf,l->len);
+        r[l->len] = '\0';
+        *out = r;
+        *outlen = l->len;
+        *outpos = l->pos;
+        return 0;
+    }
+
+    /* Gaps are copied as-is, folded ranges are replaced by their markers.
+     * The bytes inside each [start,end) range stay in l->buf but are not
+     * emitted to the terminal. */
+    len = l->len;
+    for (j = 0; j < fs.count; j++) {
+        struct linenoiseFold *f = fs.fold+j;
+        len -= f->end - f->start;
+        len += f->displaylen;
+    }
+    r = malloc(len+1);
+    if (r == NULL) return -1;
+
+    src = dst = 0;
+    pos = 0;
+    for (j = 0; j < fs.count; j++) {
+        struct linenoiseFold *f = fs.fold+j;
+        size_t gap = f->start - src;
+
+        if (!pos_set && l->pos <= f->start) {
+            pos = dst + (l->pos - src);
+            pos_set = 1;
+        }
+        memcpy(r+dst,l->buf+src,gap);
+        dst += gap;
+
+        if (!pos_set && l->pos < f->end) {
+            pos = dst + f->displaylen;
+            pos_set = 1;
+        }
+        memcpy(r+dst,f->display,f->displaylen);
+        dst += f->displaylen;
+        if (!pos_set && l->pos == f->end) {
+            pos = dst;
+            pos_set = 1;
+        }
+        src = f->end;
+    }
+    if (!pos_set) pos = dst + (l->pos - src);
+    memcpy(r+dst,l->buf+src,l->len-src);
+    r[len] = '\0';
+
+    *out = r;
+    *outlen = len;
+    *outpos = pos;
+    return 0;
+}
+
+/* Return the number of bytes to move right from pos. If pos is at the start of
+ * a folded range, the whole hidden range is skipped by one cursor movement. */
+static size_t linenoiseEditNextLen(struct linenoiseState *l, size_t pos) {
+    struct linenoiseFolds fs;
+    int j;
+
+    if (linenoiseGetRenderFolds(l,&fs)) {
+        for (j = 0; j < fs.count; j++) {
+            if (pos == fs.fold[j].start)
+                return fs.fold[j].end - fs.fold[j].start;
+        }
+    }
+    return utf8NextCharLen(l->buf,pos,l->len);
+}
+
+/* Return the number of bytes to move left from pos. If pos is at the end of a
+ * folded range, the whole hidden range is skipped by one cursor movement. */
+static size_t linenoiseEditPrevLen(struct linenoiseState *l, size_t pos) {
+    struct linenoiseFolds fs;
+    int j;
+
+    if (linenoiseGetRenderFolds(l,&fs)) {
+        for (j = 0; j < fs.count; j++) {
+            if (pos == fs.fold[j].end)
+                return fs.fold[j].end - fs.fold[j].start;
+        }
+    }
+    return utf8PrevCharLen(l->buf,pos);
+}
+
+/* Add a fold range, keeping the array sorted by start offset. */
+static void linenoiseFoldAdd(struct linenoiseState *l, size_t start, size_t end) {
+    int j;
+
+    if (start >= end || l->fold_count == LINENOISE_MAX_FOLDS) return;
+    j = l->fold_count;
+    while (j > 0 && start < l->fold_start[j-1]) {
+        l->fold_start[j] = l->fold_start[j-1];
+        l->fold_end[j] = l->fold_end[j-1];
+        j--;
+    }
+    l->fold_start[j] = start;
+    l->fold_end[j] = end;
+    l->fold_count++;
+}
+
+/* Clear all remembered fold ranges. */
+static void linenoiseFoldClear(struct linenoiseState *l) {
+    l->fold_count = 0;
+}
+
+/* Remove one remembered fold range. */
+static void linenoiseFoldRemove(struct linenoiseState *l, int j) {
+    memmove(l->fold_start+j,l->fold_start+j+1,
+            sizeof(size_t)*(l->fold_count-j-1));
+    memmove(l->fold_end+j,l->fold_end+j+1,
+            sizeof(size_t)*(l->fold_count-j-1));
+    l->fold_count--;
+}
+
+/* Return true if [pos,pos+len) overlaps any folded range. */
+static int linenoiseRangeOverlapsFold(struct linenoiseState *l, size_t pos, size_t len) {
+    size_t end = pos + len;
+    int j;
+
+    for (j = 0; j < l->fold_count; j++) {
+        if (end > l->fold_start[j] && pos < l->fold_end[j])
+            return 1;
+    }
+    return 0;
+}
+
+/* Adjust fold ranges after an insertion. If insertion somehow lands inside a
+ * fold, remove that fold because it no longer maps to an unchanged range. */
+static void linenoiseAdjustFoldsAfterInsert(struct linenoiseState *l, size_t pos, size_t len) {
+    int j = 0;
+
+    while (j < l->fold_count) {
+        if (pos <= l->fold_start[j]) {
+            l->fold_start[j] += len;
+            l->fold_end[j] += len;
+            j++;
+        } else if (pos < l->fold_end[j]) {
+            linenoiseFoldRemove(l,j);
+        } else {
+            j++;
+        }
+    }
+}
+
+/* Adjust fold ranges after a deletion. If deletion overlaps a fold, remove
+ * that fold because it no longer maps to an unchanged range. */
+static void linenoiseAdjustFoldsAfterDelete(struct linenoiseState *l, size_t pos, size_t len) {
+    size_t end = pos + len;
+    int j = 0;
+
+    while (j < l->fold_count) {
+        if (end <= l->fold_start[j]) {
+            l->fold_start[j] -= len;
+            l->fold_end[j] -= len;
+            j++;
+        } else if (pos >= l->fold_end[j]) {
+            j++;
+        } else {
+            linenoiseFoldRemove(l,j);
+        }
+    }
+}
+
+/* Helper of refreshSingleLine() and refreshMultiLine() to show hints
+ * to the right of the prompt. Now uses display widths for proper UTF-8. */
+void refreshShowHints(struct abuf *ab, struct linenoiseState *l, int pwidth, size_t bufwidth) {
+    if (hintsCallback) {
+        char seq[64];
+        int color = -1, bold = 0;
+        char *hint;
+
+        if (pwidth + bufwidth >= l->cols) return;
+        hint = hintsCallback(l->buf,&color,&bold);
+        if (hint) {
+            size_t hintlen = strlen(hint);
+            size_t hintwidth = utf8StrWidth(hint, hintlen);
+            size_t hintmaxwidth = l->cols - (pwidth + bufwidth);
+            /* Truncate hint to fit, respecting UTF-8 boundaries. */
+            if (hintwidth > hintmaxwidth) {
+                size_t i = 0, w = 0;
+                while (i < hintlen) {
+                    size_t clen = utf8NextCharLen(hint, i, hintlen);
+                    int cwidth = utf8SingleCharWidth(hint + i, clen);
+                    if (w + cwidth > hintmaxwidth) break;
+                    w += cwidth;
+                    i += clen;
+                }
+                hintlen = i;
+            }
+            if (bold == 1 && color == -1) color = 37;
+            if (color != -1 || bold != 0)
+                snprintf(seq,64,"\033[%d;%d;49m",bold,color);
+            else
+                seq[0] = '\0';
+            abAppend(ab,seq,strlen(seq));
+            abAppend(ab,hint,hintlen);
+            if (color != -1 || bold != 0)
+                abAppend(ab,"\033[0m",4);
+            /* Call the function to free the hint returned. */
+            if (freeHintsCallback) freeHintsCallback(hint);
+        }
+    }
+}
+
+/* Single line low level line refresh.
+ *
+ * Rewrite the currently edited line accordingly to the buffer content,
+ * cursor position, and number of columns of the terminal.
+ *
+ * Flags is REFRESH_* macros. The function can just remove the old
+ * prompt, just write it, or both.
+ *
+ * This function is UTF-8 aware and uses display widths (not byte counts)
+ * for cursor positioning and horizontal scrolling. */
+static void refreshSingleLine(struct linenoiseState *l, int flags) {
+    char seq[64];
+    size_t pwidth = utf8StrWidth(l->prompt, l->plen); /* Prompt display width */
+    int fd = l->ofd;
+    char *render = NULL;
+    char *buf;
+    size_t len;             /* Byte length of buffer to display */
+    size_t pos;             /* Byte position of cursor in display buffer */
+    size_t poscol;          /* Display column of cursor */
+    size_t lencol;          /* Display width of buffer */
+    size_t fullwidth;        /* Display width before horizontal trimming. */
+    struct abuf ab;
+
+    if (linenoiseRenderBuffer(l,&render,&len,&pos) == -1) return;
+    buf = render;
+
+    /* Calculate the display width up to cursor and total display width. */
+    poscol = utf8StrWidth(buf, pos);
+    lencol = utf8StrWidth(buf, len);
+    fullwidth = lencol;
+
+    /* Scroll the buffer horizontally if cursor is past the right edge.
+     * We need to trim full UTF-8 characters from the left until the
+     * cursor position fits within the terminal width. */
+    while (pwidth + poscol >= l->cols) {
+        size_t clen = utf8NextCharLen(buf, 0, len);
+        int cwidth = utf8SingleCharWidth(buf, clen);
+        buf += clen;
+        len -= clen;
+        pos -= clen;
+        poscol -= cwidth;
+        lencol -= cwidth;
+    }
+
+    /* Trim from the right if the line still doesn't fit. */
+    while (pwidth + lencol > l->cols) {
+        size_t clen = utf8PrevCharLen(buf, len);
+        int cwidth = utf8SingleCharWidth(buf + len - clen, clen);
+        len -= clen;
+        lencol -= cwidth;
+    }
+
+    abInit(&ab);
+    /* Cursor to left edge */
+    snprintf(seq,sizeof(seq),"\r");
+    abAppend(&ab,seq,strlen(seq));
+
+    if (flags & REFRESH_WRITE) {
+        /* Write the prompt and the current buffer content */
+        abAppend(&ab,l->prompt,l->plen);
+        if (maskmode == 1) {
+            /* In mask mode, we output one '*' per UTF-8 character, not byte */
+            size_t i = 0;
+            while (i < len) {
+                abAppend(&ab,"*",1);
+                i += utf8NextCharLen(buf, i, len);
+            }
+        } else {
+            abAppend(&ab,buf,len);
+        }
+        /* Show hints if any. */
+        refreshShowHints(&ab,l,pwidth,fullwidth);
+    }
+
+    /* Erase to right */
+    snprintf(seq,sizeof(seq),"\x1b[0K");
+    abAppend(&ab,seq,strlen(seq));
+
+    if (flags & REFRESH_WRITE) {
+        /* Move cursor to original position (using display column, not byte). */
+        snprintf(seq,sizeof(seq),"\r\x1b[%dC", (int)(poscol+pwidth));
+        abAppend(&ab,seq,strlen(seq));
+    }
+
+    if (write(fd,ab.b,ab.len) == -1) {} /* Can't recover from write error. */
+    abFree(&ab);
+    free(render);
+}
+
+/* Multi line low level line refresh.
+ *
+ * Rewrite the currently edited line accordingly to the buffer content,
+ * cursor position, and number of columns of the terminal.
+ *
+ * Flags is REFRESH_* macros. The function can just remove the old
+ * prompt, just write it, or both.
+ *
+ * This function is UTF-8 aware and uses display widths for positioning. */
+static void refreshMultiLine(struct linenoiseState *l, int flags) {
+    char seq[64];
+    size_t pwidth = utf8StrWidth(l->prompt, l->plen);  /* Prompt display width */
+    char *render = NULL;
+    size_t render_len, render_pos;
+    size_t bufwidth;
+    size_t poswidth;
+    int rows; /* rows used by current rendered buffer. */
+    int rpos = l->oldrpos;   /* cursor relative row from previous refresh. */
+    int rpos2; /* rpos after refresh. */
+    int col; /* column position, zero-based. */
+    int old_rows = l->oldrows;
+    int fd = l->ofd, j;
+    struct abuf ab;
+
+    if (linenoiseRenderBuffer(l,&render,&render_len,&render_pos) == -1) return;
+    bufwidth = utf8StrWidth(render, render_len);
+    poswidth = utf8StrWidth(render, render_pos);
+    rows = (pwidth+bufwidth+l->cols-1)/l->cols;
+    l->oldrows = rows;
+
+    /* First step: clear all the lines used before. To do so start by
+     * going to the last row. */
+    abInit(&ab);
+
+    if (flags & REFRESH_CLEAN) {
+        if (old_rows-rpos > 0) {
+            lndebug("go down %d", old_rows-rpos);
+            snprintf(seq,64,"\x1b[%dB", old_rows-rpos);
+            abAppend(&ab,seq,strlen(seq));
+        }
+
+        /* Now for every row clear it, go up. */
+        for (j = 0; j < old_rows-1; j++) {
+            lndebug("clear+up");
+            snprintf(seq,64,"\r\x1b[0K\x1b[1A");
+            abAppend(&ab,seq,strlen(seq));
+        }
+    }
+
+    if (flags & REFRESH_ALL) {
+        /* Clean the top line. */
+        lndebug("clear");
+        snprintf(seq,64,"\r\x1b[0K");
+        abAppend(&ab,seq,strlen(seq));
+    }
+
+    if (flags & REFRESH_WRITE) {
+        /* Write the prompt and the current buffer content */
+        abAppend(&ab,l->prompt,l->plen);
+        if (maskmode == 1) {
+            /* In mask mode, output one '*' per UTF-8 character, not byte */
+            size_t i = 0;
+            while (i < render_len) {
+                abAppend(&ab,"*",1);
+                i += utf8NextCharLen(render, i, render_len);
+            }
+        } else {
+            abAppend(&ab,render,render_len);
+        }
+
+        /* Show hints if any. */
+        refreshShowHints(&ab,l,pwidth,bufwidth);
+
+        /* If we are at the very end of the screen with our prompt, we need to
+         * emit a newline and move the prompt to the first column. */
+        if (l->pos &&
+            render_pos == render_len &&
+            (poswidth+pwidth) % l->cols == 0)
+        {
+            lndebug("<newline>");
+            abAppend(&ab,"\n",1);
+            snprintf(seq,64,"\r");
+            abAppend(&ab,seq,strlen(seq));
+            rows++;
+            if (rows > (int)l->oldrows) l->oldrows = rows;
+        }
+
+        /* Move cursor to right position. */
+        rpos2 = (pwidth+poswidth+l->cols)/l->cols; /* Current cursor relative row */
+        lndebug("rpos2 %d", rpos2);
+
+        /* Go up till we reach the expected position. */
+        if (rows-rpos2 > 0) {
+            lndebug("go-up %d", rows-rpos2);
+            snprintf(seq,64,"\x1b[%dA", rows-rpos2);
+            abAppend(&ab,seq,strlen(seq));
+        }
+
+        /* Set column. */
+        col = (pwidth+poswidth) % l->cols;
+        lndebug("set col %d", 1+col);
+        if (col)
+            snprintf(seq,64,"\r\x1b[%dC", col);
+        else
+            snprintf(seq,64,"\r");
+        abAppend(&ab,seq,strlen(seq));
+    }
+
+    lndebug("\n");
+    l->oldpos = l->pos;
+    if (flags & REFRESH_WRITE) l->oldrpos = rpos2;
+
+    if (write(fd,ab.b,ab.len) == -1) {} /* Can't recover from write error. */
+    abFree(&ab);
+    free(render);
+}
+
+/* Calls the two low level functions refreshSingleLine() or
+ * refreshMultiLine() according to the selected mode. */
+static void refreshLineWithFlags(struct linenoiseState *l, int flags) {
+    if (mlmode)
+        refreshMultiLine(l,flags);
+    else
+        refreshSingleLine(l,flags);
+}
+
+/* Utility function to avoid specifying REFRESH_ALL all the times. */
+static void refreshLine(struct linenoiseState *l) {
+    refreshLineWithFlags(l,REFRESH_ALL);
+}
+
+/* Hide the current line, when using the multiplexing API. */
+void linenoiseHide(struct linenoiseState *l) {
+    if (mlmode)
+        refreshMultiLine(l,REFRESH_CLEAN);
+    else
+        refreshSingleLine(l,REFRESH_CLEAN);
+}
+
+/* Show the current line, when using the multiplexing API. */
+void linenoiseShow(struct linenoiseState *l) {
+    if (l->in_completion) {
+        refreshLineWithCompletion(l,NULL,REFRESH_WRITE);
+    } else {
+        refreshLineWithFlags(l,REFRESH_WRITE);
+    }
+}
+
+/* Grow the editing buffer if this state owns a growable buffer. Only the
+ * blocking linenoise() API sets buflen_max: the multiplexing API still uses
+ * the caller-provided fixed buffer. */
+static int linenoiseEditGrow(struct linenoiseState *l, size_t needed) {
+    size_t newlen;
+    char *newbuf;
+
+    if (needed <= l->buflen) return 0;
+
+    /* buflen_max is zero when the caller provided a fixed buffer, as in the
+     * multiplexing API: in that case there is nothing we can grow. */
+    if (l->buflen_max == 0 || needed > l->buflen_max) return -1;
+
+    /* Grow exponentially, but stop at the configured maximum before the
+     * doubling would overflow or go past it. */
+    newlen = l->buflen ? l->buflen : 16;
+    while (newlen < needed) {
+        if (newlen > l->buflen_max/2) {
+            newlen = l->buflen_max;
+            break;
+        }
+        newlen *= 2;
+    }
+    if (newlen < needed || newlen == SIZE_MAX) return -1;
+
+    /* Allocate one extra byte for the nul terminator. */
+    newbuf = realloc(l->buf,newlen+1);
+    if (newbuf == NULL) return -1;
+    l->buf = newbuf;
+    l->buflen = newlen;
+    return 0;
+}
+
+/* Insert bytes into l->buf without repainting the prompt. The paste path uses
+ * this to first store the real pasted bytes, then mark their range as folded,
+ * and only then refresh so raw pasted newlines are never printed directly. */
+static int linenoiseEditInsertNoRefresh(struct linenoiseState *l, const char *c, size_t clen) {
+    size_t insert_pos = l->pos;
+
+    if (clen > SIZE_MAX-l->len || linenoiseEditGrow(l,l->len+clen) == -1)
+        return -1;
+
+    if (l->len == l->pos) {
+        memcpy(l->buf+l->pos,c,clen);
+    } else {
+        memmove(l->buf+l->pos+clen,l->buf+l->pos,l->len-l->pos);
+        memcpy(l->buf+l->pos,c,clen);
+    }
+    l->pos += clen;
+    l->len += clen;
+    l->buf[l->len] = '\0';
+    linenoiseAdjustFoldsAfterInsert(l,insert_pos,clen);
+    return 0;
+}
+
+/* Insert the character(s) 'c' of length 'clen' at cursor current position.
+ * This handles both single-byte ASCII and multi-byte UTF-8 sequences.
+ *
+ * On error writing to the terminal -1 is returned, otherwise 0. */
+int linenoiseEditInsert(struct linenoiseState *l, const char *c, size_t clen) {
+    if (l->len == l->pos) {
+        int needs_refresh = memchr(c, '\n', clen) != NULL ||
+                             memchr(c, '\r', clen) != NULL;
+
+        if (linenoiseEditInsertNoRefresh(l,c,clen) == -1) return 0;
+        if (!needs_refresh && !mlmode && !hintsCallback &&
+            (maskmode || l->fold_count == 0))
+        {
+            size_t bufwidth = utf8StrWidth(l->buf,l->len);
+            if (utf8StrWidth(l->prompt,l->plen)+bufwidth < l->cols) {
+                /* Avoid a full update of the line in the trivial case:
+                 * single-width char, no hints, fits in one line. */
+                if (maskmode == 1) {
+                    if (write(l->ofd,"*",1) == -1) return -1;
+                } else {
+                    if (write(l->ofd,c,clen) == -1) return -1;
+                }
+                return 0;
+            }
+        }
+        refreshLine(l);
+    } else {
+        if (linenoiseEditInsertNoRefresh(l,c,clen) == -1) return 0;
+        refreshLine(l);
+    }
+    return 0;
+}
+
+/* Move cursor on the left. Moves by one UTF-8 character, not byte. */
+void linenoiseEditMoveLeft(struct linenoiseState *l) {
+    if (l->pos > 0) {
+        l->pos -= linenoiseEditPrevLen(l, l->pos);
+        refreshLine(l);
+    }
+}
+
+/* Move cursor on the right. Moves by one UTF-8 character, not byte. */
+void linenoiseEditMoveRight(struct linenoiseState *l) {
+    if (l->pos != l->len) {
+        l->pos += linenoiseEditNextLen(l, l->pos);
+        refreshLine(l);
+    }
+}
+
+/* Move cursor to the start of the line. */
+void linenoiseEditMoveHome(struct linenoiseState *l) {
+    if (l->pos != 0) {
+        l->pos = 0;
+        refreshLine(l);
+    }
+}
+
+/* Move cursor to the end of the line. */
+void linenoiseEditMoveEnd(struct linenoiseState *l) {
+    if (l->pos != l->len) {
+        l->pos = l->len;
+        refreshLine(l);
+    }
+}
+
+/* Substitute the currently edited line with the next or previous history
+ * entry as specified by 'dir'. */
+#define LINENOISE_HISTORY_NEXT 0
+#define LINENOISE_HISTORY_PREV 1
+void linenoiseEditHistoryNext(struct linenoiseState *l, int dir) {
+    if (history_len > 1) {
+        const char *src;
+        size_t len;
+        struct linenoiseFold f;
+
+        /* Update the current history entry before to
+         * overwrite it with the next one. */
+        free(history[history_len - 1 - l->history_index]);
+        history[history_len - 1 - l->history_index] = strdup(l->buf);
+        /* Show the new entry */
+        l->history_index += (dir == LINENOISE_HISTORY_PREV) ? 1 : -1;
+        if (l->history_index < 0) {
+            l->history_index = 0;
+            return;
+        } else if (l->history_index >= history_len) {
+            l->history_index = history_len-1;
+            return;
+        }
+
+        /* Copy the selected history entry into the edit buffer. With the
+         * fixed-buffer API, truncate the entry if it does not fit. */
+        src = history[history_len - 1 - l->history_index];
+        len = strlen(src);
+        if (linenoiseEditGrow(l,len) == -1 && len > l->buflen)
+            len = l->buflen;
+        memcpy(l->buf,src,len);
+        l->buf[len] = '\0';
+        l->len = l->pos = len;
+        linenoiseFoldClear(l);
+
+        /* History stores the real text, but not the original paste ranges.
+         * If the recalled entry needs folding, create one display fold now
+         * so text typed after recall remains outside the folded range. */
+        if (linenoiseBuildHistoryFold(l,&f))
+            linenoiseFoldAdd(l,f.start,f.end);
+        refreshLine(l);
+    }
+}
+
+/* Delete the character at the right of the cursor without altering the cursor
+ * position. Basically this is what happens with the "Delete" keyboard key.
+ * Now handles multi-byte UTF-8 characters. */
+void linenoiseEditDelete(struct linenoiseState *l) {
+    if (l->len > 0 && l->pos < l->len) {
+        size_t clen = linenoiseEditNextLen(l, l->pos);
+        linenoiseAdjustFoldsAfterDelete(l,l->pos,clen);
+        memmove(l->buf+l->pos, l->buf+l->pos+clen, l->len-l->pos-clen);
+        l->len -= clen;
+        l->buf[l->len] = '\0';
+        refreshLine(l);
+    }
+}
+
+/* Backspace implementation. Deletes the UTF-8 character before the cursor. */
+void linenoiseEditBackspace(struct linenoiseState *l) {
+    if (l->pos > 0 && l->len > 0) {
+        size_t clen = linenoiseEditPrevLen(l, l->pos);
+        linenoiseAdjustFoldsAfterDelete(l,l->pos-clen,clen);
+        memmove(l->buf+l->pos-clen, l->buf+l->pos, l->len-l->pos);
+        l->pos -= clen;
+        l->len -= clen;
+        l->buf[l->len] = '\0';
+        refreshLine(l);
+    }
+}
+
+/* Delete the previous word, maintaining the cursor at the start of the
+ * current word. Handles UTF-8 by moving character-by-character. */
+void linenoiseEditDeletePrevWord(struct linenoiseState *l) {
+    size_t old_pos = l->pos;
+    size_t diff;
+
+    /* Skip spaces before the word (move backwards by UTF-8 chars). */
+    while (l->pos > 0 && l->buf[l->pos-1] == ' ')
+        l->pos -= linenoiseEditPrevLen(l, l->pos);
+    /* Skip non-space characters (move backwards by UTF-8 chars). */
+    while (l->pos > 0 && l->buf[l->pos-1] != ' ')
+        l->pos -= linenoiseEditPrevLen(l, l->pos);
+    diff = old_pos - l->pos;
+    linenoiseAdjustFoldsAfterDelete(l,l->pos,diff);
+    memmove(l->buf+l->pos, l->buf+old_pos, l->len-old_pos+1);
+    l->len -= diff;
+    refreshLine(l);
+}
+
+/* This function is part of the multiplexed API of Linenoise, that is used
+ * in order to implement the blocking variant of the API but can also be
+ * called by the user directly in an event driven program. It will:
+ *
+ * 1. Initialize the linenoise state passed by the user.
+ * 2. Put the terminal in RAW mode.
+ * 3. Show the prompt.
+ * 4. Return control to the user, that will have to call linenoiseEditFeed()
+ *    each time there is some data arriving in the standard input.
+ *
+ * The user can also call linenoiseEditHide() and linenoiseEditShow() if it
+ * is required to show some input arriving asyncronously, without mixing
+ * it with the currently edited line.
+ *
+ * When linenoiseEditFeed() returns non-NULL, the user finished with the
+ * line editing session (pressed enter CTRL-D/C): in this case the caller
+ * needs to call linenoiseEditStop() to put back the terminal in normal
+ * mode. This will not destroy the buffer, as long as the linenoiseState
+ * is still valid in the context of the caller.
+ *
+ * The function returns 0 on success, or -1 if writing to standard output
+ * fails. If stdin_fd or stdout_fd are set to -1, the default is to use
+ * STDIN_FILENO and STDOUT_FILENO.
+ */
+int linenoiseEditStart(struct linenoiseState *l, int stdin_fd, int stdout_fd, char *buf, size_t buflen, const char *prompt) {
+    /* Populate the linenoise state that we pass to functions implementing
+     * specific editing functionalities. */
+    l->in_completion = 0;
+    l->ifd = stdin_fd != -1 ? stdin_fd : STDIN_FILENO;
+    l->ofd = stdout_fd != -1 ? stdout_fd : STDOUT_FILENO;
+    l->buf = buf;
+    l->buflen = buflen;
+    l->buflen_max = 0;
+    l->prompt = prompt;
+    l->plen = strlen(prompt);
+    l->oldpos = l->pos = 0;
+    l->len = 0;
+    linenoiseFoldClear(l);
+
+    /* Enter raw mode. */
+    rawmode_output = l->ofd;
+    if (enableRawMode(l->ifd) == -1) return -1;
+
+    l->cols = getColumns(stdin_fd, stdout_fd);
+    l->oldrows = 0;
+    l->oldrpos = 1;  /* Cursor starts on row 1. */
+    l->history_index = 0;
+
+    /* Buffer starts empty. */
+    l->buf[0] = '\0';
+    l->buflen--; /* Make sure there is always space for the nulterm */
+
+    /* If stdin is not a tty, stop here with the initialization. We
+     * will actually just read a line from standard input in blocking
+     * mode later, in linenoiseEditFeed(). */
+    if (!isatty(l->ifd) && !getenv("LINENOISE_ASSUME_TTY")) return 0;
+
+    /* The latest history entry is always our current buffer, that
+     * initially is just an empty string. */
+    linenoiseHistoryAdd("");
+
+    if (write(l->ofd,prompt,l->plen) == -1) return -1;
+    return 0;
+}
+
+/* Make sure the temporary paste buffer can hold len+need bytes. Return -1 on
+ * allocation failure or if the requested size is over PASTE_MAX_BYTES. */
+static int pasteBufferReserve(char **buf, size_t *cap, size_t len, size_t need) {
+    size_t want;
+    char *nb;
+
+    /* Nothing to do if the current paste buffer already has room for the
+     * bytes collected so far plus the new bytes we want to append. */
+    if (*cap >= len + need) return 0;
+
+    /* Start small, then double like the line buffer. The cap avoids turning a
+     * huge paste into an unbounded allocation attempt. */
+    want = *cap ? *cap : 64;
+    while (want < len + need) {
+        size_t doubled = want*2;
+        if (doubled <= want || doubled > PASTE_MAX_BYTES) {
+            want = PASTE_MAX_BYTES;
+            break;
+        }
+        want = doubled;
+    }
+    if (want < len + need) return -1;
+
+    /* realloc(NULL, want) handles the first allocation too. */
+    nb = realloc(*buf, want);
+    if (nb == NULL) return -1;
+    *buf = nb;
+    *cap = want;
+    return 0;
+}
+
+/* Append bytes to the temporary paste buffer, growing both it and l->buf as
+ * needed. Return -1 if the paste is too large or allocation fails. */
+static int pasteBufferAppend(struct linenoiseState *l, char **buf, size_t *cap,
+                             size_t *len, const char *s, size_t slen, size_t maxlen) {
+    size_t needed;
+
+    if (*len > maxlen || slen > maxlen-*len) return -1;
+    if (*len > SIZE_MAX-slen) return -1;
+    needed = *len+slen;
+    if (l->len > SIZE_MAX-needed) return -1;
+    if (linenoiseEditGrow(l,l->len+needed) == -1) return -1;
+    if (pasteBufferReserve(buf,cap,*len,slen) == -1) return -1;
+    memcpy(*buf+*len,s,slen);
+    *len = needed;
+    return 0;
+}
+
+/* Read a bracketed paste until ESC[201~ and insert the real bytes. If folding
+ * is needed, remember the inserted range so only rendering is shortened. */
+static void linenoiseEditPaste(struct linenoiseState *l) {
+    static const char END[] = "\x1b[201~";
+    const size_t ENDLEN = sizeof(END)-1;
+    char *buf = NULL;
+    size_t cap = 0, len = 0, match = 0;
+    size_t maxlen = l->buflen_max ? l->buflen_max : l->buflen;
+    int overflowed = 0;
+
+    maxlen = maxlen > l->len ? maxlen - l->len : 0;
+    if (maxlen > PASTE_MAX_BYTES) maxlen = PASTE_MAX_BYTES;
+    /* Once all fold slots are used, consume later pastes without storing them. */
+    if (l->fold_count == LINENOISE_MAX_FOLDS) maxlen = 0;
+
+    while (1) {
+        char c;
+        if (read(l->ifd, &c, 1) != 1) break;
+
+        /* Track a possible ESC[201~ terminator without copying it into the
+         * paste. If it turns out to be ordinary input, flush the partial
+         * match below. */
+        if (c == END[match]) {
+            match++;
+            if (match == ENDLEN) break;
+            continue;
+        }
+
+        if (match > 0) {
+            if (!overflowed &&
+                pasteBufferAppend(l,&buf,&cap,&len,END,match,maxlen) == -1)
+                overflowed = 1;
+            match = 0;
+            if (c == END[0]) {
+                match = 1;
+                continue;
+            }
+        }
+
+        if (!overflowed &&
+            pasteBufferAppend(l,&buf,&cap,&len,&c,1,maxlen) == -1)
+            overflowed = 1;
+    }
+
+    if (overflowed) {
+        free(buf);
+        linenoiseBeep();
+        return;
+    }
+    if (buf == NULL) return;
+
+    {
+        /* Normalize pasted CR and CRLF to LF, so the edit buffer uses one
+         * internal newline representation. */
+        size_t r = 0, w = 0;
+        while (r < len) {
+            if (buf[r] == '\r') {
+                buf[w++] = '\n';
+                r += (r+1 < len && buf[r+1] == '\n') ? 2 : 1;
+            } else {
+                buf[w++] = buf[r++];
+            }
+        }
+        len = w;
+    }
+
+    if (!maskmode && shouldFoldText(buf,len)) {
+        size_t start = l->pos;
+        if (linenoiseEditInsertNoRefresh(l,buf,len) == -1) {
+            free(buf);
+            linenoiseBeep();
+            return;
+        }
+        linenoiseFoldAdd(l,start,start+len);
+        refreshLine(l);
+    } else {
+        linenoiseEditInsert(l,buf,len);
+    }
+    free(buf);
+}
+
+char *linenoiseEditMore = "If you see this, you are misusing the API: when linenoiseEditFeed() is called, if it returns linenoiseEditMore the user is yet editing the line. See the README file for more information.";
+
+/* This function is part of the multiplexed API of linenoise, see the top
+ * comment on linenoiseEditStart() for more information. Call this function
+ * each time there is some data to read from the standard input file
+ * descriptor. In the case of blocking operations, this function can just be
+ * called in a loop, and block.
+ *
+ * The function returns linenoiseEditMore to signal that line editing is still
+ * in progress, that is, the user didn't yet pressed enter / CTRL-D. Otherwise
+ * the function returns the pointer to the heap-allocated buffer with the
+ * edited line, that the user should free with linenoiseFree().
+ *
+ * On special conditions, NULL is returned and errno is populated:
+ *
+ * EAGAIN if the user pressed Ctrl-C
+ * ENOENT if the user pressed Ctrl-D
+ *
+ * Some other errno: I/O error.
+ */
+char *linenoiseEditFeed(struct linenoiseState *l) {
+    /* Not a TTY, pass control to line reading without character
+     * count limits. */
+    if (!isatty(l->ifd) && !getenv("LINENOISE_ASSUME_TTY")) return linenoiseNoTTY();
+
+    char c;
+    int nread;
+    char seq[3];
+
+    nread = read(l->ifd,&c,1);
+    if (nread < 0) {
+        return (errno == EAGAIN || errno == EWOULDBLOCK) ? linenoiseEditMore : NULL;
+    } else if (nread == 0) {
+        return NULL;
+    }
+
+    /* Only autocomplete when the callback is set. completeLine()
+     * returns the character to be handled next, or zero when the
+     * key was consumed to navigate completions. */
+    if ((l->in_completion || c == 9 /* TAB */) && completionCallback != NULL) {
+        int retval = completeLine(l,c);
+        /* Read next character when 0 */
+        if (retval == 0) return linenoiseEditMore;
+        c = retval;
+    }
+
+    switch(c) {
+    case ENTER:    /* enter */
+        history_len--;
+        free(history[history_len]);
+        if (mlmode) linenoiseEditMoveEnd(l);
+        if (hintsCallback) {
+            /* Force a refresh without hints to leave the previous
+             * line as the user typed it after a newline. */
+            linenoiseHintsCallback *hc = hintsCallback;
+            hintsCallback = NULL;
+            refreshLine(l);
+            hintsCallback = hc;
+        }
+        return strdup(l->buf);
+    case CTRL_C:     /* ctrl-c */
+        errno = EAGAIN;
+        return NULL;
+    case BACKSPACE:   /* backspace */
+    case 8:     /* ctrl-h */
+        linenoiseEditBackspace(l);
+        break;
+    case CTRL_D:     /* ctrl-d, remove char at right of cursor, or if the
+                        line is empty, act as end-of-file. */
+        if (l->len > 0) {
+            linenoiseEditDelete(l);
+        } else {
+            history_len--;
+            free(history[history_len]);
+            errno = ENOENT;
+            return NULL;
+        }
+        break;
+    case CTRL_T:    /* ctrl-t, swaps current character with previous. */
+        /* Handle UTF-8: swap the two UTF-8 characters around cursor. */
+        if (l->pos > 0 && l->pos < l->len) {
+            char tmp[32];
+            size_t prevlen = linenoiseEditPrevLen(l, l->pos);
+            size_t currlen = linenoiseEditNextLen(l, l->pos);
+            size_t prevstart = l->pos - prevlen;
+            if (prevlen > sizeof(tmp) || currlen > sizeof(tmp)) break;
+            if (linenoiseRangeOverlapsFold(l,prevstart,prevlen+currlen)) {
+                linenoiseBeep();
+                break;
+            }
+            /* Copy current char to tmp, move previous char right, paste tmp. */
+            memcpy(tmp, l->buf + l->pos, currlen);
+            memmove(l->buf + prevstart + currlen, l->buf + prevstart, prevlen);
+            memcpy(l->buf + prevstart, tmp, currlen);
+            if (l->pos + currlen <= l->len) l->pos += currlen;
+            refreshLine(l);
+        }
+        break;
+    case CTRL_B:     /* ctrl-b */
+        linenoiseEditMoveLeft(l);
+        break;
+    case CTRL_F:     /* ctrl-f */
+        linenoiseEditMoveRight(l);
+        break;
+    case CTRL_P:    /* ctrl-p */
+        linenoiseEditHistoryNext(l, LINENOISE_HISTORY_PREV);
+        break;
+    case CTRL_N:    /* ctrl-n */
+        linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
+        break;
+    case ESC:    /* escape sequence */
+        /* Read the next two bytes representing the escape sequence.
+         * Use two calls to handle slow terminals returning the two
+         * chars at different times. */
+        if (read(l->ifd,seq,1) == -1) break;
+        if (read(l->ifd,seq+1,1) == -1) break;
+
+        /* ESC [ sequences. */
+        if (seq[0] == '[') {
+            if (seq[1] >= '0' && seq[1] <= '9') {
+                char param[8];
+                size_t plen = 1;
+                char final = 0;
+
+                param[0] = seq[1];
+                while (plen < sizeof(param)) {
+                    char p;
+                    if (read(l->ifd,&p,1) != 1) break;
+                    if (p >= '0' && p <= '9') {
+                        param[plen++] = p;
+                    } else {
+                        final = p;
+                        break;
+                    }
+                }
+                if (final == '~') {
+                    if (plen == 1 && param[0] == '3') {
+                        linenoiseEditDelete(l);
+                    } else if (plen == 3 && memcmp(param,"200",3) == 0) {
+                        linenoiseEditPaste(l);
+                    }
+                }
+            } else {
+                switch(seq[1]) {
+                case 'A': /* Up */
+                    linenoiseEditHistoryNext(l, LINENOISE_HISTORY_PREV);
+                    break;
+                case 'B': /* Down */
+                    linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
+                    break;
+                case 'C': /* Right */
+                    linenoiseEditMoveRight(l);
+                    break;
+                case 'D': /* Left */
+                    linenoiseEditMoveLeft(l);
+                    break;
+                case 'H': /* Home */
+                    linenoiseEditMoveHome(l);
+                    break;
+                case 'F': /* End*/
+                    linenoiseEditMoveEnd(l);
+                    break;
+                }
+            }
+        }
+
+        /* ESC O sequences. */
+        else if (seq[0] == 'O') {
+            switch(seq[1]) {
+            case 'H': /* Home */
+                linenoiseEditMoveHome(l);
+                break;
+            case 'F': /* End*/
+                linenoiseEditMoveEnd(l);
+                break;
+            }
+        }
+        break;
+    default:
+        /* Handle UTF-8 multi-byte sequences. When we receive the first byte
+         * of a multi-byte UTF-8 character, read the remaining bytes to
+         * complete the sequence before inserting. */
+        {
+            char utf8[4];
+            int utf8len = utf8ByteLen(c);
+            utf8[0] = c;
+            if (utf8len > 1) {
+                /* Read remaining bytes of the UTF-8 sequence. */
+                int i;
+                for (i = 1; i < utf8len; i++) {
+                    if (read(l->ifd, utf8+i, 1) != 1) break;
+                }
+            }
+            if (linenoiseEditInsert(l, utf8, utf8len)) return NULL;
+        }
+        break;
+    case CTRL_U: /* Ctrl+u, delete the whole line. */
+        l->buf[0] = '\0';
+        l->pos = l->len = 0;
+        linenoiseFoldClear(l);
+        refreshLine(l);
+        break;
+    case CTRL_K: /* Ctrl+k, delete from current to end of line. */
+        linenoiseAdjustFoldsAfterDelete(l,l->pos,l->len-l->pos);
+        l->buf[l->pos] = '\0';
+        l->len = l->pos;
+        refreshLine(l);
+        break;
+    case CTRL_A: /* Ctrl+a, go to the start of the line */
+        linenoiseEditMoveHome(l);
+        break;
+    case CTRL_E: /* ctrl+e, go to the end of the line */
+        linenoiseEditMoveEnd(l);
+        break;
+    case CTRL_L: /* ctrl+l, clear screen */
+        linenoiseClearScreen();
+        refreshLine(l);
+        break;
+    case CTRL_W: /* ctrl+w, delete previous word */
+        linenoiseEditDeletePrevWord(l);
+        break;
+    }
+    return linenoiseEditMore;
+}
+
+/* This is part of the multiplexed linenoise API. See linenoiseEditStart()
+ * for more information. This function is called when linenoiseEditFeed()
+ * returns something different than NULL. At this point the user input
+ * is in the buffer, and we can restore the terminal in normal mode. */
+void linenoiseEditStop(struct linenoiseState *l) {
+    if (!isatty(l->ifd) && !getenv("LINENOISE_ASSUME_TTY")) return;
+    disableRawMode(l->ifd);
+    printf("\n");
+}
+
+/* This just implements a blocking loop for the multiplexed API.
+ * In many applications that are not event-drivern, we can just call
+ * the blocking linenoise API, wait for the user to complete the editing
+ * and return the buffer. This wrapper owns l.buf, so it can let the edit
+ * state grow it dynamically for large pasted input. */
+static char *linenoiseBlockingEdit(int stdin_fd, int stdout_fd, const char *prompt)
+{
+    struct linenoiseState l;
+    char *buf = malloc(LINENOISE_INITIAL_BUFLEN);
+    char *res;
+
+    if (buf == NULL) {
+        errno = ENOMEM;
+        return NULL;
+    }
+
+    if (linenoiseEditStart(&l,stdin_fd,stdout_fd,buf,
+                           LINENOISE_INITIAL_BUFLEN,prompt) == -1)
+    {
+        free(buf);
+        return NULL;
+    }
+    l.buflen_max = LINENOISE_MAX_LINE;
+    while((res = linenoiseEditFeed(&l)) == linenoiseEditMore);
+    linenoiseEditStop(&l);
+    free(l.buf);
+    return res;
+}
+
+/* This special mode is used by linenoise in order to print scan codes
+ * on screen for debugging / development purposes. It is implemented
+ * by the linenoise_example program using the --keycodes option. */
+void linenoisePrintKeyCodes(void) {
+    char quit[4];
+
+    printf("Linenoise key codes debugging mode.\n"
+            "Press keys to see scan codes. Type 'quit' at any time to exit.\n");
+    rawmode_output = STDOUT_FILENO;
+    if (enableRawMode(STDIN_FILENO) == -1) return;
+    memset(quit,' ',4);
+    while(1) {
+        char c;
+        int nread;
+
+        nread = read(STDIN_FILENO,&c,1);
+        if (nread <= 0) continue;
+        memmove(quit,quit+1,sizeof(quit)-1); /* shift string to left. */
+        quit[sizeof(quit)-1] = c; /* Insert current char on the right. */
+        if (memcmp(quit,"quit",sizeof(quit)) == 0) break;
+
+        printf("'%c' %02x (%d) (type quit to exit)\n",
+            isprint(c) ? c : '?', (int)c, (int)c);
+        printf("\r"); /* Go left edge manually, we are in raw mode. */
+        fflush(stdout);
+    }
+    disableRawMode(STDIN_FILENO);
+}
+
+/* Read a newline-terminated record from fp with no fixed-size stack buffer.
+ * Used for non-tty input, unsupported terminals, and history loading. */
+static char *linenoiseReadLine(FILE *fp, int *err) {
+    char *line = NULL;
+    size_t len = 0, cap = 0;
+
+    if (err) *err = 0;
+
+    while(1) {
+        if (len+1 >= cap) {
+            size_t newcap = cap ? cap*2 : 16;
+            char *oldval = line;
+            if (newcap <= cap) {
+                free(line);
+                if (err) *err = 1;
+                errno = ENOMEM;
+                return NULL;
+            }
+            line = realloc(line,newcap);
+            if (line == NULL) {
+                if (oldval) free(oldval);
+                if (err) *err = 1;
+                return NULL;
+            }
+            cap = newcap;
+        }
+        int c = fgetc(fp);
+        if (c == EOF || c == '\n') {
+            if (c == EOF && len == 0) {
+                free(line);
+                return NULL;
+            } else {
+                line[len] = '\0';
+                return line;
+            }
+        } else {
+            line[len] = c;
+            len++;
+        }
+    }
+}
+
+/* This function is called when linenoise() is called with the standard
+ * input file descriptor not attached to a TTY. So for example when the
+ * program using linenoise is called in pipe or with a file redirected
+ * to its standard input. In this case, we want to be able to return the
+ * line regardless of its length. */
+static char *linenoiseNoTTY(void) {
+    return linenoiseReadLine(stdin,NULL);
+}
+
+/* The high level function that is the main API of the linenoise library.
+ * This function checks if the terminal has basic capabilities, just checking
+ * for a blacklist of stupid terminals, and later either calls the line
+ * editing function or uses a simple line reader so that you will be able
+ * to type something even in the most desperate of the conditions. */
+char *linenoise(const char *prompt) {
+    if (!isatty(STDIN_FILENO) && !getenv("LINENOISE_ASSUME_TTY")) {
+        /* Not a tty: read from file / pipe. In this mode we don't want any
+         * limit to the line size, so we call a function to handle that. */
+        return linenoiseNoTTY();
+    }
+
+    if (isUnsupportedTerm()) {
+        char *retval;
+        size_t len;
+
+        printf("%s",prompt);
+        fflush(stdout);
+        retval = linenoiseNoTTY();
+        if (retval == NULL) return NULL;
+        len = strlen(retval);
+        while(len && retval[len-1] == '\r') {
+            len--;
+            retval[len] = '\0';
+        }
+        return retval;
+    } else {
+        return linenoiseBlockingEdit(STDIN_FILENO,STDOUT_FILENO,prompt);
+    }
+}
+
+/* This is just a wrapper the user may want to call in order to make sure
+ * the linenoise returned buffer is freed with the same allocator it was
+ * created with. Useful when the main program is using an alternative
+ * allocator. */
+void linenoiseFree(void *ptr) {
+    if (ptr == linenoiseEditMore) return; // Protect from API misuse.
+    free(ptr);
+}
+
+/* ================================ History ================================= */
+
+/* Free the history, but does not reset it. Only used when we have to
+ * exit() to avoid memory leaks are reported by valgrind & co. */
+static void freeHistory(void) {
+    if (history) {
+        int j;
+
+        for (j = 0; j < history_len; j++)
+            free(history[j]);
+        free(history);
+    }
+}
+
+/* At exit we'll try to fix the terminal to the initial conditions. */
+static void linenoiseAtExit(void) {
+    disableRawMode(STDIN_FILENO);
+    freeHistory();
+}
+
+/* This is the API call to add a new entry in the linenoise history.
+ * It uses a fixed array of char pointers that are shifted (memmoved)
+ * when the history max length is reached in order to remove the older
+ * entry and make room for the new one, so it is not exactly suitable for huge
+ * histories, but will work well for a few hundred of entries.
+ *
+ * Using a circular buffer is smarter, but a bit more complex to handle. */
+int linenoiseHistoryAdd(const char *line) {
+    char *linecopy;
+
+    if (history_max_len == 0) return 0;
+
+    /* Initialization on first call. */
+    if (history == NULL) {
+        history = malloc(sizeof(char*)*history_max_len);
+        if (history == NULL) return 0;
+        memset(history,0,(sizeof(char*)*history_max_len));
+    }
+
+    /* Don't add duplicated lines. */
+    if (history_len && !strcmp(history[history_len-1], line)) return 0;
+
+    /* Add an heap allocated copy of the line in the history.
+     * If we reached the max length, remove the older line. */
+    linecopy = strdup(line);
+    if (!linecopy) return 0;
+    if (history_len == history_max_len) {
+        free(history[0]);
+        memmove(history,history+1,sizeof(char*)*(history_max_len-1));
+        history_len--;
+    }
+    history[history_len] = linecopy;
+    history_len++;
+    return 1;
+}
+
+/* Set the maximum length for the history. This function can be called even
+ * if there is already some history, the function will make sure to retain
+ * just the latest 'len' elements if the new history length value is smaller
+ * than the amount of items already inside the history. */
+int linenoiseHistorySetMaxLen(int len) {
+    char **new;
+
+    if (len < 1) return 0;
+    if (history) {
+        int tocopy = history_len;
+
+        new = malloc(sizeof(char*)*len);
+        if (new == NULL) return 0;
+
+        /* If we can't copy everything, free the elements we'll not use. */
+        if (len < tocopy) {
+            int j;
+
+            for (j = 0; j < tocopy-len; j++) free(history[j]);
+            tocopy = len;
+        }
+        memset(new,0,sizeof(char*)*len);
+        memcpy(new,history+(history_len-tocopy), sizeof(char*)*tocopy);
+        free(history);
+        history = new;
+    }
+    history_max_len = len;
+    if (history_len > history_max_len)
+        history_len = history_max_len;
+    return 1;
+}
+
+/* Save the history in the specified file. On success 0 is returned
+ * otherwise -1 is returned. */
+int linenoiseHistorySave(const char *filename) {
+    mode_t old_umask = umask(S_IXUSR|S_IRWXG|S_IRWXO);
+    FILE *fp;
+    int j;
+
+    fp = fopen(filename,"w");
+    umask(old_umask);
+    if (fp == NULL) return -1;
+    fchmod(fileno(fp),S_IRUSR|S_IWUSR);
+    for (j = 0; j < history_len; j++) {
+        char *p = history[j];
+        /* Keep the history file newline-separated: embedded newlines in an
+         * entry are stored as CR and converted back by linenoiseHistoryLoad(). */
+        while (*p) {
+            fputc(*p == '\n' ? '\r' : *p, fp);
+            p++;
+        }
+        fputc('\n', fp);
+    }
+    fclose(fp);
+    return 0;
+}
+
+/* Load the history from the specified file. If the file does not exist
+ * zero is returned and no operation is performed.
+ *
+ * If the file exists and the operation succeeded 0 is returned, otherwise
+ * on error -1 is returned. */
+int linenoiseHistoryLoad(const char *filename) {
+    FILE *fp = fopen(filename,"r");
+    char *buf;
+    int err = 0;
+
+    if (fp == NULL) return -1;
+
+    while ((buf = linenoiseReadLine(fp,&err)) != NULL) {
+        size_t j;
+
+        /* Rebuild embedded newlines that were saved as CR. */
+        for (j = 0; buf[j]; j++) {
+            if (buf[j] == '\r') buf[j] = '\n';
+        }
+        linenoiseHistoryAdd(buf);
+        free(buf);
+    }
+    if (err || ferror(fp)) {
+        fclose(fp);
+        return -1;
+    }
+    fclose(fp);
+    return 0;
+}

--- a/src/linenoise/linenoise.h
+++ b/src/linenoise/linenoise.h
@@ -1,0 +1,120 @@
+/* linenoise.h -- VERSION 1.0
+ *
+ * Guerrilla line editing library against the idea that a line editing lib
+ * needs to be 20,000 lines of C code.
+ *
+ * See linenoise.c for more information.
+ *
+ * ------------------------------------------------------------------------
+ *
+ * Copyright (c) 2010-2023, Salvatore Sanfilippo <antirez at gmail dot com>
+ * Copyright (c) 2010-2013, Pieter Noordhuis <pcnoordhuis at gmail dot com>
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  *  Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *
+ *  *  Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef __LINENOISE_H
+#define __LINENOISE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stddef.h> /* For size_t. */
+
+extern char *linenoiseEditMore;
+
+#define LINENOISE_MAX_FOLDS 16
+
+/* The linenoiseState structure represents the state during line editing.
+ * We pass this state to functions implementing specific editing
+ * functionalities. */
+struct linenoiseState {
+    int in_completion;  /* The user pressed TAB and we are now in completion
+                         * mode, so input is handled by completeLine(). */
+    size_t completion_idx; /* Index of next completion to propose. */
+    int ifd;            /* Terminal stdin file descriptor. */
+    int ofd;            /* Terminal stdout file descriptor. */
+    char *buf;          /* Edited line buffer. */
+    size_t buflen;      /* Edited line buffer size. */
+    size_t buflen_max;  /* Max buffer size, or 0 if fixed. */
+    const char *prompt; /* Prompt to display. */
+    size_t plen;        /* Prompt length. */
+    size_t pos;         /* Current cursor position. */
+    size_t oldpos;      /* Previous refresh cursor position. */
+    size_t len;         /* Current edited line length. */
+    size_t cols;        /* Number of columns in terminal. */
+    size_t oldrows;     /* Rows used by last refrehsed line (multiline mode) */
+    int oldrpos;        /* Cursor row from last refresh (for multiline clearing). */
+    int history_index;  /* The history index we are currently editing. */
+    int fold_count;    /* Number of folded ranges. */
+    size_t fold_start[LINENOISE_MAX_FOLDS]; /* Folded range start offsets. */
+    size_t fold_end[LINENOISE_MAX_FOLDS];   /* Folded range end offsets. */
+};
+
+typedef struct linenoiseCompletions {
+  size_t len;
+  char **cvec;
+} linenoiseCompletions;
+
+/* Non blocking API. */
+int linenoiseEditStart(struct linenoiseState *l, int stdin_fd, int stdout_fd, char *buf, size_t buflen, const char *prompt);
+char *linenoiseEditFeed(struct linenoiseState *l);
+void linenoiseEditStop(struct linenoiseState *l);
+void linenoiseHide(struct linenoiseState *l);
+void linenoiseShow(struct linenoiseState *l);
+
+/* Blocking API. */
+char *linenoise(const char *prompt);
+void linenoiseFree(void *ptr);
+
+/* Completion API. */
+typedef void(linenoiseCompletionCallback)(const char *, linenoiseCompletions *);
+typedef char*(linenoiseHintsCallback)(const char *, int *color, int *bold);
+typedef void(linenoiseFreeHintsCallback)(void *);
+void linenoiseSetCompletionCallback(linenoiseCompletionCallback *);
+void linenoiseSetHintsCallback(linenoiseHintsCallback *);
+void linenoiseSetFreeHintsCallback(linenoiseFreeHintsCallback *);
+void linenoiseAddCompletion(linenoiseCompletions *, const char *);
+
+/* History API. */
+int linenoiseHistoryAdd(const char *line);
+int linenoiseHistorySetMaxLen(int len);
+int linenoiseHistorySave(const char *filename);
+int linenoiseHistoryLoad(const char *filename);
+
+/* Other utilities. */
+void linenoiseClearScreen(void);
+void linenoiseSetMultiLine(int ml);
+void linenoisePrintKeyCodes(void);
+void linenoiseMaskModeEnable(void);
+void linenoiseMaskModeDisable(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __LINENOISE_H */

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,8 @@
 #ifdef HCC_ENABLE_JIT
 #include "aarch64-jit.h"
 #include "x86_64-jit.h"
+#include "memsafe.h"
+#include "repl.h"
 #endif
 #include "lexer.h"
 #include "list.h"
@@ -67,10 +69,37 @@ typedef struct hccLib {
     char *install_cmd;
 } hccLib;
 
-int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) { 
+/* `-l` flags for every `#link <name>` directive, ready to splice into
+ * a link command. Empty string when nothing was #link'd. Also adds
+ * `-L` for lib dirs the platform linker doesn't necessarily search on
+ * its own (Homebrew on Apple Silicon most notably) - but only ones
+ * that exist, so ld doesn't warn, and only when a `#link <name>` is
+ * actually in play. */
+static AoStr *linkLibFlags(Cctrl *cc) {
+    AoStr *flags = aoStrNew();
+    if (!listEmpty(cc->link_libs)) {
+        static const char *const extra_dirs[] = {
+            "/opt/homebrew/lib",
+            "/usr/local/lib",
+        };
+        for (size_t i = 0; i < sizeof(extra_dirs)/sizeof(extra_dirs[0]); ++i) {
+            if (access(extra_dirs[i], F_OK) == 0) {
+                aoStrCatFmt(flags, "-L%s ", extra_dirs[i]);
+            }
+        }
+        listForEach(cc->link_libs) {
+            AoStr *name = it->value;
+            aoStrCatFmt(flags, "-l%s ", name->data);
+        }
+    }
+    return flags;
+}
+
+int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
     AoStr *dylib_cmd = aoStrNew();
     AoStr *stylib_cmd = aoStrNew();
     AoStr *installcmd = aoStrNew();
+    AoStr *link_flags = linkLibFlags(cc);
     
     /* All literal INSTALL_PREFIX paths are now plumbed through
      * args->install_dir so a `-lib tos --install-dir=X` build lands
@@ -85,7 +114,7 @@ int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
 
     aoStrCatPrintf(dylib_cmd,
             "cp -pPR ./%s %s/lib/lib%s && "
-            "%s -dynamiclib -Wl,-install_name,%s/lib/%s -o %s "CLIBS" -o %s %s",
+            "%s -dynamiclib -Wl,-install_name,%s/lib/%s -o %s "CLIBS" -o %s %s %s",
             lib->stylib_name,
             args->install_dir,
             lib->stylib_name,
@@ -94,7 +123,8 @@ int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
             name,
             lib->dylib_version_name,
             lib->dylib_name,
-            args->obj_outfile);
+            args->obj_outfile,
+            link_flags->data);
 
     aoStrCatPrintf(installcmd,
             "cp -pPR ./%s %s/lib/lib%s && "
@@ -122,11 +152,12 @@ int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
      * routing every global access through the GOT. The symbols stay in
      * the dynamic table, so the JIT can still dlsym them (e.g. `Fs`). */
     aoStrCatPrintf(dylib_cmd,
-            "%s -fPIC -shared -Wl,-Bsymbolic -Wl,-soname,%s %s -o %s "CLIBS,
+            "%s -fPIC -shared -Wl,-Bsymbolic -Wl,-soname,%s %s -o %s "CLIBS" %s",
             cc->CC,
             lib->dylib_version_name,
             args->obj_outfile,
-            lib->dylib_name);
+            lib->dylib_name,
+            link_flags->data);
 
     /* Install two artefacts:
      *   - the static archive `libtos.a`, which AOT links via `-ltos`.
@@ -156,6 +187,7 @@ int hccLibInit(Cctrl *cc, hccLib *lib, CliArgs *args, char *name) {
 #error "System not supported"
 #endif
     aoStrCatPrintf(stylib_cmd,"ar rcs %s %s",lib->stylib_name,args->obj_outfile);
+    aoStrRelease(link_flags);
     lib->install_cmd = aoStrMove(installcmd);
     lib->dylib_cmd = aoStrMove(dylib_cmd);
     lib->stylib_cmd = aoStrMove(stylib_cmd);
@@ -244,7 +276,8 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         safeSystem(lib.install_cmd, 1);
     } else {
         AoStr *ofiles = aoStrNew();
-        
+        AoStr *link_flags = linkLibFlags(cc);
+
         /* Concatinate a string with all of the .o and .so files */
         if (!listEmpty(cc->object_files)) {
             listForEach(cc->object_files) {
@@ -266,11 +299,12 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         if (args->run) {
             AoStr *run_cmd = aoStrNew();
             writeAsmToTmp(asmbuf);
-            aoStrCatPrintf(run_cmd,"%s -L%s/lib %s %s %s "CLIBS" -ltos && ./a.out && rm ./a.out",
+            aoStrCatPrintf(run_cmd,"%s -L%s/lib %s %s %s %s "CLIBS" -ltos && ./a.out && rm ./a.out",
                     cc->CC,
                     args->install_dir,
                     ASM_TMP_FILE,
                     ofiles->data,
+                    link_flags->data,
                     args->clibs ? args->clibs : "");
             /* Don't use 'safeSystem' else anything other than a '0' exit
              * code will cause a panic which is incorrect... This is a bit of a
@@ -288,11 +322,12 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
         }
         char *clibs = args->clibs ? args->clibs : "";
 
-        aoStrCatPrintf(cmd, "%s -L%s/lib %s %s %s -ltos "CLIBS" -o %s",
+        aoStrCatPrintf(cmd, "%s -L%s/lib %s %s %s %s -ltos "CLIBS" -o %s",
                 cc->CC,
                 args->install_dir,
                 ASM_TMP_FILE,
                 ofiles->data,
+                link_flags->data,
                 clibs,
                 args->output_filename);
 
@@ -370,7 +405,6 @@ int main(int argc, char **argv) {
     AoStr *asmbuf;
     Cctrl *cc;
 
-
     CliArgs args;
     cliArgsInit(&args);
     /* now parse cli options */
@@ -401,8 +435,16 @@ int main(int argc, char **argv) {
         cc->CC = mprintf("cc");
     }
 
-    if (args.use_legacy_x86) {
-        cc->flags |= CCTRL_USE_LEGACY_X86;
+    if (args.use_legacy_x86) cc->flags |= CCTRL_USE_LEGACY_X86;
+    if (args.werror)         cc->flags |= CCTRL_WERROR;
+    if (args.memsafe)        cc->flags |= CCTRL_MEMSAFE;
+
+    /* Exactly one of the two is always defined; `#ifjit` / `#ifaot`
+     * key off them. The REPL runs on the JIT, so it counts. */
+    if (args.jit || args.repl) {
+        cctrlAddDefine(cc, "__HCC_JIT__");
+    } else {
+        cctrlAddDefine(cc, "__HCC_AOT__");
     }
 
     if (args.assemble) {
@@ -412,6 +454,19 @@ int main(int argc, char **argv) {
 
     if (!listEmpty(args.defines_list)) {
         cctrlSetCommandLineDefines(cc,args.defines_list);
+    }
+
+    if (args.repl) {
+#ifdef HCC_ENABLE_JIT
+        int rc = replRun(cc, &args);
+        memoryRelease();
+        return rc;
+#else
+        fprintf(stderr, "hcc: this build has no JIT; -repl is unavailable "
+                "(rebuild with -DHCC_ENABLE_JIT=on)\n");
+        memoryRelease();
+        return 1;
+#endif
     }
 
     if (args.print_tokens) {
@@ -447,6 +502,8 @@ int main(int argc, char **argv) {
 
 #ifdef HCC_ENABLE_JIT
     if (args.jit) {
+        /* Arm the tracking allocator before compiling - the JIT's
+         * finalize binds MAlloc/Free call sites at chunk compile. */
 #if defined(__aarch64__) || defined(__arm64__)
         HccJit *jit = aarch64JitCompile(cc);
 #elif defined(__x86_64__)
@@ -461,11 +518,17 @@ int main(int argc, char **argv) {
             return 1;
         }
         int rc = hccJitRunMain(jit, argc, argv);
+        if (args.memsafe) memsafeReportLeaks(stderr);
         hccJitFree(jit);
         memoryRelease();
         return rc;
     }
 #endif
+    /* -jit returns above and -repl returned earlier; reaching here
+     * with the flag set means an AOT-style invocation. */
+    if (args.memsafe)
+        fprintf(stderr,
+                "hcc: -Memsafe currently requires -jit or -repl; ignored\n");
 
     if (args.cfg_create || args.cfg_create_png || args.cfg_create_svg) {
         Vec *cfgs = cfgConstruct(cc);

--- a/src/memsafe.c
+++ b/src/memsafe.c
@@ -1,0 +1,317 @@
+/* Tracking allocator for JIT'd HolyC. Disabled by default on the JIT,
+ * enabled by default with the repl.
+ *
+ * MAlloc/Free/CAlloc/ReAlloc normally live in the libtos dylib, whose
+ * INTERNAL libc calls never pass the JIT resolver - so interposition
+ * happens at the HolyC entry points. The wrappers ARE the
+ * implementation rather than forwarding to the dylib: that keeps them
+ * independent of the installed libtos (a stale or missing build for
+ * the running arch would otherwise silently disable tracking). The
+ * layout is just a u64 size header at [p-8] (memory.HC), so MSize and
+ * dylib-internal frees interoperate with blocks made here, and vice
+ * versa. The tracked pointer is the payload - exactly what HolyC code
+ * holds. */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#if defined(__APPLE__)
+#include <malloc/malloc.h> /* malloc_zone_from_ptr */
+#endif
+
+#include "containers.h"
+#include "jit-common.h"
+#include "memsafe.h"
+
+typedef struct MemsafeEntry {
+    void *ptr;
+    u64 size;
+    int alloc_round;
+    int free_round;
+    /* Raw return addresses into JIT code; symbolised lazily so the
+     * alloc hot path never scans the symbol table. */
+    uintptr_t alloc_site[2];
+    uintptr_t free_site[2];
+} MemsafeEntry;
+
+static HccJit *memsafe_jit = NULL;
+static Map *memsafe_live = NULL; /* (u64)ptr -> MemsafeEntry* */
+static int memsafe_round = 0;    /* attribution tag; <= 0 omitted */
+
+/* Recently-freed ring: bounds how long a double free stays
+ * classifiable. Beyond it the pointer falls through to the zone
+ * check, i.e. untracked behaviour. */
+#define MEMSAFE_RING 256
+static MemsafeEntry memsafe_ring[MEMSAFE_RING];
+static int memsafe_ring_next = 0;
+
+void memsafeSetRound(int round) {
+    memsafe_round = round;
+}
+
+/* First `max` return addresses landing in JIT code, walking this
+ * (healthy) C call stack: wrapper <- _FREE/_MALLOC (JIT) <- user fn
+ * (JIT) <- entry (C, stops matching). */
+static int memsafeCallSites(uintptr_t *out, int max) {
+    HccJit *jit = memsafe_jit;
+    if (jit == NULL) return 0;
+    int n = 0;
+    uintptr_t fp = (uintptr_t)__builtin_frame_address(0);
+    uintptr_t prev = 0;
+    for (int depth = 0; depth < 32 && fp && n < max; ++depth) {
+        if (fp & 7) break;
+        if (prev && fp <= prev) break;
+        uintptr_t ret = ((uintptr_t *)fp)[1];
+        uintptr_t next = ((uintptr_t *)fp)[0];
+        if (ret && hccJitFindChunk(jit, (void *)ret)) out[n++] = ret;
+        prev = fp;
+        fp = next;
+    }
+    return n;
+}
+
+/* The stdlib shims (`_MALLOC`, `Free`, `ReAlloc`, ...) sit between the
+ * wrapper and the user's code, so skip them when naming a site. */
+static int memsafeIsAllocShim(const char *sym) {
+    while (*sym == '_') sym++;
+    return strcasecmp(sym, "malloc") == 0 ||
+           strcasecmp(sym, "free") == 0 ||
+           strcasecmp(sym, "calloc") == 0 ||
+           strcasecmp(sym, "realloc") == 0 ||
+           strcasecmp(sym, "mallocident") == 0 ||
+           strcasecmp(sym, "msize") == 0;
+}
+
+static void memsafePrintSite(FILE *f, const uintptr_t *sites, int nsites) {
+    HccJit *jit = memsafe_jit;
+    for (int i = 0; i < nsites; ++i) {
+        if (sites[i] == 0) continue;
+        size_t off = 0;
+        const char *sym = jit
+            ? hccJitFindSymbolForAddr(jit, (void *)sites[i], &off)
+            : NULL;
+        if (sym && memsafeIsAllocShim(sym)) continue;
+        if (sym) fprintf(f, "in `%s`+%zu", sym, off);
+        else     fprintf(f, "at %p", (void *)sites[i]);
+        return;
+    }
+    fprintf(f, "at an unknown site");
+}
+
+/* "round N " when rounds are in play (the REPL); nothing otherwise. */
+static void memsafePrintRound(FILE *f, int round) {
+    if (round > 0) fprintf(f, "round %d ", round);
+}
+
+static void memsafeTrack(void *p, u64 size) {
+    if (memsafe_live == NULL || p == NULL) return;
+    u64 key = (u64)(uintptr_t)p;
+    /* A stale entry can exist if host code freed this pointer behind
+     * our back and libc has now reused the address so replace it. */
+    MemsafeEntry *old = (MemsafeEntry *)mapGetInt(memsafe_live, key);
+    if (old) {
+        mapRemoveInt(memsafe_live, key);
+        free(old);
+    }
+    MemsafeEntry *e = (MemsafeEntry *)calloc(1, sizeof(*e));
+    if (e == NULL) return;
+    e->ptr = p;
+    e->size = size;
+    e->alloc_round = memsafe_round;
+    memsafeCallSites(e->alloc_site, 2);
+    mapAddIntOrErr(memsafe_live, key, e);
+}
+
+static MemsafeEntry *memsafeRingFind(void *p) {
+    for (int i = 0; i < MEMSAFE_RING; ++i)
+        if (memsafe_ring[i].ptr == p) return &memsafe_ring[i];
+    return NULL;
+}
+
+/* Untrack a live pointer, recording it in the recently-freed ring.
+ * Returns 1 if it was live. */
+static int memsafeRetire(void *p) {
+    if (memsafe_live == NULL || p == NULL) return 0;
+    u64 key = (u64)(uintptr_t)p;
+    MemsafeEntry *e = (MemsafeEntry *)mapGetInt(memsafe_live, key);
+    if (e == NULL) return 0;
+    mapRemoveInt(memsafe_live, key);
+    e->free_round = memsafe_round;
+    memset(e->free_site, 0, sizeof(e->free_site));
+    memsafeCallSites(e->free_site, 2);
+    memsafe_ring[memsafe_ring_next] = *e;
+    memsafe_ring_next = (memsafe_ring_next + 1) % MEMSAFE_RING;
+    free(e);
+    return 1;
+}
+
+static void memsafeReportDoubleFree(void *p, MemsafeEntry *r) {
+    uintptr_t here[2] = { 0, 0 };
+    memsafeCallSites(here, 2);
+    fprintf(stderr, "Free: double free of %p (%llu bytes)\n",
+                    p, (unsigned long long)r->size);
+    fprintf(stderr, "  allocated   ");
+    memsafePrintRound(stderr, r->alloc_round);
+    memsafePrintSite(stderr, r->alloc_site, 2);
+    fprintf(stderr, "\n  first freed ");
+    memsafePrintRound(stderr, r->free_round);
+    memsafePrintSite(stderr, r->free_site, 2);
+    fprintf(stderr, "\n  this free   ");
+    memsafePrintRound(stderr, memsafe_round);
+    memsafePrintSite(stderr, here, 2);
+    fprintf(stderr, " - ignored, heap unharmed\n");
+    fflush(stderr);
+}
+
+static void memsafeReportWildFree(void *p) {
+    uintptr_t here[2] = { 0, 0 };
+    memsafeCallSites(here, 2);
+    fprintf(stderr, "Free: %p was never heap-allocated "
+            "(stack, global or interior pointer?) ", p);
+    memsafePrintSite(stderr, here, 2);
+    fprintf(stderr, " - ignored\n");
+    fflush(stderr);
+}
+
+/* ---------------- the MAlloc-ABI wrappers ---------------- */
+
+static void *memsafeMAlloc(u64 size) {
+    u8 *base = (u8 *)malloc(size + 8);
+    if (base == NULL) return NULL;
+    *(u64 *)base = size;
+    void *p = base + 8;
+    memsafeTrack(p, size);
+    return p;
+}
+
+static void *memsafeCAlloc(u64 size) {
+    void *p = memsafeMAlloc(size);
+    if (p) memset(p, 0, size);
+    return p;
+}
+
+static void memsafeFree(void *p) {
+    if (p == NULL) return;
+    if (memsafeRetire(p)) {
+        free((u8 *)p - 8);
+        return;
+    }
+    MemsafeEntry *r = memsafeRingFind(p);
+    if (r) {
+        memsafeReportDoubleFree(p, r);
+        return;
+    }
+#if defined(__APPLE__)
+    /* Unknown pointer: probe the header address. Owned by a zone allocated by
+     * MAlloc inside libtos/host code we can't see; the layout is identical, so
+     * free the base. */
+    if (malloc_zone_from_ptr((uint8_t *)p - 8)) {
+        free((u8 *)p - 8);
+        return;
+    }
+    memsafeReportWildFree(p);
+#else
+    /* No safe way to probe an arbitrary pointer on Linux. */
+    free((u8 *)p - 8);
+#endif
+}
+
+static void *memsafeReAlloc(void *p, u64 size) {
+    if (p == NULL) return memsafeMAlloc(size);
+    /* Refuse before touching the old block: a freed block's header
+     * (and bytes) are not ours to read any more. */
+    MemsafeEntry *r = memsafeRingFind(p);
+    if (r != NULL) {
+        memsafeReportDoubleFree(p, r);
+        return NULL;
+    }
+    void *q = memsafeMAlloc(size);
+    if (q == NULL) return NULL;
+    u64 old_size = *(u64 *)((u8 *)p - 8);
+    memcpy(q, p, old_size < size ? old_size : size);
+    memsafeFree(p);
+    return q;
+}
+
+static int memsafeCmpSize(const void *a, const void *b) {
+    const MemsafeEntry *ea = *(MemsafeEntry *const *)a;
+    const MemsafeEntry *eb = *(MemsafeEntry *const *)b;
+    if (ea->size != eb->size) return eb->size > ea->size ? 1 : -1;
+    return 0;
+}
+
+/* Fill a Vec with the live entries (caller vecRelease's it - the vec
+ * type's release is a no-op, entries stay owned by the map). */
+static Vec *memsafeCollect(u64 *out_total) {
+    Vec *v = vecNew(&vec_unsigned_long_type);
+    u64 total = 0;
+    MapIter mi;
+    mapIterInit(memsafe_live, &mi);
+    while (mapIterNext(&mi)) {
+        MemsafeEntry *e = (MemsafeEntry *)mi.node->value;
+        total += e->size;
+        vecPush(v, e);
+    }
+    if (out_total) *out_total = total;
+    return v;
+}
+
+static void memsafeList(FILE *f, Vec *v) {
+    qsort(v->entries, v->size, sizeof(void *), memsafeCmpSize);
+    u64 shown = v->size < 20 ? v->size : 20;
+    for (u64 i = 0; i < shown; ++i) {
+        MemsafeEntry *e = vecGet(MemsafeEntry *, v, i);
+        fprintf(f, "  %p  %8llu bytes  ", e->ptr,
+                (unsigned long long)e->size);
+        memsafePrintRound(f, e->alloc_round);
+        memsafePrintSite(f, e->alloc_site, 2);
+        fprintf(f, "\n");
+    }
+    if (v->size > shown)
+        fprintf(f, "  ... %llu more\n",
+                (unsigned long long)(v->size - shown));
+}
+
+void memsafeDumpLive(FILE *f) {
+    if (memsafe_live == NULL) return;
+    u64 total = 0;
+    Vec *v = memsafeCollect(&total);
+    fprintf(f, "heap: %llu live allocation(s), %llu bytes\n",
+            (unsigned long long)v->size, (unsigned long long)total);
+    memsafeList(f, v);
+    vecRelease(v);
+    fflush(f);
+}
+
+void memsafeReportLeaks(FILE *f) {
+    if (memsafe_live == NULL || memsafe_live->size == 0) return;
+    /* The program's buffered stdout should land before the report. */
+    fflush(stdout);
+    u64 total = 0;
+    Vec *v = memsafeCollect(&total);
+    fprintf(f, "memsafe: %llu allocation(s) (%llu bytes) never freed\n",
+            (unsigned long long)v->size, (unsigned long long)total);
+    memsafeList(f, v);
+    vecRelease(v);
+    fflush(f);
+}
+
+void memsafeInit(HccJit *jit) {
+    if (jit == NULL) return;
+    memsafe_jit = jit;
+    if (memsafe_live == NULL)
+        memsafe_live = mapNew(64, &map_uint_to_uint_type);
+    /* host_symbols wins over dlsym, so these shadow the libtos dylib's
+     * implementations at every JIT'd call site. Both the asm-label
+     * spellings (_MALLOC on x86_64) and the compiled-HolyC ones (Free
+     * on aarch64) are covered; register before any chunk compiles. */
+    hccJitDefineSymbol(jit, "_MALLOC",  (void *)(uintptr_t)memsafeMAlloc);
+    hccJitDefineSymbol(jit, "_CALLOC",  (void *)(uintptr_t)memsafeCAlloc);
+    hccJitDefineSymbol(jit, "_REALLOC", (void *)(uintptr_t)memsafeReAlloc);
+    hccJitDefineSymbol(jit, "_FREE",    (void *)(uintptr_t)memsafeFree);
+    hccJitDefineSymbol(jit, "Free",     (void *)(uintptr_t)memsafeFree);
+    hccJitDefineSymbol(jit, "CAlloc",   (void *)(uintptr_t)memsafeCAlloc);
+    hccJitDefineSymbol(jit, "ReAlloc",  (void *)(uintptr_t)memsafeReAlloc);
+}

--- a/src/memsafe.h
+++ b/src/memsafe.h
@@ -1,0 +1,36 @@
+#ifndef MEMSAFE_H__
+#define MEMSAFE_H__
+
+#include <stdio.h>
+
+#include "jit-common.h"
+
+/* Tracking allocator for JIT'd HolyC.
+ *
+ * Interposes the HolyC allocator entry points (_MALLOC/Free/CAlloc/
+ * ReAlloc) in a jit's host_symbols - which the resolver checks before
+ * dlsym - so every allocation user code makes is classified at the
+ * Free call: double frees and wild frees are reported with their
+ * allocating/freeing call sites and never forwarded, leaving the heap
+ * unharmed. macOS malloc's own detection is probabilistic for small
+ * blocks (SIGABRT, SIGTRAP or silent corruption, run-dependent); this
+ * is deterministic.
+ *
+ * Used always by the REPL (plus the `ReplHeap;` builtin), and by
+ * `hcc -Memsafe -jit`, which adds a leak report at exit. */
+
+/* Register the tracking allocator in `jit`'s host_symbols. Must run
+ * before any chunk is compiled - finalize binds call sites then. */
+void memsafeInit(HccJit *jit);
+
+/* Attribution tag for reports; the REPL sets its eval round. Rounds
+ * <= 0 are omitted from output. */
+void memsafeSetRound(int round);
+
+/* Live allocations, biggest first (the `ReplHeap;` builtin). */
+void memsafeDumpLive(FILE *f);
+
+/* End-of-run leak summary: silent when nothing is live. */
+void memsafeReportLeaks(FILE *f);
+
+#endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -1401,7 +1401,7 @@ Ast *parseCaseLabel(Cctrl *cc, Lexeme *tok) {
         case_->type = ast_void_type;
     } else {
         case_ = astCase(label,begining,end,stmts);
-        assertUniqueSwitchCaseLabels(cc->tmp_case_list,case_);
+        assertUniqueSwitchCaseLabels(cc,cc->tmp_case_list,case_);
     }
 
     vecPush(cc->tmp_case_list,case_);
@@ -1905,6 +1905,45 @@ static int astStmtFallsThrough(Ast *s) {
     }
 }
 
+/* Naked `asm { }` functions get no compiler-generated epilogue - the
+ * body is pasted verbatim, so a missing `RET` lets the CPU fall off the
+ * end into whatever follows (typically a SIGILL). Heuristic: scan for a
+ * whole-word control transfer that ends the function - RET/ERET/IRET or
+ * a tail branch (JMP/B/BR) - case-insensitive. A tail branch counts so
+ * legitimate tail-call exits don't trip the warning. */
+static int asmTextHasReturn(AoStr *text) {
+    static const char *exits[] = { "ret", "eret", "iret", "jmp", "br", "b" };
+    if (!text || !text->data) return 0;
+    const char *s = text->data;
+    int n = (int)text->len;
+    for (int i = 0; i < n; i++) {
+        if (i > 0) {
+            char p = s[i - 1];   /* only test at a word start */
+            if ((p >= 'A' && p <= 'Z') || (p >= 'a' && p <= 'z') ||
+                (p >= '0' && p <= '9') || p == '_')
+                continue;
+        }
+        for (size_t k = 0; k < sizeof(exits) / sizeof(exits[0]); k++) {
+            const char *w = exits[k];
+            int wl = (int)strlen(w);
+            if (i + wl > n) continue;
+            int match = 1;
+            for (int j = 0; j < wl; j++) {
+                char a = s[i + j];
+                if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+                if (a != w[j]) { match = 0; break; }
+            }
+            if (!match) continue;
+            char after = (i + wl < n) ? s[i + wl] : '\0';   /* whole word */
+            if ((after >= 'A' && after <= 'Z') || (after >= 'a' && after <= 'z') ||
+                (after >= '0' && after <= '9') || after == '_')
+                continue;
+            return 1;
+        }
+    }
+    return 0;
+}
+
 Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
         char *fname, int len, Vec *params, int has_var_args, int is_inline)
 {
@@ -2027,6 +2066,15 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
             if (is_inline) {
                 asm_func->flags = AST_FLAG_INLINE;
             }
+
+            if (!asmTextHasReturn(asm_block->asm_stmt)) {
+                cctrlWarningAt(cc, fn_line, fn_col, fn_len,
+                    "asm function '%.*s' has no RET; execution runs off the "
+                    "end of the function - naked asm functions get no "
+                    "epilogue, so add a `RET` yourself",
+                    len, fname);
+            }
+
             cctrlTokenExpect(cc,'}');
             cc->tmp_asm_fname = prev_asm_name;
             return asm_func;
@@ -2060,6 +2108,19 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
                 cctrlRaiseException(cc,"Cannot redefine extern function: %.*s",len,fname);
 
             case AST_FUNC:
+                if (cc->flags & CCTRL_REPL) {
+                    /* REPL: shadow the old definition with a fresh
+                     * function AST. Code already compiled against the
+                     * old body keeps its old address; anything parsed
+                     * from here on binds to this one. */
+                    cc->tmp_params = params;
+                    cc->tmp_rettype = rettype;
+                    fn_type = astMakeFunctionType(cc->tmp_rettype, params);
+                    func = astFunction(fn_type,fname,len,params,NULL,locals,
+                            has_var_args);
+                    mapAdd(cc->global_env, func->fname->data, func);
+                    break;
+                }
                 cctrlRaiseException(cc,"Cannot redefine function: %.*s",len,fname);
 
             case AST_ASM_FUNC_BIND:
@@ -2417,6 +2478,22 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
                     *is_global = 1;
                     return parseForStatement(cc);
 
+                case KW_SIZEOF:
+                case KW_ALIGNOF:
+                case KW_TYPEOF:
+                    /* Floating `sizeof(x);` / `typeof(x);` - in the
+                     * REPL these are expressions to evaluate + echo,
+                     * same as `2+2;`. */
+                    if (cc->flags & CCTRL_REPL) {
+                        cctrlTokenRewind(cc);
+                        ast = parseExpr(cc,16);
+                        cctrlTokenExpect(cc,';');
+                        *is_global = 1;
+                        return ast;
+                    }
+                    cctrlRaiseException(cc,"Unexpected floating keyword: %.*s",
+                            tok->len,tok->start);
+
                 default:
                     cctrlRaiseException(cc,"Unexpected floating keyword: %.*s",
                             tok->len,tok->start);
@@ -2453,9 +2530,46 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
             *is_global = 1;
             return ast;
         } else if (tok->tk_type == TK_I64) {
+            if (cc->flags & CCTRL_REPL) {
+                /* REPL: `2+2;` is an expression to evaluate + echo. */
+                cctrlTokenRewind(cc);
+                ast = parseExpr(cc,16);
+                cctrlTokenExpect(cc,';');
+                *is_global = 1;
+                return ast;
+            }
             cctrlRaiseException(cc,"Floating integer constant '%ld' cannot be used in this context", tok->i64);
         } else if (tok->tk_type == TK_F64) {
+            if (cc->flags & CCTRL_REPL) {
+                cctrlTokenRewind(cc);
+                ast = parseExpr(cc,16);
+                cctrlTokenExpect(cc,';');
+                *is_global = 1;
+                return ast;
+            }
             cctrlRaiseException(cc,"Floating float constant '%f' cannot be used in this context", tok->f64);
+        } else if (tokenPunctIs(tok,TK_PLUS_PLUS) ||
+                   tokenPunctIs(tok,TK_MINUS_MINUS))
+        {
+            /* `++x;` / `--x;` - a side-effecting statement, legal at
+             * the top level in scripting mode. */
+            cctrlTokenRewind(cc);
+            ast = parseExpr(cc,16);
+            cctrlTokenExpect(cc,';');
+            *is_global = 1;
+            return ast;
+        } else if ((cc->flags & CCTRL_REPL) &&
+                   (tokenPunctIs(tok,'(') || tokenPunctIs(tok,'-') ||
+                    tokenPunctIs(tok,'+') || tokenPunctIs(tok,'~') ||
+                    tokenPunctIs(tok,'!') || tokenPunctIs(tok,'*') ||
+                    tokenPunctIs(tok,'&')))
+        {
+            /* REPL: unary/parenthesised expression at the top level. */
+            cctrlTokenRewind(cc);
+            ast = parseExpr(cc,16);
+            cctrlTokenExpect(cc,';');
+            *is_global = 1;
+            return ast;
         }
 
         name = cctrlTokenGet(cc);
@@ -2485,6 +2599,16 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
             cctrlRaiseException(cc,"Identifier expected: got %s",lexemeToString(name));
         }
 
+        /* Every legitimate route to the declaration code below parsed a
+         * type first. Reaching here without one means the input opened
+         * with a punct we don't treat as a statement (`*p = ...;` at
+         * the top level, say) - raise instead of dereferencing NULL. */
+        if (type == NULL) {
+            cctrlRaiseException(cc,
+                    "Expected a type declaration before `%.*s`",
+                    name->len, name->start);
+        }
+
         type = parseArrayDimensions(cc,type);
         tok = cctrlTokenPeek(cc);
 
@@ -2501,6 +2625,7 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
         {
             variable = astGVar(type,name->start,name->len,0);
             mapAdd(cc->global_env,variable->gname->data,variable);
+            cc->tmp_gvar_decl = variable;
             return parseVariableInitialiser(cc,variable,
                                             PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
         }
@@ -2511,6 +2636,7 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
 
             listAppend(cc->ast_list,ast_decl);
             mapAdd(cc->global_env,variable->gname->data,variable);
+            cc->tmp_gvar_decl = variable;
 
             /* `auto foo = <expr>;` at file scope: the variable's type
              * isn't known until the initialiser is parsed, and building
@@ -2555,6 +2681,7 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
         } else if (type->kind == AST_TYPE_ARRAY) {
             variable = astGVar(type,name->start,name->len,0);
             mapAdd(cc->global_env,variable->gname->data,variable);
+            cc->tmp_gvar_decl = variable;
             ast = parseVariableInitialiser(cc,variable,PUNCT_TERM_COMMA|PUNCT_TERM_SEMI);
             if (type->kind == AST_TYPE_AUTO) {
                 parseAssignAuto(cc,ast);
@@ -2580,6 +2707,15 @@ void parseToAst(Cctrl *cc) {
     Ast *ast;
     Lexeme *tok;
     int is_global = 0;
+
+    /* The previous parse can leave these dangling: the loop below
+     * only resets them when it keeps iterating, not when it breaks at
+     * EOF. A stale tmp_locals is fatal for the next parse (the REPL) -
+     * the first global statement would listMergeAppend (and free!) a
+     * list that may already have been merged and recycled. */
+    cc->tmp_locals = NULL;
+    cc->localenv = NULL;
+    cc->tmp_gvar_decl = NULL;
 
     /* Top-level recovery point. cctrlRaiseException longjmps here
      * once a CctrlDiagnostic is queued; we wipe function-scoped state
@@ -2609,6 +2745,13 @@ void parseToAst(Cctrl *cc) {
             cc->tmp_rettype = NULL;
             cc->tmp_loop_begin = NULL;
             cc->tmp_loop_end = NULL;
+            /* The lists below roll back the half-built AST_DECL; the
+             * variable's global_env entry must go with it, or later
+             * statements can reference storage that no longer exists. */
+            if (cc->tmp_gvar_decl) {
+                mapRemove(cc->global_env, cc->tmp_gvar_decl->gname->data);
+                cc->tmp_gvar_decl = NULL;
+            }
             if (cc->ast_list && ast_tail) {
                 ast_tail->next = cc->ast_list;
                 cc->ast_list->prev = ast_tail;
@@ -2628,6 +2771,7 @@ void parseToAst(Cctrl *cc) {
         }
 
         ast = parseToplevelDef(cc, &is_global);
+        cc->tmp_gvar_decl = NULL; /* decl completed - nothing to roll back */
         if (ast == NULL) break;
         if (is_global) {
             listAppend(cc->initalisers,ast);

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -1497,6 +1497,35 @@ Ast *parseAlignof(Cctrl *cc) {
     return astI64Type(astTypeAlign(type));
 }
 
+/* `typeof(<type or expr>)` - same operand handling as sizeof/alignof
+ * but folds to a string literal naming the type: typeof(1+1) == "I64",
+ * typeof("s") == "U8[2]", typeof(&f) == "F64 *". The expression is
+ * only type-checked, never evaluated. */
+Ast *parseTypeof(Cctrl *cc) {
+    Lexeme *tok = cctrlTokenGet(cc);
+    Lexeme *peek = cctrlTokenPeek(cc);
+    AstType *type = NULL;
+
+    if (tokenPunctIs(tok,'(') && cctrlIsKeyword(cc,peek->start,peek->len)) {
+        type = parseFullType(cc);
+        cctrlTokenExpect(cc,')');
+    } else {
+        cctrlTokenRewind(cc);
+        Ast *ast = parseUnaryExpr(cc);
+        type = ast ? ast->type : NULL;
+    }
+
+    if (!type) {
+        cctrlRaiseException(cc,
+                "typeof: could not determine the type of the operand");
+    }
+
+    AoStr *name = astTypeToAoStr(type);
+    /* real_len is the unescaped byte length + NUL; type names contain
+     * no escapes so it's just len + 1. */
+    return cctrlGetOrSetString(cc, name->data, name->len, name->len + 1);
+}
+
 Ast *parsePostFixExpr(Cctrl *cc) {
     Ast *ast;
     AstType *type;
@@ -1589,6 +1618,7 @@ Ast *parseUnaryExpr(Cctrl *cc) {
         switch (tok->i64) {
             case KW_SIZEOF: return parseSizeof(cc);
             case KW_ALIGNOF: return parseAlignof(cc);
+            case KW_TYPEOF: return parseTypeof(cc);
             case KW_DEFINED: {
                 cctrlTokenExpect(cc,'(');
                 tok = cctrlTokenGet(cc);

--- a/src/prslib.h
+++ b/src/prslib.h
@@ -22,6 +22,7 @@ Ast *findFunctionDecl(Cctrl *cc, char *fname, int len);
 Ast *parseCreateBinaryOp(Cctrl *cc, AstBinOp operation, Ast *left, Ast *right);
 Ast *parseSizeof(Cctrl *cc);
 Ast *parseAlignof(Cctrl *cc);
+Ast *parseTypeof(Cctrl *cc);
 
 /* Defined in parser.c; used here by parseParams to honour `reg`/`noreg`
  * on parameter declarations as well as locals. */

--- a/src/prsutil.c
+++ b/src/prsutil.c
@@ -480,7 +480,7 @@ int assertLValue(Ast *ast) {
     }
 }
 
-void assertUniqueSwitchCaseLabels(Vec *case_vector, Ast *case_) {
+void assertUniqueSwitchCaseLabels(Cctrl *cc, Vec *case_vector, Ast *case_) {
     for (u64 i = 0; i < case_vector->size; ++i) {
         Ast *cur = case_vector->entries[i];
         if (case_->case_end < cur->case_begin ||
@@ -491,9 +491,9 @@ void assertUniqueSwitchCaseLabels(Vec *case_vector, Ast *case_) {
             for (u64 j = 0; j < case_vector->size; ++j) {
                 astPrint(case_vector->entries[i]);
             }
-            loggerPanic("Duplicate case value: %ld\n",case_->case_begin);
+            cctrlRaiseException(cc,"Duplicate case value: %s\n",case_->case_label->data);
         }
-        loggerPanic("Duplicate case value: %ld\n",case_->case_begin);
+        cctrlRaiseException(cc, "Duplicate case value: %s\n",case_->case_label->data);
     }
 }
 

--- a/src/prsutil.h
+++ b/src/prsutil.h
@@ -37,7 +37,7 @@ int astIsArithmetic(Ast *ast, int is_float);
 void assertTokenIsTerminator(Cctrl *cc, Lexeme *tok, s64 terminator_flags);
 void assertTokenIsTerminatorWithMsg(Cctrl *cc, Lexeme *tok,
         s64 terminator_flags, const char *fmt, ...);
-void assertUniqueSwitchCaseLabels(Vec *case_vector, Ast *case_);
+void assertUniqueSwitchCaseLabels(Cctrl *cc, Vec *case_vector, Ast *case_);
 void assertIsFloatOrInt(Ast *ast, s64 lineno);
 void assertIsInt(Ast *ast, s64 lineno);
 void assertIsFloat(Ast *ast, s64 lineno);

--- a/src/repl.c
+++ b/src/repl.c
@@ -1,0 +1,1546 @@
+/* Interactive HolyC REPL.
+ *
+ * The trick that makes this cheap: the front end is already
+ * incremental. One long-lived Cctrl accumulates types, functions,
+ * globals and macros across parses, and the JIT's chunk API
+ * (hccJitCompileChunk) compiles only the ASTs appended since the last
+ * chunk into a fresh RX mapping, resolving names from earlier chunks
+ * through the persistent symbol map.
+ *
+ * Per input:
+ *   1. read lines until braces/brackets/parens balance and the input
+ *      is terminated (`;`, `}`, a directive, or a blank line)
+ *   2. lex + parse into the shared Cctrl (errors recover, REPL lives on)
+ *   3. wrap this round's top-level statements into `__repl_N`,
+ *      returning the trailing expression's value if it has one
+ *   4. compile the chunk, call `__repl_N`, echo the result
+ *
+ * TempleOS niceties fall out of the front end for free:
+ *   "Hello\n";            - naked strings print
+ *   F("%d\n", x); F(x);   - functions with default args, etc.
+ *
+ * Memory is semi-managed through the "memsafe" helpers. This makes it easier
+ * to report common errors.
+ */
+
+#include <ctype.h>
+#include <errno.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+#include <pthread.h> /* pthread_jit_write_protect_np */
+#endif
+
+#include "linenoise/linenoise.h"
+
+#include "aostr.h"
+#include "ast.h"
+#include "cctrl.h"
+#include "cli.h"
+#include "lexer.h"
+#include "list.h"
+#include "memory.h"
+#include "parser.h"
+#include "repl.h"
+#include "util.h"
+#include "version.h"
+
+#include "jit-common.h"
+#include "memsafe.h"
+#if defined(__aarch64__) || defined(__arm64__)
+#include "aarch64-jit.h"
+#include "asm/dis_arm64.h"
+#elif defined(__x86_64__)
+#include "x86_64-jit.h"
+#include "asm/dis_x86_64.h"
+#endif
+
+#define REPL_PROMPT      ">>> "
+#define REPL_PROMPT_CONT "..> "
+#define REPL_HISTORY_MAX 1000
+
+/* linenoise callbacks carry no user-data pointer, so the completion
+ * callback reaches the compiler state through these. repl_jit is for
+ * the `Uf` builtin, which JIT'd code calls back into. */
+static Cctrl *repl_cc = NULL;
+static HccJit *repl_jit = NULL;
+static char repl_history_path[512];
+static char *repl_prompt = REPL_PROMPT;
+static char *repl_prompt_cont = REPL_PROMPT_CONT;
+static char *repl_root_dir = NULL;
+
+/* -------------- Forward definitions ------------------------- */
+
+static AoStr *replGetRcPath(void);
+static void replDropInitialisers(Cctrl *cc);
+static int replParse(Cctrl *cc, char *root_dir, char *name, AoStr *src);
+static Ast *replBuildWrapper(Cctrl *cc, int round, AstType **echo_type);
+static void replExec(AoStr *input, int round);
+
+/* -------------- Forward definitions END --------------------- */
+
+static const HccJitBackend *replHostBackend(void) {
+#if defined(__aarch64__) || defined(__arm64__)
+    return aarch64JitBackend();
+#elif defined(__x86_64__)
+    return x86_64JitBackend();
+#else
+    return NULL;
+#endif
+}
+
+/* ---------------- fault recovery ----------------
+ *
+ * JIT'd code runs in-process, so `U8 *p = 0; *p = 1;` would take the
+ * whole session down with it - history, definitions, everything.
+ * Instead the hardware fault is caught, reported with a disassembly
+ * window around the faulting pc, and control siglongjmps back to the
+ * prompt. TempleOS dropped you into its debugger on a fault; we drop
+ * you back at the prompt.
+ *
+ * Recovery is best-effort by nature: if the fault fired while a libc
+ * lock was held (mid-malloc, say) the session may wedge later. That
+ * trade is right for a playground. Faults OUTSIDE an eval keep the
+ * default disposition - a crash in hcc itself dies loudly. */
+
+static sigjmp_buf repl_fault_env;
+static volatile sig_atomic_t repl_in_eval = 0;
+static volatile int repl_fault_sig = 0;
+static volatile uintptr_t repl_fault_pc = 0;
+static volatile uintptr_t repl_fault_addr = 0;
+static volatile uintptr_t repl_fault_fp = 0;
+static volatile uintptr_t repl_fault_lr = 0;
+static volatile uintptr_t repl_fault_frame = 0;
+
+/* The handler's frame-pointer walk (replFaultFindJitFrame) reads
+ * saved-fp/return-address pairs off a stack we no longer trust; if a
+ * read lands on an unmapped page, the nested fault delivery bails the
+ * walk out through here instead of killing the session. */
+static sigjmp_buf repl_walk_env;
+static volatile sig_atomic_t repl_in_walk = 0;
+
+/* A stack overflow in JIT'd code exhausts the main stack, so the
+ * handler needs somewhere else to run (SA_ONSTACK). Static, so
+ * recovery never depends on a working malloc. */
+static uint8_t repl_fault_stack[64 * 1024];
+
+static uintptr_t replFaultPcOf(void *uc_) {
+    ucontext_t *uc = (ucontext_t *)uc_;
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    return (uintptr_t)uc->uc_mcontext->__ss.__pc;
+#elif defined(__APPLE__) && defined(__x86_64__)
+    return (uintptr_t)uc->uc_mcontext->__ss.__rip;
+#elif defined(__linux__) && defined(__aarch64__)
+    return (uintptr_t)uc->uc_mcontext.pc;
+#elif defined(__linux__) && defined(__x86_64__)
+    return (uintptr_t)uc->uc_mcontext.gregs[REG_RIP];
+#else
+    (void)uc;
+    return 0;
+#endif
+}
+
+static uintptr_t replFaultFpOf(void *uc_) {
+    ucontext_t *uc = (ucontext_t *)uc_;
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    return (uintptr_t)uc->uc_mcontext->__ss.__fp;
+#elif defined(__APPLE__) && defined(__x86_64__)
+    return (uintptr_t)uc->uc_mcontext->__ss.__rbp;
+#elif defined(__linux__) && defined(__aarch64__)
+    return (uintptr_t)uc->uc_mcontext.regs[29];
+#elif defined(__linux__) && defined(__x86_64__)
+    return (uintptr_t)uc->uc_mcontext.gregs[REG_RBP];
+#else
+    (void)uc;
+    return 0;
+#endif
+}
+
+/* Link register (arm64 only): a fault in a frameless libc leaf keeps
+ * its caller here rather than in a stack frame record. */
+static uintptr_t replFaultLrOf(void *uc_) {
+    ucontext_t *uc = (ucontext_t *)uc_;
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    return (uintptr_t)uc->uc_mcontext->__ss.__lr;
+#elif defined(__linux__) && defined(__aarch64__)
+    return (uintptr_t)uc->uc_mcontext.regs[30];
+#else
+    (void)uc;
+    return 0;
+#endif
+}
+
+static uintptr_t replFaultFindJitFrame(HccJit *jit, uintptr_t fp,
+                                       uintptr_t lr);
+
+static void replFaultHandler(int sig, siginfo_t *si, void *uc) {
+    if (repl_in_walk) {
+        /* The frame walk below hit unmapped stack memory - abandon
+         * the walk, not the report. */
+        repl_in_walk = 0;
+        siglongjmp(repl_walk_env, 1);
+    }
+    if (!repl_in_eval) {
+        /* Not our eval: restore the default action and return - the
+         * faulting instruction re-executes and the process dies with
+         * a normal crash report. */
+        signal(sig, SIG_DFL);
+        return;
+    }
+    repl_fault_sig  = sig;
+    repl_fault_addr = (uintptr_t)si->si_addr;
+    repl_fault_pc   = replFaultPcOf(uc);
+    repl_fault_fp   = replFaultFpOf(uc);
+    repl_fault_lr   = replFaultLrOf(uc);
+
+    /* Attribute a host-code fault (abort() from a double free, a crash
+     * deep in libc) to the JIT frame that called out. This MUST happen
+     * here, on the alternate stack: after the siglongjmp the reporter's
+     * own calls recycle the main stack and overwrite the very frame
+     * records we need to read. */
+    repl_fault_frame = 0;
+    if (repl_jit &&
+        hccJitFindChunk(repl_jit, (void *)repl_fault_pc) == NULL)
+    {
+        repl_fault_frame = replFaultFindJitFrame(repl_jit, repl_fault_fp,
+                                                 repl_fault_lr);
+    }
+
+    repl_in_eval = 0;
+    siglongjmp(repl_fault_env, 1);
+}
+
+static void replInstallFaultHandlers(void) {
+    stack_t ss;
+    memset(&ss, 0, sizeof(ss));
+    ss.ss_sp = repl_fault_stack;
+    ss.ss_size = sizeof(repl_fault_stack);
+    sigaltstack(&ss, NULL);
+
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = replFaultHandler;
+    sa.sa_flags = SA_SIGINFO | SA_ONSTACK;
+    sigemptyset(&sa.sa_mask);
+    /* SIGTRAP: macOS malloc reports some heap corruption via a brk
+     * trap (__os_crash) rather than abort(). */
+    static const int sigs[] = { SIGSEGV, SIGBUS, SIGILL, SIGABRT, SIGFPE,
+                                SIGTRAP };
+    for (size_t i = 0; i < sizeof(sigs) / sizeof(sigs[0]); ++i)
+        sigaction(sigs[i], &sa, NULL);
+}
+
+static const char *replSigName(int sig) {
+    switch (sig) {
+        case SIGSEGV: return "SIGSEGV";
+        case SIGBUS:  return "SIGBUS";
+        case SIGILL:  return "SIGILL";
+        case SIGFPE:  return "SIGFPE";
+        case SIGABRT: return "SIGABRT";
+        case SIGTRAP: return "SIGTRAP";
+        default:      return "signal";
+    }
+}
+
+/* A fault whose pc is in host code (a double free aborting inside
+ * libSystem, say) still has JIT frames further up the stack - abort
+ * and friends preserve frame pointers, and so does JIT'd HolyC.
+ * Walk the saved-fp/return-address chain until a return address
+ * lands in a JIT chunk; that's the HolyC frame that made the call.
+ * Frame records: [fp] = caller's fp, [fp+8] = return address, on
+ * both AAPCS64 (x29) and SysV x86-64 (rbp).
+ *
+ * The stack may be arbitrarily damaged, so every step is checked
+ * (alignment, growth toward the stack base, a depth cap) and the
+ * loads run under repl_in_walk so a fault bails out via
+ * repl_walk_env instead of killing the report. */
+static uintptr_t replFaultFindJitFrame(HccJit *jit, uintptr_t fp,
+                                       uintptr_t lr) {
+    if (jit == NULL) return 0;
+    if (lr && hccJitFindChunk(jit, (void *)lr)) return lr;
+
+    uintptr_t found = 0;
+    if (sigsetjmp(repl_walk_env, 1) == 0) {
+        repl_in_walk = 1;
+        uintptr_t prev = 0;
+        for (int depth = 0; depth < 64 && fp; ++depth) {
+            if (fp & 7) break;              /* torn frame record */
+            if (prev && fp <= prev) break;  /* must move toward base */
+            uintptr_t ret = ((uintptr_t *)fp)[1];
+            uintptr_t next = ((uintptr_t *)fp)[0];
+            if (ret && hccJitFindChunk(jit, (void *)ret)) {
+                found = ret;
+                break;
+            }
+            prev = fp;
+            fp = next;
+        }
+    }
+    repl_in_walk = 0;
+    return found;
+}
+
+static void replReportFault(void) {
+#if defined(__APPLE__) && (defined(__aarch64__) || defined(__arm64__))
+    /* If the fault hit while a finalize had the MAP_JIT region
+     * writable, put this thread back in execute mode. */
+    pthread_jit_write_protect_np(1);
+#endif
+
+    uint8_t *pc = (uint8_t *)repl_fault_pc;
+    fprintf(stderr, "\n*** %s: fault address %p, pc %p",
+            replSigName(repl_fault_sig),
+            (void *)repl_fault_addr,
+            (void *)pc);
+
+    HccJit *jit = repl_jit;
+    AsmJitCode *chunk = jit ? hccJitFindChunk(jit, pc) : NULL;
+    size_t off = 0;
+    const char *sym = jit ? hccJitFindSymbolForAddr(jit, pc, &off) : NULL;
+    uint8_t *show = pc; /* where the disassembly window points */
+
+    if      (sym)   fprintf(stderr, " in `%s`+%zu\n", sym, off);
+    else if (chunk) fprintf(stderr, " in a call veneer\n");
+    else {
+        /* pc is host/libc code - the handler already walked the frame
+         * chain (while the faulting frames were still intact) to find
+         * the HolyC frame that called out. */
+        uintptr_t frame = repl_fault_frame;
+        if (frame) {
+            chunk = hccJitFindChunk(jit, (void *)frame);
+            sym = hccJitFindSymbolForAddr(jit, (void *)frame, &off);
+            show = (uint8_t *)frame;
+            fprintf(stderr, " in host code,\n    called from ");
+            if (sym) fprintf(stderr, "`%s`+%zu\n", sym, off);
+            else     fprintf(stderr, "%p in JIT code\n", (void *)frame);
+        } else {
+            fprintf(stderr, " (no JIT frame on the stack - possibly an hcc bug)\n");
+        }
+    }
+
+    /* Disassemble around the interesting pc - only when it's inside a
+     * JIT mapping, so the window reads live, readable bytes. For a
+     * walked frame `show` is the return address: the call itself is
+     * the line just above it. */
+    if (chunk) {
+        uint8_t *base = (uint8_t *)chunk->code;
+        uint8_t *live_end = base + chunk->size + chunk->veneer_size;
+        uint8_t *lo = show, *hi = show + 20;
+
+#if defined(__aarch64__) || defined(__arm64__)
+        lo = show - 16; /* fixed-width insns: backing up is safe */
+#endif
+
+        if (lo < base) lo = base;
+        if (hi > live_end) hi = live_end;
+#if defined(__aarch64__) || defined(__arm64__)
+        aarch64_disasm_buf_at(lo, (size_t)(hi - lo),
+                              (uint64_t)(uintptr_t)lo, stderr);
+#elif defined(__x86_64__)
+        x86_64_disasm_buf_at(lo, (size_t)(hi - lo),
+                             (uint64_t)(uintptr_t)lo, stderr);
+#endif
+    }
+    fprintf(stderr, "recovered; session state is best-effort from here\n");
+    fflush(stderr);
+}
+
+/* `ReplHeap;` - live allocations, biggest first. The tracker itself
+ * lives in memsafe.c; replRun installs it via memsafeInit. */
+static void replBuiltinReplHeap(void) {
+    memsafeDumpLive(stdout);
+}
+
+/* ---------------- Uf: the unassembler builtin ----------------
+ *
+ * `Uf("Fib");` prints the disassembly of a JIT-compiled function,
+ * TempleOS's "unassemble function", pointed at libtasm's disassembler. It's a
+ * host C function registered in the jit's symbol table, so compiled HolyC
+ * calls straight back into the compiler. */
+
+static void replBuiltinUf(char *name) {
+    HccJit *jit = repl_jit;
+    if (name == NULL || jit == NULL) return;
+
+    uint8_t *addr = (uint8_t *)hccJitLookup(jit, name);
+    if (addr == NULL) {
+        printf("Uf: `%s` is not a JIT-compiled function in this session\n",
+               name);
+        return;
+    }
+
+    /* The containing chunk's mapping bounds the code hard (chunk size
+     * excludes the veneer area)... */
+    uint8_t *end = NULL;
+    AsmJitCode *owner = NULL;
+    listForEach(jit->chunks) {
+        AsmJitCode *chunk = (AsmJitCode *)it->value;
+        uint8_t *base = (uint8_t *)chunk->code;
+        if (addr >= base && addr < base + chunk->size) {
+            end = base + chunk->size;
+            owner = chunk;
+            break;
+        }
+    }
+    if (end == NULL) {
+        printf("Uf: cannot locate the code chunk for `%s`\n", name);
+        return;
+    }
+
+    /* ...tightened to the next function emitted in the same chunk. */
+    MapIter mi;
+    mapIterInit(jit->symbols, &mi);
+    while (mapIterNext(&mi)) {
+        uint8_t *sym = (uint8_t *)mi.node->value;
+        if (sym > addr && sym < end) end = sym;
+    }
+
+    printf("%s @ %p, %zu bytes:\n", name, (void *)addr,
+           (size_t)(end - addr));
+#if defined(__aarch64__) || defined(__arm64__)
+    aarch64_disasm_buf_at(addr, (size_t)(end - addr), (uint64_t)(uintptr_t)addr,
+                          stdout);
+#elif defined(__x86_64__)
+    x86_64_disasm_buf_at(addr, (size_t)(end - addr), (uint64_t)(uintptr_t)addr,
+                         stdout);
+#endif
+
+    /* Out-of-range calls (e.g. into libSystem) go through movz/movk
+     * trampolines parked after the chunk's code - show them so a `bl`
+     * past the function's end has a visible target. Shared by every
+     * function in the chunk, hence the separate heading. */
+    if (owner->veneer_size > 0) {
+        uint8_t *vbase = (uint8_t *)owner->code + owner->size;
+        printf("veneers @ %p, %zu bytes:\n", (void *)vbase,
+               owner->veneer_size);
+#if defined(__aarch64__) || defined(__arm64__)
+        aarch64_disasm_buf_at(vbase, owner->veneer_size,
+                              (uint64_t)(uintptr_t)vbase, stdout);
+#elif defined(__x86_64__)
+        x86_64_disasm_buf_at(vbase, owner->veneer_size,
+                             (uint64_t)(uintptr_t)vbase, stdout);
+#endif
+    }
+    fflush(stdout);
+}
+
+static void replEvalString(char *code) {
+    if (!code) return;
+    u64 len = strlen(code);
+    AoStr b = {
+        .data = code,
+        .len = len,
+        .capacity = 0,
+    };
+    replExec(&b, INT_MAX);
+}
+
+/* --------- ReplReloadRc: Refresh the `~/.hcc_rc.HC` ----------
+ * Reinclude the `~/.hcc_rc.HC` this does not however delete the previous
+ * function or `#define` definitions, so it won't delete stuff. But it will
+ * re-define already existing symbols
+ */
+static void replBuiltinReloadRc(void) {
+    HccJit *jit = repl_jit;
+    if (jit == NULL) return;
+    Cctrl *cc = jit->cc;
+
+    AoStr *hcc_rc = replGetRcPath();
+    if (!hcc_rc) return;
+
+    Lexer *l = (Lexer *)malloc(sizeof(Lexer));
+    lexInit(l, NULL, CCF_PRE_PROC);
+    lexSetBuiltinRoot(l, repl_root_dir);
+    lexPushFile(l, hcc_rc);
+    cctrlDiagClear(cc);
+    cctrlResetTokenBuffer(cc);
+    cctrlInitParse(cc, l);
+    parseToAst(cc);
+
+    if (cctrlDiagFlush(cc) > 0) {
+        fprintf(stderr, "ReplReloadRc: errors\n");
+    }
+
+    cctrlDiagClear(cc);
+    replDropInitialisers(cc);
+
+    if (hccJitCompileChunk(jit, NULL) != 0) {
+        fprintf(stderr, "repl: warning: failed to compile rc file\n");
+    }
+
+    lexerRelease(l);
+}
+
+/* --------- ReplListFn: List all defined functions ---------- */
+static void replBuiltinListFn(void) {
+    HccJit *jit = repl_jit;
+    if (jit == NULL) return;
+    Cctrl *cc = jit->cc;
+    MapIter it;
+    mapIterInit(cc->global_env, &it);
+    while (mapIterNext(&it)) {
+        Ast *entry = it.node->value;
+        if (astIsFnLike(entry)) {
+            /* Can't free the string as it belongs to the AoStr pool... We
+             * need a way to be able to detach buffers from AoStr and free
+             * the underlying buffer as we leak everywhere. */
+            char *fn_str = astFunctionToString(entry);
+            fprintf(stderr, "%s\n", fn_str);
+        }
+    }
+}
+
+
+/* --------- ReplFindFn: Find a function -------------------------------- */
+static void replBuiltinFindFn(char *name) {
+    HccJit *jit = repl_jit;
+    if (jit == NULL) return;
+    Cctrl *cc = jit->cc;
+    MapIter it;
+    mapIterInit(cc->global_env, &it);
+    Vec *vec = vecNew(&vec_cstring_type);
+    while (mapIterNext(&it)) {
+        Ast *entry = it.node->value;
+        if (astIsFnLike(entry) && entry->fname && strstr(entry->fname->data, name)) {
+            char *fn_str = astFunctionToString(entry);
+            vecPush(vec, fn_str);
+        }
+    }
+    for (u64 i = 0; i < vec->size; ++i) {
+        char *fn = (char *)vec->entries[i];
+        fprintf(stderr, "%s\n",fn);
+    }
+    vecRelease(vec);
+}
+
+/* --------- ReplListGlobal: List all defined global variables ---------- */
+static void replBuiltinListGVars(void) {
+    HccJit *jit = repl_jit;
+    if (jit == NULL) return;
+    Cctrl *cc = jit->cc;
+    MapIter it;
+    mapIterInit(cc->global_env, &it);
+    while (mapIterNext(&it)) {
+        Ast *entry = it.node->value;
+        if (entry->kind == AST_GVAR) {
+            AoStr *gbl_str = astLValueToAoStr(entry,0);
+            AoStr *gbl_type = astTypeToColorAoStr(entry->type);
+            if (astTypeIsPtr(entry->type)) {
+                fprintf(stderr, "%s%s\n", gbl_type->data, gbl_str->data);
+            } else {
+                fprintf(stderr, "%s %s\n", gbl_type->data, gbl_str->data);
+            }
+            aoStrRelease(gbl_str);
+            aoStrRelease(gbl_type);
+        }
+    }
+}
+
+/* ---------------- ReplClassRep: Print a class or union --------- */
+static void replBuiltinPrintClass(char *name) {
+    HccJit *jit = repl_jit;
+    if (name == NULL || *name == '\0' || jit == NULL) return;
+    Cctrl *cc = jit->cc;
+    s64 len = (s64)strlen(name);
+
+    AstType *cls = mapGetLen(cc->clsdefs, name, len);
+    if (cls) {
+        AoStr *cls_str = astClassToAoStr(cls);
+        fprintf(stderr, "%s\n",cls_str->data);
+        aoStrRelease(cls_str);
+    }
+}
+
+/* ---------------- ReplDel: drop a definition ----------------
+ *
+ * `ReplDel("name");` removes a global variable, function, class,
+ * union or #define from the session so the name can be redefined
+ * from scratch. Already-compiled code that captured the old
+ * definition keeps working - this only frees the NAME (and, for
+ * globals, the JIT's storage binding so a redefinition gets a fresh
+ * slot instead of aliasing the old one at a possibly different
+ * size). */
+static void replBuiltinReplDel(char *name) {
+    HccJit *jit = repl_jit;
+    if (name == NULL || *name == '\0' || jit == NULL) return;
+    Cctrl *cc = jit->cc;
+    s64 len = (s64)strlen(name);
+    int removed = 0;
+
+    struct { Map *m; const char *what; } tables[] = {
+        { cc->global_env, "global" },
+        { cc->clsdefs,    "class" },
+        { cc->uniondefs,  "union" },
+        { cc->macro_defs, "#define" },
+        { cc->asm_funcs,  "asm function" },
+    };
+    for (size_t i = 0; i < sizeof(tables)/sizeof(tables[0]); ++i) {
+        if (tables[i].m && mapGetLen(tables[i].m, name, len)) {
+            mapRemove(tables[i].m, name);
+            printf("ReplDel: removed %s `%s`\n", tables[i].what, name);
+            removed = 1;
+        }
+    }
+    if (!removed) {
+        printf("ReplDel: nothing named `%s`\n", name);
+        return;
+    }
+
+    /* Unbind the JIT's view under both the raw and the Mach-O-mangled
+     * spelling. Old storage/code is intentionally leaked - compiled
+     * chunks may still reference it. */
+    char mangled[256];
+    snprintf(mangled, sizeof(mangled), "_%s", name);
+    if (jit->host_symbols) {
+        mapRemove(jit->host_symbols, name);
+        mapRemove(jit->host_symbols, mangled);
+    }
+    if (jit->symbols) {
+        mapRemove(jit->symbols, name);
+        mapRemove(jit->symbols, mangled);
+    }
+}
+
+/* Prototypes for the REPL's host builtins, parsed at startup so calls
+ * type-check like any other function (and show up in completion and
+ * hints). The implementations are registered via hccJitDefineSymbol. */
+static const char repl_builtin_protos[] =
+    "extern \"c\" U0 Uf(U8 *fname);\n"
+    "extern \"c\" U0 ReplReloadRc();\n"
+    "extern \"c\" U0 ReplListFn();\n"
+    "extern \"c\" U0 ReplFindFn(U8 *name);\n"
+    "extern \"c\" U0 ReplListGVars();\n"
+    "extern \"c\" U0 ReplClassRep(U8 *name);\n"
+    "extern \"c\" U0 ReplEval(U8 *code);\n"
+    "extern \"c\" U0 ReplDel(U8 *name);\n"
+    "extern \"c\" U0 ReplHeap();\n";
+
+/* ---------------- tab completion ---------------- */
+
+#define REPL_MAX_CANDIDATES 512
+
+static void replCollectFromMap(Map *m, const char *prefix, size_t plen,
+                               const char **cands, int *n) {
+    if (!m) return;
+    MapIter mi;
+    mapIterInit(m, &mi);
+    while (mapIterNext(&mi) && *n < REPL_MAX_CANDIDATES) {
+        const char *key = (const char *)mi.node->key;
+        if (!key || strncmp(key, prefix, plen) != 0) continue;
+        cands[(*n)++] = key;
+    }
+}
+
+static int replCandidateCmp(const void *a, const void *b) {
+    return strcmp(*(const char *const *)a, *(const char *const *)b);
+}
+
+/* Complete the identifier being typed at the end of `line` against
+ * everything the session knows: functions and globals (global_env),
+ * class/union names, built-in type keywords and #defines. linenoise
+ * wants each completion as the WHOLE replacement line, so the part of
+ * the line before the identifier is carried over verbatim. */
+static void replCompletion(const char *line, linenoiseCompletions *lc) {
+    Cctrl *cc = repl_cc;
+    if (!cc) return;
+
+    size_t len = strlen(line);
+    size_t start = len;
+    while (start > 0) {
+        char c = line[start - 1];
+        if (isalnum((unsigned char)c) || c == '_') start--;
+        else break;
+    }
+    if (start == len) return;                        /* nothing to complete */
+    if (isdigit((unsigned char)line[start])) return; /* a number literal */
+
+    const char *prefix = line + start;
+    size_t plen = len - start;
+
+    const char *cands[REPL_MAX_CANDIDATES];
+    int n = 0;
+    replCollectFromMap(cc->global_env, prefix, plen, cands, &n);
+    /* Asm-bound functions (MAlloc, Free, ... - `_extern _NAME` in
+     * tos.HH) live in their own map, not global_env. */
+    replCollectFromMap(cc->asm_funcs, prefix, plen, cands, &n);
+    replCollectFromMap(cc->clsdefs, prefix, plen, cands, &n);
+    replCollectFromMap(cc->uniondefs, prefix, plen, cands, &n);
+    replCollectFromMap(cc->symbol_table, prefix, plen, cands, &n);
+    replCollectFromMap(cc->macro_defs, prefix, plen, cands, &n);
+    if (n == 0) return;
+
+    qsort(cands, n, sizeof(cands[0]), replCandidateCmp);
+
+    char buf[1024];
+    for (int i = 0; i < n; ++i) {
+        if (i > 0 && strcmp(cands[i], cands[i-1]) == 0) continue; /* dedup */
+        snprintf(buf, sizeof(buf), "%.*s%s", (int)start, line, cands[i]);
+        linenoiseAddCompletion(lc, buf);
+    }
+}
+
+/* ---------------- input reading ---------------- */
+
+typedef struct ReplScan {
+    int depth;      /* net paren/bracket/brace nesting */
+    int open;      /* inside a string, char const or block comment */
+    int pp_depth;   /* net #if* / #endif nesting */
+} ReplScan;
+
+/* Nesting scan that ignores delimiters inside strings, char consts
+ * (HolyC allows multi-char 'ab'), // and block comments. Also counts
+ * preprocessor conditional nesting (#if / #ifdef / #ifndef / #ifjit /
+ * #ifaot vs #endif) so a multi-line conditional block is held open and
+ * submitted as ONE input - split across inputs each fresh parse gets a
+ * fresh lexer and the skip/collect state is lost. */
+static void replScan(const char *s, size_t len, ReplScan *out) {
+    int depth = 0;
+    int pp_depth = 0;
+    enum { CODE, STR, CHR, LINE_COMMENT, BLOCK_COMMENT } st = CODE;
+    for (size_t i = 0; i < len; ++i) {
+        char c = s[i];
+        switch (st) {
+            case STR:
+                if (c == '\\') { if (i + 1 < len) i++; }
+                else if (c == '"') st = CODE;
+                break;
+            case CHR:
+                if (c == '\\') { if (i + 1 < len) i++; }
+                else if (c == '\'') st = CODE;
+                break;
+            case LINE_COMMENT:
+                if (c == '\n') st = CODE;
+                break;
+            case BLOCK_COMMENT:
+                if (c == '*' && i + 1 < len && s[i+1] == '/') { i++; st = CODE; }
+                break;
+            case CODE:
+                if (c == '"') st = STR;
+                else if (c == '\'') st = CHR;
+                else if (c == '/' && i + 1 < len && s[i+1] == '/') { i++; st = LINE_COMMENT; }
+                else if (c == '/' && i + 1 < len && s[i+1] == '*') { i++; st = BLOCK_COMMENT; }
+                else if (c == '(' || c == '[' || c == '{') depth++;
+                else if (c == ')' || c == ']' || c == '}') depth--;
+                else if (c == '#') {
+                    size_t j = i + 1;
+                    while (j < len && (s[j] == ' ' || s[j] == '\t')) j++;
+                    size_t k = j;
+                    while (k < len && isalpha((unsigned char)s[k])) k++;
+                    /* "if" prefix covers if/ifdef/ifndef/ifjit/ifaot;
+                     * #include starts "in" so it doesn't match. */
+                    if (k - j >= 2 && s[j] == 'i' && s[j+1] == 'f') {
+                        pp_depth++;
+                    } else if (k - j == 5 && !strncmp(s + j, "endif", 5)) {
+                        pp_depth--;
+                    }
+                }
+                break;
+        }
+    }
+    out->depth = depth;
+    out->open = (st == STR || st == CHR || st == BLOCK_COMMENT);
+    out->pp_depth = pp_depth;
+}
+
+static int replLineIsBlank(const char *s) {
+    for (; *s; ++s) {
+        if (!isspace((unsigned char)*s)) return 0;
+    }
+    return 1;
+}
+
+/* Last non-whitespace char of the buffer, or '\0' if it's all space. */
+static char replLastChar(AoStr *buf) {
+    for (s64 i = (s64)buf->len - 1; i >= 0; --i) {
+        if (!isspace((unsigned char)buf->data[i])) return buf->data[i];
+    }
+    return '\0';
+}
+
+static char replFirstChar(AoStr *buf) {
+    for (u64 i = 0; i < buf->len; ++i) {
+        if (!isspace((unsigned char)buf->data[i])) return buf->data[i];
+    }
+    return '\0';
+}
+
+static int replStartsWithShellEscape(AoStr *buf) {
+    return buf->len >= 3 && buf->data[0] == '@' && buf->data[1] == ' ';
+}
+
+/* ---------------- live syntax highlighting & hints ----------------
+ *
+ * The vendored linenoise is used as-is; it has no display hooks. What
+ * it does have is the multiplexed editing API, which exposes the whole
+ * edit state (buffer, cursor, columns). So we drive the feed loop
+ * ourselves and, after every keystroke, repaint the line over the one
+ * linenoise just drew - same glyphs in the same cells, plus zero-width
+ * SGR colour codes, so the cursor maths of both renderers agree. */
+
+#define C_KEYWORD "\x1b[1;35m"  /* control keywords - bold magenta  */
+#define C_TYPE    "\x1b[33m"    /* built-in + class types - yellow  */
+#define C_STRING  "\x1b[32m"    /* strings / char consts - green    */
+#define C_NUMBER  "\x1b[36m"    /* numeric literals - cyan          */
+#define C_COMMENT "\x1b[90m"    /* comments + hints - bright black  */
+#define C_RESET   "\x1b[0m"
+
+static int repl_use_colour = 0;
+
+/* Control keywords, mirroring lexer.c's lexer_types[] (the type
+ * keywords are looked up live in cc->symbol_table instead). */
+static const char *repl_keywords[] = {
+    "auto", "_extern", "extern", "asm", "switch", "case", "break",
+    "continue", "while", "do", "for", "goto", "default", "return",
+    "try", "catch", "throw", "reg", "noreg", "if", "else", "sizeof",
+    "alignof", "typeof", "inline", "atomic", "volatile", "public", "private",
+    "class", "union", "static",
+};
+
+static int replIsKeyword(const char *s, size_t len) {
+    for (size_t i = 0; i < sizeof(repl_keywords)/sizeof(repl_keywords[0]); ++i) {
+        if (strlen(repl_keywords[i]) == len &&
+            memcmp(repl_keywords[i], s, len) == 0) return 1;
+    }
+    return 0;
+}
+
+/* Built-in type keywords (I64, U0, ...) and user-defined classes and
+ * unions - both live on the persistent Cctrl. */
+static int replIsTypeName(Cctrl *cc, char *s, size_t len) {
+    if (mapGetLen(cc->symbol_table, s, len)) return 1;
+    if (mapGetLen(cc->clsdefs, s, len)) return 1;
+    if (mapGetLen(cc->uniondefs, s, len)) return 1;
+    return 0;
+}
+
+static int replIsRecognisedConstant(Cctrl *cc, char *s, size_t len) {
+    if (mapGetLen(cc->macro_defs, s, len)) return 1;
+    return 0;
+}
+
+static int replIsIdentChar(char c) {
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+/* Append `s` colourised into `out`. Same token classes the lexer sees:
+ * strings, char consts, comments, numbers, identifiers (split into
+ * keyword / type / plain), `#directives`. */
+static void replColourise(Cctrl *cc, char *s, size_t len, AoStr *out) {
+    size_t i = 0;
+
+    /* A leading #directive is keyword-coloured as one token. */
+    while (i < len && isspace((unsigned char)s[i])) i++;
+    if (i < len && s[i] == '#') {
+        size_t end = i + 1;
+        while (end < len && replIsIdentChar(s[end])) end++;
+        aoStrCatLen(out, s, i);
+        aoStrCatLen(out, C_KEYWORD, strlen(C_KEYWORD));
+        aoStrCatLen(out, s + i, end - i);
+        aoStrCatLen(out, C_RESET, strlen(C_RESET));
+        i = end;
+    } else {
+        i = 0;
+    }
+
+    while (i < len) {
+        char c = s[i];
+        if (c == '"' || c == '\'') {
+            char quote = c;
+            size_t end = i + 1;
+            while (end < len) {
+                if (s[end] == '\\' && end + 1 < len) end += 2;
+                else if (s[end] == quote) { end++; break; }
+                else end++;
+            }
+            aoStrCatLen(out, C_STRING, strlen(C_STRING));
+            aoStrCatLen(out, s + i, end - i);
+            aoStrCatLen(out, C_RESET, strlen(C_RESET));
+            i = end;
+        } else if (c == '/' && i + 1 < len &&
+                   (s[i+1] == '/' || s[i+1] == '*')) {
+            size_t end;
+            if (s[i+1] == '/') {
+                end = len;
+            } else {
+                end = i + 2;
+                while (end + 1 < len &&
+                       !(s[end] == '*' && s[end+1] == '/')) end++;
+                end = (end + 1 < len) ? end + 2 : len;
+            }
+            aoStrCatLen(out, C_COMMENT, strlen(C_COMMENT));
+            aoStrCatLen(out, s + i, end - i);
+            aoStrCatLen(out, C_RESET, strlen(C_RESET));
+            i = end;
+        } else if (isdigit((unsigned char)c)) {
+            size_t end = i + 1;
+            while (end < len &&
+                   (isalnum((unsigned char)s[end]) || s[end] == '.')) end++;
+            aoStrCatLen(out, C_NUMBER, strlen(C_NUMBER));
+            aoStrCatLen(out, s + i, end - i);
+            aoStrCatLen(out, C_RESET, strlen(C_RESET));
+            i = end;
+        } else if (replIsIdentChar(c) && !isdigit((unsigned char)c)) {
+            size_t end = i + 1;
+            while (end < len && replIsIdentChar(s[end])) end++;
+            const char *colour = NULL;
+            if      (replIsKeyword(s + i, end - i)) colour = C_KEYWORD;
+            else if (replIsRecognisedConstant(cc, s + i, end - i)) colour = C_NUMBER;
+            else if (replIsTypeName(cc, s + i, end - i)) colour = C_TYPE;
+            if (colour) {
+                aoStrCatLen(out, colour, strlen(colour));
+                aoStrCatLen(out, s + i, end - i);
+                aoStrCatLen(out, C_RESET, strlen(C_RESET));
+            } else {
+                aoStrCatLen(out, s + i, end - i);
+            }
+            i = end;
+        } else {
+            aoStrPutChar(out, c);
+            i++;
+        }
+    }
+}
+
+/* If the line ends in the full name of a known function (and the `(`
+ * hasn't been typed yet), return its parameter list - "(I64 x, ...)" -
+ * to paint as a grey hint after the cursor. Cached per function name:
+ * this runs on every keystroke and astTypeToString allocates. */
+static const char *replHintFor(Cctrl *cc, const char *buf, size_t len) {
+    static char cached_fn[128];
+    static AoStr *cached_hint = NULL;
+
+    size_t start = len;
+    while (start > 0 && replIsIdentChar(buf[start-1])) start--;
+    size_t ilen = len - start;
+    if (ilen == 0 || ilen >= sizeof(cached_fn)) return NULL;
+    if (isdigit((unsigned char)buf[start])) return NULL;
+
+    if (strncmp(cached_fn, buf + start, ilen) != 0 ||
+        cached_fn[ilen] != '\0')
+    {
+        snprintf(cached_fn, sizeof(cached_fn), "%.*s", (int)ilen,
+                 buf + start);
+        if (cached_hint) aoStrRelease(cached_hint);
+        cached_hint = NULL;
+
+        Ast *fn = (Ast *)mapGetLen(cc->global_env, (char *)buf + start, ilen);
+        if (fn == NULL) fn = (Ast *)mapGetLen(cc->asm_funcs,
+                                              (char *)buf + start, ilen);
+        if (fn == NULL || fn->params == NULL) return NULL;
+        if (fn->kind != AST_FUNC && fn->kind != AST_FUN_PROTO &&
+            fn->kind != AST_EXTERN_FUNC && fn->kind != AST_ASM_FUNC_BIND)
+        {
+            return NULL;
+        }
+
+        AoStr *h = aoStrNew();
+        aoStrPutChar(h, '(');
+        for (u64 i = 0; i < fn->params->size; ++i) {
+            Ast *p = vecGet(Ast *, fn->params, i);
+            if (i > 0) aoStrCatLen(h, ", ", 2);
+            if (p == NULL) continue;
+            if (p->kind == AST_VAR_ARGS) {
+                aoStrCatLen(h, "...", 3);
+                continue;
+            }
+            Ast *var = (p->kind == AST_DEFAULT_PARAM) ? p->declvar : p;
+            int glue = 0; /* type already ends in `*` (or a space) */
+            if (var && var->type) {
+                char *t = astTypeToString(var->type);
+                size_t tlen = strlen(t);
+                aoStrCatPrintf(h, "%s", t);
+                glue = tlen > 0 && (t[tlen-1] == '*' || t[tlen-1] == ' ');
+            }
+            if (var && var->lname) {
+                aoStrCatPrintf(h, glue ? "%s" : " %s", var->lname->data);
+            }
+            if (p->kind == AST_DEFAULT_PARAM) aoStrCatLen(h, "=..", 3);
+        }
+        aoStrPutChar(h, ')');
+        cached_hint = h;
+    }
+    return cached_hint ? cached_hint->data : NULL;
+}
+
+/* Repaint the line linenoise just drew, with colours (and optionally
+ * the grey signature hint). Zero-width SGR codes only, so the glyphs
+ * land in exactly the cells linenoise put them in - no flicker, and
+ * its cursor arithmetic stays valid. Bail out whenever our simple
+ * one-row ASCII model doesn't hold (completion menu cycling, lines
+ * that wrap, UTF-8) - the plain rendering underneath is still correct. */
+static void replOverdraw(struct linenoiseState *ls, int with_hint) {
+    if (!repl_use_colour || repl_cc == NULL) return;
+    if (ls->in_completion) return;
+    if (ls->plen + ls->len >= ls->cols) return;
+    for (size_t i = 0; i < ls->len; ++i) {
+        if ((unsigned char)ls->buf[i] >= 0x80) return;
+    }
+
+    AoStr *out = aoStrNew();
+    aoStrPutChar(out, '\r');
+    aoStrCatLen(out, ls->prompt, ls->plen);
+    replColourise(repl_cc, ls->buf, ls->len, out);
+    if (with_hint) {
+        const char *hint = replHintFor(repl_cc, ls->buf, ls->len);
+        if (hint &&
+            ls->plen + ls->len + strlen(hint) < ls->cols) {
+            aoStrCatLen(out, C_COMMENT, strlen(C_COMMENT));
+            aoStrCatLen(out, hint, strlen(hint));
+            aoStrCatLen(out, C_RESET, strlen(C_RESET));
+        }
+    }
+    aoStrCatLen(out, "\x1b[0K", 4);
+    aoStrCatPrintf(out, "\r\x1b[%dC", (int)(ls->plen + ls->pos));
+    if (write(ls->ofd, out->data, out->len) == -1) { /* not fatal */ }
+    aoStrRelease(out);
+}
+
+/* TERM values linenoise's blocking API refuses to do escapes on; its
+ * multiplexed API skips that check, so mirror it here and fall back
+ * to the (already dumb-terminal-safe) blocking call. */
+static int replDumbTerm(void) {
+    static const char *unsupported[] = {"dumb", "cons25", "emacs"};
+    char *term = getenv("TERM");
+    if (term == NULL) return 0;
+    for (size_t i = 0; i < sizeof(unsupported)/sizeof(unsupported[0]); ++i) {
+        if (strcasecmp(term, unsupported[i]) == 0) return 1;
+    }
+    return 0;
+}
+
+/* Blocking line edit with live highlighting: linenoiseBlockingEdit's
+ * feed loop with a colour repaint after every keystroke. The final
+ * repaint before Enter drops the hint so no grey text is left behind
+ * in scrollback. */
+static char *replLinenoiseEdit(const char *prompt) {
+    if (replDumbTerm()) return linenoise(prompt);
+
+    struct linenoiseState ls;
+    char *buf = (char *)malloc(4096);
+    if (buf == NULL) return linenoise(prompt);
+
+    if (linenoiseEditStart(&ls, -1, -1, buf, 4096, prompt) == -1) {
+        free(buf);
+        return linenoise(prompt);
+    }
+    ls.buflen_max = 1024 * 1024; /* let big pastes grow it, as stock does */
+
+    char *res;
+    while ((res = linenoiseEditFeed(&ls)) == linenoiseEditMore) {
+        replOverdraw(&ls, 1);
+    }
+    if (res != NULL) replOverdraw(&ls, 0);
+    linenoiseEditStop(&ls);
+    free(ls.buf);
+    return res;
+}
+
+/* Fetch one physical line. Interactive lines come from linenoise
+ * (editing, history, tab completion); piped input stays on plain
+ * stdio so scripted use is deterministic. Returns a heap line WITHOUT
+ * its trailing newline, or NULL on EOF. `*cancelled` is set when the
+ * user pressed Ctrl-C (interactive only). */
+static char *replGetLine(int interactive, const char *prompt,
+                         int *cancelled) {
+    *cancelled = 0;
+    if (interactive) {
+        errno = 0;
+        char *line = replLinenoiseEdit(prompt);
+        if (line == NULL && errno == EAGAIN) *cancelled = 1; /* Ctrl-C */
+        return line;
+    }
+    char chunk[4096];
+    AoStr *acc = aoStrNew();
+    for (;;) {
+        if (fgets(chunk, sizeof(chunk), stdin) == NULL) {
+            if (acc->len == 0) {
+                aoStrRelease(acc);
+                return NULL;
+            }
+            break;
+        }
+        aoStrCatLen(acc, chunk, strlen(chunk));
+        if (acc->data[acc->len - 1] == '\n') {
+            acc->data[--acc->len] = '\0';
+            break;
+        }
+    }
+    /* Copy out of the AoStr pool: the caller frees with free(), the
+     * same way it frees a linenoise() line. */
+    char *line = (char *)malloc(acc->len + 1);
+    memcpy(line, acc->data, acc->len + 1);
+    aoStrRelease(acc);
+    return line;
+}
+
+/* Accumulate lines until the input forms a submittable unit:
+ *   - balanced and ending in `;` or `}`        -> submit
+ *   - a single-line `#directive`               -> submit
+ *   - balanced and the user enters a blank line -> submit (a `;` is
+ *     appended if missing, so `2+2` <enter> <enter> evaluates)
+ * Ctrl-C drops whatever is pending and re-prompts. Returns NULL on
+ * EOF with nothing buffered. */
+static AoStr *replReadInput(int interactive) {
+    AoStr *buf = aoStrNew();
+
+    for (;;) {
+        const char *prompt = buf->len == 0 ? repl_prompt : repl_prompt_cont;
+        int cancelled = 0;
+        char *line = replGetLine(interactive, prompt, &cancelled);
+        if (line == NULL) {
+            if (cancelled) {
+                buf->len = 0;
+                buf->data[0] = '\0';
+                continue;
+            }
+            if (buf->len == 0 || replLineIsBlank(buf->data)) {
+                aoStrRelease(buf);
+                return NULL;
+            }
+            if (interactive) fputc('\n', stdout);
+            break;
+        }
+
+        int blank = replLineIsBlank(line);
+        if (interactive && !blank) {
+            linenoiseHistoryAdd(line);
+            if (repl_history_path[0] != '\0') {
+                linenoiseHistorySave(repl_history_path);
+            }
+        }
+        aoStrCatLen(buf, line, strlen(line));
+        aoStrPutChar(buf, '\n');
+        free(line);
+
+        if (replLineIsBlank(buf->data)) {
+            /* Nothing typed yet - stay on the primary prompt. */
+            buf->len = 0;
+            buf->data[0] = '\0';
+            continue;
+        }
+
+        ReplScan sc;
+        replScan(buf->data, buf->len, &sc);
+        if (sc.depth > 0 || sc.open || sc.pp_depth > 0) continue;
+
+        char last = replLastChar(buf);
+        if (replFirstChar(buf) == '#') {
+            /* Preprocessor directive: newline-terminated (unless the
+             * line is continued with a trailing backslash). */
+            s64 i = (s64)buf->len - 1;
+            while (i >= 0 && isspace((unsigned char)buf->data[i])) i--;
+            if (i >= 0 && buf->data[i] == '\\') continue;
+            break;
+        } else if (replStartsWithShellEscape(buf)) {
+            break;
+        }
+        if (last == ';' || last == '}') break;
+        if (blank) {
+            /* Balanced but unterminated and the user hit enter on an
+             * empty line: terminate it for them. */
+            aoStrPutChar(buf, ';');
+            break;
+        }
+    }
+    return buf;
+}
+
+/* ---------------- result echo ---------------- */
+
+/* Can (and should) the value of `ast` be returned from the wrapper
+ * and echoed? Statements and aggregate-typed values can't: aggregates
+ * would need the struct-return ABI dance for no display benefit. */
+static int replIsEchoable(Ast *ast) {
+    if (!ast || !ast->type) return 0;
+    /* Assignments and increments are mutations, not queries - echoing
+     * the stored value back (`x = 5;` printing 5, `I64 x = 5;`
+     * printing 0) reads as noise. Ask for the variable (`x;`) to see
+     * it. Compound assigns (`x += 2`) desugar to plain ASSIGN, so
+     * this covers them too. */
+    if (ast->kind == AST_BINOP && ast->binop == AST_BIN_OP_ASSIGN) return 0;
+    if (ast->kind == AST_UNOP &&
+        (ast->unop == AST_UN_OP_POST_INC || ast->unop == AST_UN_OP_POST_DEC ||
+         ast->unop == AST_UN_OP_PRE_INC  || ast->unop == AST_UN_OP_PRE_DEC))
+    {
+        return 0;
+    }
+    /* Direct calls to the print family already put their output on
+     * stdout; echoing the returned byte count after it is just
+     * confusing ("hi" followed by a mysterious 3). */
+    if (ast->kind == AST_FUNCALL && ast->fname) {
+        static const char *no_echo[] = {"printf"};
+        for (size_t i = 0; i < sizeof(no_echo)/sizeof(no_echo[0]); ++i) {
+            if (strlen(no_echo[i]) == (size_t)ast->fname->len &&
+                memcmp(no_echo[i], ast->fname->data, ast->fname->len) == 0)
+            {
+                return 0;
+            }
+        }
+    }
+    switch (ast->type->kind) {
+        case AST_TYPE_INT:
+        case AST_TYPE_CHAR:
+        case AST_TYPE_FLOAT:
+        case AST_TYPE_POINTER:
+        case AST_TYPE_FUNC:
+            break;
+        case AST_TYPE_ARRAY:
+            /* A string literal's value is just its label address, so
+             * it echoes fine as U8* (with the string preview) - e.g.
+             * a floating `typeof(x);`. Other aggregates would need
+             * the struct-return ABI dance. */
+            if (ast->kind == AST_STRING) break;
+            return 0;
+        default:
+            return 0;
+    }
+    switch (ast->kind) {
+        case AST_IF: case AST_FOR: case AST_WHILE: case AST_DO_WHILE:
+        case AST_SWITCH: case AST_CASE: case AST_DEFAULT: case AST_JUMP:
+        case AST_GOTO: case AST_LABEL: case AST_BREAK: case AST_CONTINUE:
+        case AST_RETURN: case AST_COMPOUND_STMT: case AST_DECL:
+        case AST_ASM_STMT: case AST_TRY: case AST_THROW: case AST_COMMENT:
+        case AST_PLACEHOLDER:
+            return 0;
+        default:
+            return 1;
+    }
+}
+
+static void replPrintInt(AstType *type, s64 val) {
+    if (type->kind == AST_TYPE_POINTER || type->kind == AST_TYPE_FUNC) {
+        printf("0x%llx", (unsigned long long)val);
+        /* A pointer to a 1-byte int is HolyC's string type (U8 *) -
+         * show a preview. This trusts the pointer the user's own code
+         * just returned. */
+        AstType *pt = type->ptr;
+        if (val && pt && pt->size == 1 &&
+            (pt->kind == AST_TYPE_CHAR || pt->kind == AST_TYPE_INT))
+        {
+            printf(" \"%.256s\"", (const char *)(uintptr_t)val);
+        }
+        putchar('\n');
+        return;
+    }
+    if (type->issigned) printf("%lld\n", (long long)val);
+    else                printf("%llu\n", (unsigned long long)val);
+}
+
+/* ---------------- per-round pipeline ---------------- */
+
+typedef union ReplEntry {
+    void *obj;
+    s64 (*ifn)(void);
+    double (*ffn)(void);
+} ReplEntry;
+
+/* Steal this round's top-level statements off the Cctrl (handing it
+ * fresh lists) and wrap them into `__repl_<round>`. If the trailing
+ * statement is an echoable expression it becomes the return value;
+ * `*echo_type` is set to the type to print with (NULL = no echo).
+ * Returns NULL when there were no statements this round. */
+static Ast *replBuildWrapper(Cctrl *cc, int round, AstType **echo_type) {
+    *echo_type = NULL;
+    if (listEmpty(cc->initalisers)) return NULL;
+
+    List *stmts = cc->initalisers;
+    List *locals = cc->initaliser_locals;
+    cc->initalisers = listNew();
+    cc->initaliser_locals = listNew();
+
+    AstType *rettype;
+    Ast *last = (Ast *)stmts->prev->value;
+    if (replIsEchoable(last)) {
+        /* Return through I64/U64/F64 so the host-side caller only has
+         * to deal with two machine-level signatures; the IR's return
+         * conversion widens smaller ints/floats. Pointers keep their
+         * type so the echo can show a string preview. */
+        if (astIsFloatType(last->type)) {
+            rettype = ast_float_type;
+        } else if (last->kind == AST_STRING) {
+            /* String literal: return the label address as U8* so the
+             * echo shows the string preview. */
+            rettype = astMakePointerType(ast_u8_type);
+        } else if (last->type->kind == AST_TYPE_POINTER ||
+                   last->type->kind == AST_TYPE_FUNC) {
+            rettype = last->type;
+        } else {
+            rettype = last->type->issigned ? ast_int_type : ast_uint_type;
+        }
+        stmts->prev->value = astReturn(last, rettype);
+        *echo_type = rettype;
+    } else {
+        rettype = ast_int_type;
+        listAppend(stmts, astReturn(astI64Type(0), rettype));
+    }
+
+    char name[32];
+    int len = snprintf(name, sizeof(name), "__repl_%d", round);
+    Ast *body = astCompountStatement(stmts);
+    Vec *params = astVecNew();
+    AstType *fn_type = astMakeFunctionType(rettype, params);
+    return astFunction(fn_type, name, len, params, body, locals, 0);
+}
+
+/* Drop statements a failed round left behind so they don't run as a
+ * prelude to the next input. */
+static void replDropInitialisers(Cctrl *cc) {
+    if (!listEmpty(cc->initalisers)) {
+        listRelease(cc->initalisers, NULL);
+        cc->initalisers = listNew();
+    }
+    if (!listEmpty(cc->initaliser_locals)) {
+        listRelease(cc->initaliser_locals, NULL);
+        cc->initaliser_locals = listNew();
+    }
+}
+
+/* Parse one buffer into the shared Cctrl. Returns the number of
+ * errors (diagnostics already printed). */
+static int replParse(Cctrl *cc, char *root_dir, char *name, AoStr *src) {
+    Lexer *l = (Lexer *)malloc(sizeof(Lexer));
+    lexInit(l, NULL, CCF_PRE_PROC);
+    lexSetBuiltinRoot(l, root_dir);
+    lexPushString(l, name, src->data, src->len);
+
+    cctrlDiagClear(cc);
+    cctrlResetTokenBuffer(cc);
+
+    /* cctrlInitParse prefills the token ring buffer, which lexes the
+     * input before parseToAst has installed its recovery point. Catch
+     * lex-time raises (e.g. an over-long char const) here so a bad
+     * literal errors like any other diagnostic instead of exiting
+     * the REPL. */
+    jmp_buf lex_recovery;
+    jmp_buf *prev_recovery = cc->current_recovery;
+    cc->current_recovery = &lex_recovery;
+    if (setjmp(lex_recovery) == 0) {
+        cctrlInitParse(cc, l);
+        parseToAst(cc);
+    }
+    cc->current_recovery = prev_recovery;
+
+    int errors = cctrlDiagFlush(cc);
+    cctrlDiagClear(cc);
+    lexerRelease(l);
+    return errors;
+}
+
+static AoStr *replGetRcPath(void) {
+    char *home = getenv("HOME");
+    AoStr *hcc_rc = NULL;
+    if (home) {
+        hcc_rc = aoStrPrintf("%s/.hcc_rc.HC", home);
+        if (access(hcc_rc->data, R_OK) != 0) {
+            aoStrRelease(hcc_rc);
+            hcc_rc = NULL;
+        }
+    }
+    return hcc_rc;
+}
+
+/* Warm-up: parse the builtin stdlib header (prototypes, classes,
+ * #defines for libtos, whose implementations the JIT dlopens) and
+ * compile whatever it defines as chunk 0. */
+static void replBootstrap(Cctrl *cc, HccJit *jit, CliArgs *args,
+                          char *root_dir) {
+    AoStr *builtin = aoStrPrintf("%s/include/tos.HH", args->install_dir);
+    if (access(builtin->data, R_OK) != 0) {
+        fprintf(stderr,
+                "repl: warning: %s not found; the HolyC standard library "
+                "will be unavailable\n", builtin->data);
+        aoStrRelease(builtin);
+        builtin = NULL;
+    }
+    
+    AoStr *hcc_rc = replGetRcPath();
+
+    /* We have nothing to preload */
+    if (!builtin && !hcc_rc)
+        return;
+
+    Lexer *l = (Lexer *)malloc(sizeof(Lexer));
+    lexInit(l, NULL, CCF_PRE_PROC);
+    lexSetBuiltinRoot(l, root_dir);
+
+    if (hcc_rc)  lexPushFile(l, hcc_rc);
+    if (builtin) lexPushFile(l, builtin);
+
+    cctrlDiagClear(cc);
+    cctrlResetTokenBuffer(cc);
+    cctrlInitParse(cc, l);
+    parseToAst(cc);
+    if (cctrlDiagFlush(cc) > 0) {
+        fprintf(stderr, "repl: warning: errors in %s\n", builtin->data);
+    }
+    cctrlDiagClear(cc);
+    replDropInitialisers(cc);
+
+    if (hccJitCompileChunk(jit, NULL) != 0) {
+        fprintf(stderr, "repl: warning: failed to compile the standard "
+                "library header\n");
+    }
+    lexerRelease(l);
+}
+
+static void replExecInner(AoStr *input, int round) {
+    HccJit *jit = repl_jit;
+    if (input == NULL || *input->data == '\0' || jit == NULL) return;
+    Cctrl *cc = jit->cc;
+
+    if (replParse(cc, repl_root_dir, "<repl>", input) > 0) {
+        replDropInitialisers(cc);
+        return;
+    }
+
+    AstType *echo_type = NULL;
+    Ast *wrapper = replBuildWrapper(cc, round, &echo_type);
+
+    if (hccJitCompileChunk(jit, wrapper) != 0) {
+        /* Diagnostics (unresolved symbol etc.) already printed by
+         * the backend / finalizer. */
+        cctrlDiagFlush(cc);
+        cctrlDiagClear(cc);
+        return;
+    }
+
+    if (wrapper == NULL) return; /* only definitions this round */
+
+    ReplEntry entry;
+    entry.obj = hccJitLookup(jit, wrapper->fname->data);
+    if (entry.obj == NULL) {
+        fprintf(stderr, "repl: internal error: lost entry point %s\n",
+                wrapper->fname->data);
+        return;
+    }
+
+    if (echo_type && astIsFloatType(echo_type)) {
+        double r = entry.ffn();
+        printf("%g\n", r);
+    } else {
+        s64 r = entry.ifn();
+        if (echo_type)
+            replPrintInt(echo_type, r);
+    }
+    fflush(stdout);
+}
+
+/* Fault-guard around an eval. Nested evals (JIT'd code calling the
+ * ReplEval builtin re-enters here) stack: the outer jump point is
+ * saved and restored either way, so a fault always unwinds to the
+ * innermost live eval. sigsetjmp's savemask=1 restores the signal
+ * mask on the jump - without it the delivered signal would stay
+ * blocked and the second fault of a session would kill it. */
+static void replExec(AoStr *input, int round) {
+    sigjmp_buf saved_env;
+    sig_atomic_t saved_in_eval = repl_in_eval;
+    memcpy(&saved_env, &repl_fault_env, sizeof(sigjmp_buf));
+
+    if (sigsetjmp(repl_fault_env, 1) == 0) {
+        repl_in_eval = 1;
+        /* Rounds tag memsafe reports; ReplEval's INT_MAX isn't a real
+         * round, so drop it to "untagged". */
+        memsafeSetRound(round == INT_MAX ? 0 : round);
+        replExecInner(input, round);
+    } else {
+        replReportFault();
+    }
+    repl_in_eval = saved_in_eval;
+    memcpy(&repl_fault_env, &saved_env, sizeof(sigjmp_buf));
+}
+
+int replRun(Cctrl *cc, CliArgs *args) {
+    const HccJitBackend *backend = replHostBackend();
+    if (!backend) {
+        fprintf(stderr,
+                "hcc: -repl is not supported on this host architecture\n");
+        return 1;
+    }
+
+    cc->flags |= CCTRL_REPL;
+    /* Try and prevent the repl from crashing through common errors like
+     * passing mis-matching function argument types */
+    cc->flags |= CCTRL_WERROR;
+
+    HccJit *jit = hccJitNew(cc, backend);
+    if (!jit) return 1;
+    repl_jit = jit;
+
+    /* Builtin helper functions */
+    hccJitDefineSymbol(jit, "Uf", (void *)(uintptr_t)replBuiltinUf);
+    hccJitDefineSymbol(jit, "ReplDel", (void *)(uintptr_t)replBuiltinReplDel);
+    hccJitDefineSymbol(jit, "ReplReloadRc", (void *)(uintptr_t)replBuiltinReloadRc);
+    hccJitDefineSymbol(jit, "ReplListFn", (void *)(uintptr_t)replBuiltinListFn);
+    hccJitDefineSymbol(jit, "ReplListGVars", (void *)(uintptr_t)replBuiltinListGVars);
+    hccJitDefineSymbol(jit, "ReplClassRep", (void *)(uintptr_t)replBuiltinPrintClass);
+    hccJitDefineSymbol(jit, "ReplEval", (void *)(uintptr_t)replEvalString);
+    hccJitDefineSymbol(jit, "ReplHeap", (void *)(uintptr_t)replBuiltinReplHeap);
+    hccJitDefineSymbol(jit, "ReplFindFn", (void *)(uintptr_t)replBuiltinFindFn);
+
+    /* Tracking allocator (memsafe.c) - always on in the REPL, and
+     * registered before the bootstrap so the very first chunk already
+     * binds to it. */
+    memsafeInit(jit);
+
+    int interactive = isatty(STDIN_FILENO);
+    repl_root_dir = mprintf("%s/include/", args->install_dir);
+
+    replInstallFaultHandlers();
+
+    replBootstrap(cc, jit, args, repl_root_dir);
+
+    AoStr *protos = aoStrDupRaw((char *)repl_builtin_protos,
+                                sizeof(repl_builtin_protos) - 1);
+    if (replParse(cc, repl_root_dir, "<builtins>", protos) > 0) {
+        fprintf(stderr, "repl: warning: failed to parse builtin "
+                "prototypes\n");
+    }
+    replDropInitialisers(cc);
+
+    if (interactive) {
+        repl_cc = cc;
+        repl_use_colour = !replDumbTerm() && getenv("NO_COLOR") == NULL;
+        linenoiseSetMultiLine(1);
+        linenoiseSetCompletionCallback(replCompletion);
+        linenoiseHistorySetMaxLen(REPL_HISTORY_MAX);
+        const char *home = getenv("HOME");
+        if (home != NULL) {
+            snprintf(repl_history_path, sizeof(repl_history_path),
+                     "%s/.hcc_repl_history", home);
+            linenoiseHistoryLoad(repl_history_path);
+        }
+        if (!mapHas(cc->macro_defs, "HCC_REPL_NO_HELLO")) {
+            printf("hcc %s [%s]\n"
+                   "Statements run as typed; a trailing expression's value is "
+                   "echoed.\nTab completes, arrows browse history, Ctrl-D "
+                   "exits.\n",
+                   cctrlGetVersion(),
+                   cliTargetToString(cc->target));
+        }
+    }
+
+    int round = 0;
+    for (;;) {
+        AoStr *input = replReadInput(interactive);
+        if (input == NULL) break; /* EOF */
+
+        if (replStartsWithShellEscape(input)) {
+            char *cmd = input->data + strlen("@ ");
+            int retval = system(cmd);
+            printf("%d\n", retval);
+            aoStrRelease(input);
+            continue;
+        }
+
+        round++;
+        replExec(input, round);
+    }
+
+    hccJitFree(jit);
+    return 0;
+}

--- a/src/repl.h
+++ b/src/repl.h
@@ -1,0 +1,11 @@
+#ifndef REPL_H__
+#define REPL_H__
+
+#include "cctrl.h"
+#include "cli.h"
+
+/* Run the read-eval-print loop until EOF (Ctrl-D). Returns the
+ * process exit code. */
+int replRun(Cctrl *cc, CliArgs *args);
+
+#endif

--- a/src/syntax-highlighting/hc.vim
+++ b/src/syntax-highlighting/hc.vim
@@ -1,58 +1,182 @@
-set cindent
-set filetype=HC
-set syntax=c
+" Vim syntax file
+" Language:   HolyC (TempleOS / TempleOS-derived compilers)
+" Filename:   *.HC, *.HH
+" Note:       This is a *standalone* syntax definition. It deliberately does
+"             NOT inherit from the bundled C syntax. Every construct is
+"             defined here so HolyC keeps its own identity.
+"
+" Ordering matters: when a plain :syn-match and a :syn-region can start at the
+" same column, the item defined LAST wins. So the greedy single-character
+" operator/delimiter matches are defined first (lowest priority) and the
+" things that must beat them (comments, strings, numbers) come afterwards.
+" :syn-keyword items always outrank matches/regions regardless of order.
 
-syn keyword cTypeUnhighlighted bool char short int float double unsigned signed const void
+" ---------------------------------------------------------------------------
+" Buffer-local options for HolyC files
+" ---------------------------------------------------------------------------
+setlocal cindent
+setlocal tabstop=4 softtabstop=0 expandtab shiftwidth=2 smarttab
 
-syn keyword cType     _extern extern inline static U0 Bool I8 U8 I16 U16 I32 U32 I64 U64 F32 F64 auto atomic
-syn keyword cRepeat   while for do
-syn keyword cConstant NULL FALSE TRUE EXIT_FAIL EXIT_OK I64_MIN I64_MAX U64_MAX U8_MAX I8_MAX I8_MIN STDOUT STDERR __BUFSIZ__ STDIN
-syn keyword cOperator public private sizeof
-syn clear cStatement
-syn keyword cCast cast
-syn keyword cKeyword return continue break goto
-syn keyword cClass class
+" Keep the filetype as HC so the LSP / format keymaps still recognise it.
+if &filetype !=# "HC"
+  setlocal filetype=HC
+endif
 
-syn match cAsmKeyword "\<\asm\>"
-hi def link cAsmKeyword Keyword
-hi def link cKeyword Keyword
-hi def link cCast Statement
-hi def link cClass cTypedef
+" Don't rebuild the syntax if it is already in place for this buffer.
+if exists("b:current_syntax") && b:current_syntax ==# "hc"
+  finish
+endif
 
-" this is a bit iffy
-syntax region cAsm start="\<asm\>\s*{" end="}" contains=cAsmLabel,cAsmFunction,cAsmOp,cAsmCall,cAsmMath,cAsmKeyword,cComment,cCommentL,cNumbers
-syntax match cAsmLabel "@@\d\+" contained
-syntax match cAsmFunction /^\s*\(\w\+::\)/ contained
-syntax match cAsmOp "\<\(MOV\|PUSH\|POP\|LEA\|TEST\
-            \|CLD\|REP\|LOD\|STOSB\|DEC\|RET\|CMP\|INC\|SCASB\|XCHG\
-            \|CLI\|BT\|PAUSE\|JMP\|JZ\|JNZ\|JE\|JNE\|JB\|JBE\|JA\|JAE\)\S*\>" contained
-syntax match cAsmCall "\<\(CALL\)\S*\>" contained
-syntax match cAsmMath "\<\(ADD\|SUB\|XOR\|OR\|AND\|MUL\
-            \|NOT\|MOD\|DIV\|SHL\|SHR\)\S*\>" contained
+syntax clear
+syntax case match
 
-hi def link cAsmFunction Function
-hi def link cAsmLabel cOperator 
-hi def link cAsmOp cType
-hi def link cAsmMath cOperator
-hi def link cAsmCall cOperator 
+" ---------------------------------------------------------------------------
+" Operators & delimiters (lowest priority is defined first)
+" ---------------------------------------------------------------------------
+" syn match hcOperator  "[-+*/%=<>!~&|^?:]" " I'm not a fan so commented out
+" syn match hcDelimiter "[(){}\[\];,.]"     " I also don't particularly like
+                                            " coloured punctuation
 
-syntax region _HCString start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=HCStringEscape,HCStringFormat
+" ---------------------------------------------------------------------------
+" Numbers
+" ---------------------------------------------------------------------------
+syn match hcNumber /\<0[xX]\x\+\>/
+syn match hcNumber /\<0[bB][01]\+\>/
+syn match hcNumber /\<\d\+\%([uU]\=[lL]\{0,2}\)\>/
+syn match hcFloat  /\<\d\+\.\d*\%([eE][-+]\=\d\+\)\=\>/
+syn match hcFloat  /\<\d\+[eE][-+]\=\d\+\>/
+syn match hcFloat  /\.\d\+\%([eE][-+]\=\d\+\)\=\>/
 
-syntax match HCStringEscape /\\./ contained
-syntax match HCStringFormat /%\(\d\+\$\)\=[-+' #0*]*\(\d*\|\*\|\*\d\+\$\)\(\.\(\d*\|\*\|\*\d\+\$\)\)\=\([hlLjzt]\|ll\|hh\)\=\([aAbdiuoxXDOUfFeEgGcCsSpn]\|\[\^\=.[^]]*\]\)/ contained
-syntax match HCStringFormat /%%/ contained
-syntax match HCStringFormat /\\[nrvtb'\\]/ contained
-hi def link _HCString String
-hi def link HCStringFormat cFormat
+" ---------------------------------------------------------------------------
+" Strings & character constants
+" ---------------------------------------------------------------------------
+syn match  hcEscape /\\./ contained
+" printf-style conversion specifiers (with HolyC extras: b z q t)
+syn match  hcFormat /%\%(\d\+\$\)\=[-+' #0*]*\%(\d*\|\*\|\*\d\+\$\)\%(\.\%(\d*\|\*\|\*\d\+\$\)\)\=\%([hlLjzt]\|ll\|hh\)\=\%([aAbdiuoxXDOUfFeEgGcCsSpnqtz]\|\[\^\=.[^]]*\]\)/ contained
+syn match  hcFormat /%%/ contained
+" HolyC DolDoc command embedded in a string ($FG,2$ ... $FG$); literal $ is $$.
+syn match  hcDolDoc /\$[^$]*\$/ contained
 
-syn keyword cDefine elifdef
-hi def link cAnsiFunction cFunction
-hi def link cAnsiName cIdentifier
-syn keyword cDefined defined contained containedin=cDefine
-hi def link cDefined cDefine
-hi def link cUserFunction cFunction
-hi def link cFunction Function
-hi def link cIdentifier Identifier
-hi def link cDelimiter Delimiter
-hi def link cBraces Delimiter
-hi def link cBoolean Boolean
+syn region hcString    start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=hcEscape,hcFormat,hcDolDoc
+" HolyC character constants may pack up to 8 bytes: 'A', '\n', 'TEXT'
+syn match  hcCharacter "'\%(\\.\|[^'\\]\)\{1,8}'" contains=hcEscape
+
+" ---------------------------------------------------------------------------
+" Comments
+" ---------------------------------------------------------------------------
+syn keyword hcTodo            contained TODO FIXME XXX NOTE HACK BUG
+syn match   hcCommentAnnotation /@\w\+/ contained
+syn region  hcCommentLine     start="//" skip="\\$" end="$" keepend contains=hcTodo,hcCommentAnnotation,@Spell
+syn region  hcComment         start="/\*" end="\*/" contains=hcTodo,hcCommentAnnotation,@Spell
+
+" ---------------------------------------------------------------------------
+" Preprocessor / compiler directives
+" ---------------------------------------------------------------------------
+syn match   hcPreProc /^\s*#\s*\%(define\|undef\|ifdef\|ifndef\|ifaot\|ifjit\|if\|elifdef\|elif\|else\|endif\|exe\|help_index\|help_file\|assert\|error\|warning\|pragma\|import\|public\|extern\)\>/
+syn keyword hcPreProcDefined defined
+
+syn region	hcIncluded	display contained start=+"+ skip=+\\\\\|\\"+ end=+"+
+syn match	hcIncluded	display contained "<[^>]*>"
+syn match	hcInclude	display "^\s*\zs\%(%:\|#\)\s*include\>\s*["<]" contains=hcIncluded
+syn match	hcInclude	display "^\s*\zs\%(%:\|#\)\s*link\>\s*["<]" contains=hcIncluded
+
+" ---------------------------------------------------------------------------
+" Types & structures
+" ---------------------------------------------------------------------------
+syn keyword hcType      U0 Bool I8 U8 I16 U16 I32 U32 I64 U64 F32 F64 auto
+syn keyword hcStructure class union
+
+syntax match PascalType /\%(\( \|\t\|\n\|$\|<\|}\|(\)\{1}\)\@<=\<\u[[:alnum:]]*\>\( \|\t\|\n\|$\|>\)\%( \|=\|,\|!\|:\)\@!/ containedin=cStatement,cType,cStructure
+highlight def link PascalType Type
+
+" ---------------------------------------------------------------------------
+" Storage classes / qualifiers
+" ---------------------------------------------------------------------------
+syn keyword hcStorageClass extern _extern import _import public private static
+syn keyword hcStorageClass reg noreg interrupt haserrcode argpop noargpop
+syn keyword hcStorageClass nofink inline atomic lastclass
+
+" ---------------------------------------------------------------------------
+" Statements / keywords
+" ---------------------------------------------------------------------------
+syn keyword hcConditional if else switch case default start end
+syn keyword hcRepeat      while for do
+syn keyword hcStatement   return goto break continue
+syn keyword hcOperatorKw  sizeof alignof offset try catch throw
+" Note: `asm` is intentionally NOT a keyword here a keyword match at `asm`
+" would block the asm{} region below from ever starting. The region's
+" matchgroup highlights `asm {` instead.
+
+" ---------------------------------------------------------------------------
+" Constants
+" ---------------------------------------------------------------------------
+syn keyword hcBoolean  TRUE FALSE ON OFF
+syn keyword hcConstant NULL EXIT_FAILURE EXIT_SUCCESS EXIT_FAIL EXIT_OK
+syn keyword hcConstant I64_MIN I64_MAX I32_MIN I32_MAX I16_MIN I16_MAX
+syn keyword hcConstant I8_MIN I8_MAX U64_MAX U32_MAX U16_MAX U8_MAX
+syn keyword hcConstant STDIN STDOUT STDERR __BUFSIZ__
+
+" ---------------------------------------------------------------------------
+" Functions / scopes (matches outranked by the keywords above)
+" ---------------------------------------------------------------------------
+" An identifier immediately followed by '(' is a function (def or call).
+"syn match hcFunction /\<\h\w*\ze\s*(/
+" Member / scope resolution: Name::
+syn match hcScope    /\<\h\w*\ze::/
+
+" ---------------------------------------------------------------------------
+" Inline assembly: asm { ... }
+" ---------------------------------------------------------------------------
+syn region hcAsm matchgroup=hcLabelKw start="\<asm\>\s*{" end="}" contains=hcAsmLabel,hcAsmFunction,hcComment,hcCommentLine,hcNumber,hcString,hcCharacter
+syn match  hcAsmLabel    "@@\d\+" contained
+syn match  hcAsmFunction /^\s*\w\+::/ contained
+
+" ---------------------------------------------------------------------------
+" Highlight links
+" ---------------------------------------------------------------------------
+hi def link hcComment           Comment
+hi def link hcCommentLine       Comment
+hi def link hcTodo              Todo
+hi def link hcCommentAnnotation Todo
+
+hi def link hcPreProc           PreProc
+hi def link hcPreProcDefined    PreProc
+
+hi def link hcType              Type
+hi def link hcStructure         Structure
+hi def link hcStorageClass      StorageClass
+
+hi def link hcConditional       Conditional
+hi def link hcRepeat            Repeat
+hi def link hcStatement         Statement
+hi def link hcOperatorKw        Statement
+hi def link hcLabelKw           Keyword
+
+hi def link hcBoolean           Boolean
+hi def link hcConstant          Constant
+
+hi def link hcNumber            Number
+hi def link hcFloat             Float
+
+hi def link hcString            String
+hi def link hcCharacter         Character
+hi def link hcEscape            SpecialChar
+hi def link hcFormat            Special
+hi def link hcDolDoc            PreProc
+
+hi def link hcFunction          Function
+hi def link hcScope             Identifier
+
+hi def link hcOperator          Operator
+hi def link hcDelimiter         Delimiter
+
+hi def link hcAsm               Special
+hi def link hcAsmLabel          Label
+hi def link hcAsmFunction       Function
+
+hi def link hcInclude           Include
+hi def link hcIncluded          hcString
+
+
+
+let b:current_syntax = "hc"

--- a/src/tests/60_leaf_param_arith.HC
+++ b/src/tests/60_leaf_param_arith.HC
@@ -1,0 +1,77 @@
+#include "testhelper.HC"
+
+/* Leaf functions mixing constants with register-homed parameters.
+ *
+ * Regression for a store-forwarding bug: a leaf function's param arrives
+ * register-homed (x0/x1 on AArch64), and `irForwardStoreToReads` rewrote a
+ * read of its spill slot into the arrive value even in the r2 operand
+ * position - but codegen materialises r1 into scratch x0 FIRST, so
+ * `I64 D(I64 x){ return 10/x; }` emitted `mov x0,#10` over the param and
+ * computed 10/10 == 1 for every input (same for +,-,*,%). The fix refuses
+ * forwarding a scratch-homed source into positions the consumer's own
+ * operand loading clobbers (r2, STORE_DEREF/RMW_DEREF value, phi pairs).
+ * Wrong in BOTH AOT and JIT; x86_64 was immune (arg regs don't overlap
+ * scratch). */
+
+I64 DivConstLeft(I64 x)  { return 10 / x; }
+I64 AddConstLeft(I64 x)  { return 10 + x; }
+I64 SubConstLeft(I64 x)  { return 10 - x; }
+I64 MulConstLeft(I64 x)  { return 10 * x; }
+I64 RemConstLeft(I64 x)  { return 17 % x; }
+I64 DivConstRight(I64 x) { return x / 3; }
+I64 SelfDiv(I64 x)       { return x / x; }
+I64 SelfAdd(I64 x)       { return x + x; }
+
+I64 Sub2(I64 a, I64 b)    { return b - a; }
+I64 Sub2Rev(I64 a, I64 b) { return a - b; }
+I64 Div2(I64 a, I64 b)    { return b / a; }
+I64 Mix3(I64 a, I64 b, I64 c) { return a + 10 * b - c; }
+
+F64 FDivConstLeft(F64 x) { return 10.0 / x; }
+F64 FSub2(F64 a, F64 b)  { return b - a; }
+
+U0 StoreThrough(I64 a, I64 x, I64 *p) { *p = x; }
+
+Bool ConstLeftOps()
+{
+  return DivConstLeft(2) == 5  && AddConstLeft(7) == 17 &&
+         SubConstLeft(4) == 6  && MulConstLeft(4) == 40 &&
+         RemConstLeft(5) == 2;
+}
+
+Bool ParamOnBothSides()
+{
+  return DivConstRight(21) == 7 && SelfDiv(9) == 1 && SelfAdd(21) == 42;
+}
+
+Bool TwoAndThreeParams()
+{
+  return Sub2(3, 10) == 7 && Sub2Rev(10, 3) == 7 && Div2(5, 30) == 6 &&
+         Mix3(1, 2, 3) == 18;
+}
+
+Bool FloatLeafParams()
+{
+  return FDivConstLeft(4.0) == 2.5 && FSub2(1.5, 4.0) == 2.5;
+}
+
+Bool PointerStoreParam()
+{
+  I64 v = 0;
+  StoreThrough(1, 42, &v);
+  return v == 42;
+}
+
+I32 Main()
+{
+  "Test - leaf fns mixing constants with register-homed params:\n";
+  I64 tests = 5, correct = 0;
+  if (ConstLeftOps())       correct++;
+  if (ParamOnBothSides())   correct++;
+  if (TwoAndThreeParams())  correct++;
+  if (FloatLeafParams())    correct++;
+  if (PointerStoreParam())  correct++;
+  PrintResult(correct, tests);
+  "====\n";
+  return 0;
+}

--- a/src/tests/60_link.HC
+++ b/src/tests/60_link.HC
@@ -1,0 +1,44 @@
+"Test - #link directive (AOT): ";
+#include "testhelper.HC"
+
+/* Two-stage test: build a small C shared library, then compile a
+ * second HolyC program whose only route to that library is a
+ * `#link "<path>"` directive (no .so on the hcc command line).
+ * The name form is exercised with `#link <m>` (libm exists on both
+ * macOS and Linux). */
+
+I64 correct = 0;
+I64 tests = 3;
+
+/* No quotes or `%` in the C source keeps the shell printf simple. */
+if (System("printf 'long HccLinkTestValue(void) { return 42; }' "
+           "> /tmp/hcc-60-link.c && "
+           "cc -shared -fPIC /tmp/hcc-60-link.c -o /tmp/hcc-60-link.so") == 0) {
+  correct++;
+}
+
+System("printf '#link \"/tmp/hcc-60-link.so\"\n"
+       "extern \"c\" I64 HccLinkTestValue();\n"
+       "I32 Main() { if (HccLinkTestValue() == 42) return 0; return 1; }\n'"
+       " > /tmp/hcc-60-link-path.HC");
+if (System("../../hcc /tmp/hcc-60-link-path.HC -o /tmp/hcc-60-link-path && "
+           "/tmp/hcc-60-link-path") == 0) {
+  correct++;
+}
+
+System("printf '#link <m>\n"
+       "extern \"c\" F64 cos(F64 x);\n"
+       "I32 Main() { if (cos(0.0) == 1.0) return 0; return 1; }\n'"
+       " > /tmp/hcc-60-link-name.HC");
+if (System("../../hcc /tmp/hcc-60-link-name.HC -o /tmp/hcc-60-link-name && "
+           "/tmp/hcc-60-link-name") == 0) {
+  correct++;
+}
+
+System("rm -f /tmp/hcc-60-link.c /tmp/hcc-60-link.so"
+       " /tmp/hcc-60-link-path.HC /tmp/hcc-60-link-path"
+       " /tmp/hcc-60-link-name.HC /tmp/hcc-60-link-name");
+
+PrintResult(correct, tests);
+'===\n';
+Exit(0);

--- a/src/tests/61_ifjit_ifaot.HC
+++ b/src/tests/61_ifjit_ifaot.HC
@@ -1,0 +1,50 @@
+"Test - #ifjit / #ifaot: ";
+#include "testhelper.HC"
+
+/* The suite compiles AOT, so #ifaot branches must be taken and #ifjit
+ * branches skipped. The JIT side is covered by run_jit compiling the
+ * same file expectations inverted would break these asserts there, so
+ * Mode() returns which branch was compiled in and the assert adapts
+ * via __HCC_AOT__. */
+
+I64 correct = 0;
+I64 tests = 3;
+
+I64 Mode()
+{
+#ifjit
+  return 1;
+#else
+  return 2;
+#endif
+}
+
+I64 Mode2()
+{
+#ifaot
+  return 2;
+#else
+  return 1;
+#endif
+}
+
+#ifaot
+I64 aot_only = 42;
+#endif
+#ifjit
+I64 aot_only = 0;
+#endif
+
+#ifdef __HCC_AOT__
+if (Mode() == 2) correct++;
+if (Mode2() == 2) correct++;
+if (aot_only == 42) correct++;
+#else
+if (Mode() == 1) correct++;
+if (Mode2() == 1) correct++;
+if (aot_only == 0) correct++;
+#endif
+
+PrintResult(correct, tests);
+'===\n';
+Exit(0);

--- a/src/tests/62_typeof.HC
+++ b/src/tests/62_typeof.HC
@@ -1,0 +1,35 @@
+"Test - typeof: ";
+#include "testhelper.HC"
+
+class TypeofVec2
+{
+  F64 x;
+  F64 y;
+};
+
+I64 correct = 0;
+I64 tests = 8;
+
+F64 Half(F64 v) { return v / 2.0; }
+
+U0 Main()
+{
+  I64 i = 5;
+  U8 *s = "hi";
+  TypeofVec2 v;
+
+  if (!StrCmp(typeof(1+1), "I64")) correct++;
+  if (!StrCmp(typeof(1.5), "F64")) correct++;
+  if (!StrCmp(typeof(i), "I64")) correct++;
+  if (!StrCmp(typeof(&i), "I64 *")) correct++;
+  if (!StrCmp(typeof(s), "U8 *")) correct++;
+  if (!StrCmp(typeof(v), "TypeofVec2")) correct++;
+  if (!StrCmp(typeof(U8*), "U8 *")) correct++;
+  /* The operand is type-checked, not evaluated. */
+  if (!StrCmp(typeof(Half(4.0)), "F64")) correct++;
+}
+Main;
+
+PrintResult(correct, tests);
+'===\n';
+Exit(0);

--- a/src/util.h
+++ b/src/util.h
@@ -16,7 +16,7 @@
 #define ESC_YELLOW "\033[0;33m"
 #define ESC_BOLD_YELLOW "\033[1;33m"
 #define ESC_BLUE   "\033[0;34m"
-#define ESC_PURPLE "\x1b[38;5;171m"
+#define ESC_PURPLE "\033[0;35m"// "\x1b[38;5;171m"
 #define ESC_CYAN   "\033[0;36m"
 #define ESC_BOLD_CYAN   "\033[1;36m"
 #define ESC_WHITE  "\033[0;37m"

--- a/src/x86_64-jit.c
+++ b/src/x86_64-jit.c
@@ -24,6 +24,7 @@
 #if !defined(__x86_64__) || !defined(HCC_ENABLE_JIT)
 
 HccJit *x86_64JitCompile(Cctrl *cc) { (void)cc; return NULL; }
+const HccJitBackend *x86_64JitBackend(void) { return NULL; }
 
 #else /* __x86_64__ && HCC_ENABLE_JIT */
 
@@ -1250,7 +1251,8 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                 SysvClass cl[2]; int neb = 0;
                 astSysvClassify(t, cl, &neb);
                 int gpret[2] = { R_RAX, R_RDX };
-                int gpi = 0, ssei = 0;
+                int gpi = 0;
+                int ssei = 0;
                 for (int e = 0; e < neb; ++e) {
                     int off = e * 8, rem = (int)t->size - off;
                     int sz = rem >= 8 ? 8 : rem;
@@ -1267,7 +1269,13 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                 if (irIsFloat(instr->dst->type)) jitLoadFirstSrcFpr(ctx, instr->dst);
                 else                              jitLoadFirstSrc(ctx, instr->dst);
             }
-            jitEmitBranchLocal(ctx, hccJitEpilogueLocalNum(jit, ctx->fn));
+            /* The epilogue label is defined straight after the last block,
+             * so a ret ending that block falls through to it. */
+            if (ctx->next_block != NULL ||
+                ctx->cur_block->instructions->prev->value != (void *)instr)
+            {
+                jitEmitBranchLocal(ctx, hccJitEpilogueLocalNum(jit, ctx->fn));
+            }
             break;
 
         case IR_TRUNC: {
@@ -1657,6 +1665,10 @@ static const HccJitBackend x86_64_jit_backend = {
 
 HccJit *x86_64JitCompile(Cctrl *cc) {
     return hccJitCompile(cc, &x86_64_jit_backend);
+}
+
+const HccJitBackend *x86_64JitBackend(void) {
+    return &x86_64_jit_backend;
 }
 
 #endif /* __x86_64__ && HCC_ENABLE_JIT */

--- a/src/x86_64-jit.h
+++ b/src/x86_64-jit.h
@@ -18,4 +18,8 @@
  * hccJitLookup / hccJitFree on the result. */
 HccJit *x86_64JitCompile(Cctrl *cc);
 
+/* The backend vtable, for incremental compilation via hccJitNew /
+ * hccJitCompileChunk (the REPL). NULL on non-x86_64 hosts. */
+const HccJitBackend *x86_64JitBackend(void);
+
 #endif


### PR DESCRIPTION
- `hcc -repl`
- Fix for divides not working properly.
- Add a repl with some builtin functions.
- Created library methods that make the repl shell-like.
- Created a simple memory safety set of routines for tracking things like double frees.
- Created a platform independent `Stat(...)` function.
- Added [linenoise](https://github.com/antirez/linenoise) as a dependency. I don't want to use `readline`, I don't particularly want to create my own line reading library and even if I did I most-likely couldn't do any better than linenoise.