### PR TITLE
Feat: basic LSP implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test-runner-jit
 .gdb_history
 build
 compile.sh
+lsp-test-runner

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,15 @@ unit-test:
 jit-unit-test:
 	cd ./src/tests && ../../hcc ./run_jit.HC -o test-runner-jit && ./test-runner-jit && cd ../../
 
+# Hermetic: builds libtos from the tree into a local prefix and
+# compiles the (HolyC) harness against it, so the suite tests in-tree
+# sources - never whatever happens to be installed in /usr/local.
+lsp-test:
+	mkdir -p ./build/test-prefix/include ./build/test-prefix/lib
+	cp ./src/holyc-lib/tos.HH ./build/test-prefix/include/tos.HH
+	cd ./src/holyc-lib && ../../hcc -lib tos --install-dir=$(CURDIR)/build/test-prefix ./all.HC
+	cd ./src/tests/lsp && ../../../hcc --install-dir=$(CURDIR)/build/test-prefix ./run_lsp_tests.HC -o lsp-test-runner && ./lsp-test-runner
+
 lib-tos:
 	cd ./src/holyc-lib \
 		&& ../../hcc -lib tos ./all.HC \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,8 +57,10 @@ set(SOURCES
     ir-optimise.c
     ir-regalloc.c
     ir-types.c
+    json.c
     lexer.c
     list.c
+    lsp.c
     main.c
     memory.c
     mempool.c
@@ -71,7 +73,7 @@ set(SOURCES
     x86_64.c
 )
 
-set(HEADERS 
+set(HEADERS
     aostr.h
     arena.h
     asm.h
@@ -82,6 +84,8 @@ set(HEADERS
     cli.h
     compile.h
     config.h
+    json.h
+    lsp.h
     containers.h
     ir.h
     ir-debug.h

--- a/src/aarch64-jit.c
+++ b/src/aarch64-jit.c
@@ -78,6 +78,37 @@ static int jitIsAddImm(s64 v) {
     return 0;
 }
 
+/* Can `[base, #disp]` encode for a `size`-byte access? Unscaled
+ * (ldur/stur) covers signed -256..255; the scaled unsigned form
+ * covers size-aligned 0..4095*size. */
+static int jitIsMemDisp(s32 disp, int size) {
+    if (disp >= -256 && disp <= 255) return 1;
+    if (disp >= 0 && (disp % size) == 0 && disp <= 4095 * size) return 1;
+    return 0;
+}
+
+/* sp -=/+= n for any n up to 16MB, via the imm12 (+ lsl #12) split.
+ * The register form is a trap here: reg 31 in ADD/SUB
+ * (shifted-register) decodes as XZR, not SP, so `sub sp, sp, x9`
+ * assembles to a silent no-op. The immediate form treats 31 as SP. */
+static void jitSpAdjust(AsmEnc *enc, int is_sub, u64 n) {
+    if (n == 0) return;
+    if ((n >> 12) > 0xFFF) {
+        loggerPanic("jit-aarch64: stack adjustment %llu exceeds 16MB\n",
+                    (unsigned long long)n);
+    }
+    u64 hi = n & ~0xFFFULL; /* 4096-aligned: encoder picks the sh=1 form */
+    u64 lo = n & 0xFFF;
+    if (hi) {
+        if (is_sub) aarch64_enc_sub_imm(enc, 1, A_SP, A_SP, (uint32_t)hi);
+        else        aarch64_enc_add_imm(enc, 1, A_SP, A_SP, (uint32_t)hi);
+    }
+    if (lo) {
+        if (is_sub) aarch64_enc_sub_imm(enc, 1, A_SP, A_SP, (uint32_t)lo);
+        else        aarch64_enc_add_imm(enc, 1, A_SP, A_SP, (uint32_t)lo);
+    }
+}
+
 /* Parse a register name like "x9", "w0", "d0", "s3" into an A64Reg
  * (which carries just the numeric index 0..31).  Used to translate
  * the pinned-reg / IR_LOC_REG `AoStr *reg` fields into encoder regs. */
@@ -279,9 +310,25 @@ static void jitDerefLoad(AsmEnc *enc, int size, A64Reg dst, A64Reg base,
         return;
     }
     if (disp != 0) {
-        /* Imm offset form. ldur (imm9 unscaled) for negative or
-         * misaligned; ldr/ldrb/ldrh (scaled) for positive aligned. */
-        if (disp < 0 || disp > 32760) {
+        int ok_scaled = disp >= 0 && (disp % size) == 0 &&
+                        disp <= 4095 * size;
+        if (!ok_scaled && !jitIsMemDisp(disp, size)) {
+            /* Out of every immediate form's range: register-offset
+             * via x10. base may be a live allocated register (must
+             * not be mutated) and x9 can hold a store value. */
+            jitEmitMovImm(enc, A_X10, (s64)disp);
+            if (size == 4) {
+                aarch64_enc_ldst_regoff(enc, 0, 1, 4, 0, dst, base, A_X10);
+                aarch64_enc_sxtw(enc, dst, dst);
+            } else {
+                aarch64_enc_ldst_regoff(enc, 0, 1, size, 0, dst, base, A_X10);
+                if (size == 1) aarch64_enc_uxtb(enc, 0, dst, dst);
+                else if (size == 2) aarch64_enc_uxth(enc, dst, dst);
+            }
+            return;
+        }
+        if (!ok_scaled) {
+            /* Small negative or misaligned: ldur (imm9 unscaled). */
             aarch64_enc_ldur(enc, size == 4 ? 4 : size, dst, base, disp);
             if (size == 4) aarch64_enc_sxtw(enc, dst, dst);
             else if (size == 1) aarch64_enc_uxtb(enc, 0, dst, dst);
@@ -316,7 +363,16 @@ static void jitDerefStore(AsmEnc *enc, int size, A64Reg val, A64Reg base,
         return;
     }
     if (disp != 0) {
-        if (disp < 0 || disp > 32760) {
+        int ok_scaled = disp >= 0 && (disp % size) == 0 &&
+                        disp <= 4095 * size;
+        if (!ok_scaled && !jitIsMemDisp(disp, size)) {
+            /* See jitDerefLoad: x10, never mutate base, x9 may be
+             * the value. */
+            jitEmitMovImm(enc, A_X10, (s64)disp);
+            aarch64_enc_ldst_regoff(enc, 0, 0, size, 0, val, base, A_X10);
+            return;
+        }
+        if (!ok_scaled) {
             aarch64_enc_stur(enc, size, val, base, disp);
             return;
         }
@@ -1174,8 +1230,15 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                     aarch64_enc_ldst_regoff(enc, 1, 1, fsz, sh ? 1 : 0,
                                             A_X0 /*d0*/, base, idx);
                 } else if (instr->disp != 0) {
-                    aarch64_enc_fp_ldst_imm(enc, 1, fsz, A_X0 /*d0*/, base,
-                                            (uint32_t)instr->disp);
+                    if (instr->disp >= 0 && (instr->disp % fsz) == 0 &&
+                        instr->disp <= 4095 * fsz) {
+                        aarch64_enc_fp_ldst_imm(enc, 1, fsz, A_X0 /*d0*/,
+                                                base, (uint32_t)instr->disp);
+                    } else {
+                        jitEmitMovImm(enc, A_X10, (s64)instr->disp);
+                        aarch64_enc_ldst_regoff(enc, 1, 1, fsz, 0,
+                                                A_X0 /*d0*/, base, A_X10);
+                    }
                 } else {
                     aarch64_enc_fp_ldst_imm(enc, 1, fsz, A_X0 /*d0*/, base, 0);
                 }
@@ -1219,8 +1282,15 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                     aarch64_enc_ldst_regoff(enc, 1, 0, fsz, sh ? 1 : 0,
                                             A_X0 /*d0*/, base, idx);
                 } else if (instr->disp != 0) {
-                    aarch64_enc_fp_ldst_imm(enc, 0, fsz, A_X0 /*d0*/, base,
-                                            (uint32_t)instr->disp);
+                    if (instr->disp >= 0 && (instr->disp % fsz) == 0 &&
+                        instr->disp <= 4095 * fsz) {
+                        aarch64_enc_fp_ldst_imm(enc, 0, fsz, A_X0 /*d0*/,
+                                                base, (uint32_t)instr->disp);
+                    } else {
+                        jitEmitMovImm(enc, A_X10, (s64)instr->disp);
+                        aarch64_enc_ldst_regoff(enc, 1, 0, fsz, 0,
+                                                A_X0 /*d0*/, base, A_X10);
+                    }
                 } else {
                     aarch64_enc_fp_ldst_imm(enc, 0, fsz, A_X0 /*d0*/, base, 0);
                 }
@@ -1531,14 +1601,7 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
             s32 n_stack = jitPartitionCallArgs(is_stack, n, args, callee_va,
                                                named_count, force_va_stack);
             int stack_bytes = (n_stack * 8 + 15) & ~15;
-            if (stack_bytes > 0) {
-                if (stack_bytes <= 0xFFF) {
-                    aarch64_enc_sub_imm(enc, 1, A_SP, A_SP, (uint32_t)stack_bytes);
-                } else {
-                    jitEmitMovImm(enc, A_X9, (s64)stack_bytes);
-                    aarch64_enc_sub_reg(enc, 1, A_SP, A_SP, A_X9);
-                }
-            }
+            jitSpAdjust(enc, 1, (u64)stack_bytes);
             int stack_idx = 0;
             for (u64 i = 0; i < n; ++i) {
                 if (!is_stack[i]) continue;
@@ -1571,14 +1634,7 @@ static void jitEmitInstr(JitFnCtx *ctx, IrInstr *instr) {
                 size_t off = aarch64_jit_emit_bl_placeholder(enc);
                 hccJitAddCallFixup(enc, off, normalised, AFR_AARCH64_CALL26);
             }
-            if (stack_bytes > 0) {
-                if (stack_bytes <= 0xFFF) {
-                    aarch64_enc_add_imm(enc, 1, A_SP, A_SP, (uint32_t)stack_bytes);
-                } else {
-                    jitEmitMovImm(enc, A_X9, (s64)stack_bytes);
-                    aarch64_enc_add_reg(enc, 1, A_SP, A_SP, A_X9);
-                }
-            }
+            jitSpAdjust(enc, 0, (u64)stack_bytes);
             if (instr->dst && instr->dst->type != IR_TYPE_VOID) {
                 if (irIsFloat(instr->dst->type)) jitSpillDstFpr(ctx, instr, A_X0);
                 else                              jitSpillDst   (ctx, instr, A_X0);
@@ -1624,14 +1680,7 @@ static void jitEmitPrologue(JitFnCtx *ctx) {
     aarch64_enc_add_imm(enc, 1, A_FP, A_SP, 0);
     uint32_t aligned = ((uint32_t)ctx->fn->stack_space + 15u) & ~15u;
     ctx->aligned_frame = aligned;
-    if (aligned > 0) {
-        if (aligned <= 0xFFF) {
-            aarch64_enc_sub_imm(enc, 1, A_SP, A_SP, aligned);
-        } else {
-            jitEmitMovImm(enc, A_X9, (s64)aligned);
-            aarch64_enc_sub_reg(enc, 1, A_SP, A_SP, A_X9);
-        }
-    }
+    jitSpAdjust(enc, 1, aligned);
 }
 
 static void jitEmitEpilogue(JitFnCtx *ctx) {
@@ -1640,14 +1689,7 @@ static void jitEmitEpilogue(JitFnCtx *ctx) {
         aarch64_jit_emit_ret(enc);
         return;
     }
-    if (ctx->aligned_frame > 0) {
-        if (ctx->aligned_frame <= 0xFFF) {
-            aarch64_enc_add_imm(enc, 1, A_SP, A_SP, ctx->aligned_frame);
-        } else {
-            jitEmitMovImm(enc, A_X9, (s64)ctx->aligned_frame);
-            aarch64_enc_add_reg(enc, 1, A_SP, A_SP, A_X9);
-        }
-    }
+    jitSpAdjust(enc, 0, ctx->aligned_frame);
     aarch64_jit_emit_ldp_post(enc, A_FP, A_LR, A_SP, 16);
     aarch64_jit_emit_ret(enc);
 }
@@ -1710,7 +1752,9 @@ static int jitCompileFunction(HccJit *jit, Ast *ast, IrCtx *ir_ctx) {
             asm_define_label(&jit->enc, ln, NULL);
         }
         listForEach(block->instructions) {
-            jitEmitInstr(&ctx, (IrInstr *)it->value);
+            IrInstr *in = (IrInstr *)it->value;
+            hccJitNoteLine(jit, in->line);
+            jitEmitInstr(&ctx, in);
         }
     }
     setRelease(referenced);

--- a/src/aarch64.c
+++ b/src/aarch64.c
@@ -269,33 +269,58 @@ static void aarch64FpFrameStore(AoStr *buf, const char *dreg, u32 size,
     aoStrCatFmt(buf, "%s %s, %s\n\t", op, fpr, mem);
 }
 
-/* Emit `reg += disp` honouring the AArch64 imm12 (optionally lsl 12)
- * restriction. Anything wider materialises through x9. */
+/* Emit `op dst, src, #v` (op is "add"/"sub", v its magnitude, >= 0)
+ * for any v: one instruction when the immediate encodes, the
+ * hi-(lsl #12)+lo two-instruction split up to 16MB, and a
+ * materialise + register form beyond that. The register form is
+ * legal for sp operands too (extended-register encoding). Only the
+ * >16MB path clobbers x9, so src == x9 is safe for real frames. */
+static void aarch64EmitAddSubImm(AoStr *buf, const char *op,
+                                 const char *dst, const char *src, s64 v)
+{
+    if (v < 0) {
+        loggerPanic("ir-cg-aarch64: %s immediate must be a magnitude, "
+                    "got %lld\n", op, (long long)v);
+    }
+    if (v <= 0xFFF) {
+        aoStrCatFmt(buf, "%s %s, %s, #%I\n\t", op, dst, src, v);
+        return;
+    }
+    if ((v >> 12) <= 0xFFF) {
+        aoStrCatFmt(buf, "%s %s, %s, #%I, lsl #12\n\t",
+                    op, dst, src, v >> 12);
+        if (v & 0xFFF) {
+            aoStrCatFmt(buf, "%s %s, %s, #%I\n\t",
+                        op, dst, dst, v & 0xFFF);
+        }
+        return;
+    }
+    aarch64EmitMovImm(buf, "x9", v);
+    aoStrCatFmt(buf, "%s %s, %s, x9\n\t", op, dst, src);
+}
+
+/* Emit `reg += disp` (the in-place form of the above). */
 static void aarch64AddSubImm(AoStr *buf, const char *reg, s64 disp) {
     if (disp == 0) return;
-    const char *mnem = disp < 0 ? "sub" : "add";
-    u64 mag = (u64)(disp < 0 ? -disp : disp);
-    if (mag <= 0xFFF) {
-        aoStrCatFmt(buf, "%s %s, %s, #%I\n\t", mnem, reg, reg, (s64)mag);
-        return;
-    }
-    if ((mag & 0xFFF) == 0 && mag <= 0xFFFULL << 12) {
-        aoStrCatFmt(buf, "%s %s, %s, #%I, lsl #12\n\t",
-                    mnem, reg, reg, (s64)(mag >> 12));
-        return;
-    }
-    if (mag <= 0xFFFFFFULL) {
-        u64 hi = mag >> 12;
-        u64 lo = mag & 0xFFF;
-        aoStrCatFmt(buf, "%s %s, %s, #%I, lsl #12\n\t",
-                    mnem, reg, reg, (s64)hi);
-        if (lo)
-            aoStrCatFmt(buf, "%s %s, %s, #%I\n\t",
-                        mnem, reg, reg, (s64)lo);
-        return;
-    }
-    aarch64EmitMovImm(buf, "x9", (s64)mag);
-    aoStrCatFmt(buf, "%s %s, %s, x9\n\t", mnem, reg, reg);
+    if (disp < 0) aarch64EmitAddSubImm(buf, "sub", reg, reg, -disp);
+    else          aarch64EmitAddSubImm(buf, "add", reg, reg, disp);
+}
+
+/* `dst = x29 + loff` for any signed frame offset. */
+static void aarch64EmitFrameAddr(AoStr *buf, const char *dst, s64 loff)
+{
+    if (loff >= 0) aarch64EmitAddSubImm(buf, "add", dst, "x29", loff);
+    else           aarch64EmitAddSubImm(buf, "sub", dst, "x29", -loff);
+}
+
+/* Can `[base, #disp]` encode for a `size`-byte access? Unscaled
+ * (ldur/stur) covers signed -256..255; the scaled unsigned form
+ * covers size-aligned 0..4095*size. */
+static int aarch64IsMemDisp(s32 disp, u32 size) {
+    if (disp >= -256 && disp <= 255) return 1;
+    if (disp >= 0 && (disp % (s32)size) == 0 &&
+        disp <= 4095 * (s32)size) return 1;
+    return 0;
 }
 
 /* Width-aware load through a register-held address. */
@@ -319,8 +344,14 @@ static void aarch64DerefLoad(AoStr *buf, u32 size, const char *dst_reg,
         else snprintf(mem, sizeof(mem), "[%s, %s, lsl #%d]",
                       base_reg, idx_reg, sh);
         aarch64AddSubImm(buf, base_reg, (s64)disp);
-    } else if (disp != 0) {
+    } else if (disp != 0 && aarch64IsMemDisp(disp, size)) {
         snprintf(mem, sizeof(mem), "[%s, #%d]", base_reg, (int)disp);
+    } else if (disp != 0) {
+        /* Out-of-range displacement: register-offset form via x10 -
+         * base_reg may be a live allocated register, so it must not
+         * be mutated (x10 is free: values use x0/x9, bases x1-x7). */
+        aarch64EmitMovImm(buf, "x10", (s64)disp);
+        snprintf(mem, sizeof(mem), "[%s, x10]", base_reg);
     } else {
         snprintf(mem, sizeof(mem), "[%s]", base_reg);
     }
@@ -352,8 +383,13 @@ static void aarch64DerefStore(AoStr *buf, u32 size, const char *val_reg,
         else snprintf(mem, sizeof(mem), "[%s, %s, lsl #%d]",
                       base_reg, idx_reg, sh);
         aarch64AddSubImm(buf, base_reg, (s64)disp);
-    } else if (disp != 0) {
+    } else if (disp != 0 && aarch64IsMemDisp(disp, size)) {
         snprintf(mem, sizeof(mem), "[%s, #%d]", base_reg, (int)disp);
+    } else if (disp != 0) {
+        /* See aarch64DerefLoad: never mutate base_reg, x10 is free
+         * (the value may be sitting in x9). */
+        aarch64EmitMovImm(buf, "x10", (s64)disp);
+        snprintf(mem, sizeof(mem), "[%s, x10]", base_reg);
     } else {
         snprintf(mem, sizeof(mem), "[%s]", base_reg);
     }
@@ -589,6 +625,7 @@ static int aarch64IsAddImm(s64 v) {
     if ((v & 0xFFF) == 0 && (v >> 12) <= 0xFFF) return 1;
     return 0;
 }
+
 
 /* True if `imm` is encodable as an AArch64 logical bitmask immediate
  * (rotation of N consecutive 1-bits, repeated at 2/4/8/16/32/64 bit
@@ -842,26 +879,42 @@ static void aarch64CopyToSp(AoStr *buf, const char *src_reg, int size, int dst)
 
 /* Copy `size` bytes from [base_reg, #src] to [x29, #dst] using x10 as a
  * scratch register (8/4/2/1-byte chunks). Both src and dst are signed
- * displacements; clang selects ldur/stur for the negative-slot case. */
+ * displacements; clang selects ldur/stur for the negative-slot case.
+ * Either side whose window leaves the always-encodable ldur/stur range
+ * is rebased onto a scratch first (x11 for the source - base_reg may
+ * itself be x9 - and x12 for the frame side; both are free, the
+ * allocator only hands out x0-x7). */
 static void aarch64CopyToSlot(AoStr *buf, const char *base_reg, int size,
                               int src, int dst)
 {
+    const char *dst_base = "x29";
+    if (src < -240 || src + size > 240) {
+        if (src >= 0) aarch64EmitAddSubImm(buf, "add", "x11", base_reg, src);
+        else          aarch64EmitAddSubImm(buf, "sub", "x11", base_reg, -src);
+        base_reg = "x11";
+        src = 0;
+    }
+    if (dst < -240 || dst + size > 240) {
+        aarch64EmitFrameAddr(buf, "x12", dst);
+        dst_base = "x12";
+        dst = 0;
+    }
     int o = 0;
     while (size - o >= 8) {
         aoStrCatFmt(buf, "ldr x10, [%s, #%i]\n\t", base_reg, src + o);
-        aoStrCatFmt(buf, "str x10, [x29, #%i]\n\t", dst + o);
+        aoStrCatFmt(buf, "str x10, [%s, #%i]\n\t", dst_base, dst + o);
         o += 8;
     }
     int rem = size - o;
     if (rem == 4) {
         aoStrCatFmt(buf, "ldr w10, [%s, #%i]\n\t", base_reg, src + o);
-        aoStrCatFmt(buf, "str w10, [x29, #%i]\n\t", dst + o);
+        aoStrCatFmt(buf, "str w10, [%s, #%i]\n\t", dst_base, dst + o);
     } else if (rem == 2) {
         aoStrCatFmt(buf, "ldrh w10, [%s, #%i]\n\t", base_reg, src + o);
-        aoStrCatFmt(buf, "strh w10, [x29, #%i]\n\t", dst + o);
+        aoStrCatFmt(buf, "strh w10, [%s, #%i]\n\t", dst_base, dst + o);
     } else if (rem == 1) {
         aoStrCatFmt(buf, "ldrb w10, [%s, #%i]\n\t", base_reg, src + o);
-        aoStrCatFmt(buf, "strb w10, [x29, #%i]\n\t", dst + o);
+        aoStrCatFmt(buf, "strb w10, [%s, #%i]\n\t", dst_base, dst + o);
     } else if (rem != 0) {
         loggerPanic("ir-cg-aarch64: %d-byte param copy chunk not "
                     "supported\n", rem);
@@ -900,10 +953,10 @@ static void a64TxtEmitInit(A64Emitter *e, IrCgCtx *ctx) {
 
 /* AOT (assembly-text) leaf ops for the shared a64EmitCall lowering. */
 static void a64TxtSubSp(void *be, int n) {
-    aoStrCatFmt(((IrCgCtx *)be)->buf, "sub sp, sp, #%i\n\t", n);
+    aarch64EmitAddSubImm(((IrCgCtx *)be)->buf, "sub", "sp", "sp", n);
 }
 static void a64TxtAddSp(void *be, int n) {
-    aoStrCatFmt(((IrCgCtx *)be)->buf, "add sp, sp, #%i\n\t", n);
+    aarch64EmitAddSubImm(((IrCgCtx *)be)->buf, "add", "sp", "sp", n);
 }
 static void a64TxtLoadStructAddr(void *be, IrValue *a) {
     aarch64LoadToReg((IrCgCtx *)be, a, "x9");
@@ -1002,13 +1055,21 @@ static void a64TxtCallInit(A64CallEmitter *e, IrCgCtx *ctx) {
 /* AOT (assembly-text) leaf ops for the shared a64EmitParamPrologue. */
 static void a64TxtAggStore(void *be, int is_fp, int reg, int loff, int size) {
     AoStr *buf = ((IrCgCtx *)be)->buf;
+    /* Big frames put the slot beyond stur range; rebase onto x9 (free
+     * here - incoming args live in x0-x7/d0-d7). */
+    const char *base = "x29";
+    if (loff < -240 || loff > 240) {
+        aarch64EmitFrameAddr(buf, "x9", loff);
+        base = "x9";
+        loff = 0;
+    }
     if (is_fp)
-        aoStrCatFmt(buf, "str %s%i, [x29, #%i]\n\t", size == 4 ? "s" : "d",
-                    reg, loff);
-    else if (size >= 8) aoStrCatFmt(buf, "str x%i, [x29, #%i]\n\t", reg, loff);
-    else if (size == 4) aoStrCatFmt(buf, "str w%i, [x29, #%i]\n\t", reg, loff);
-    else if (size == 2) aoStrCatFmt(buf, "strh w%i, [x29, #%i]\n\t", reg, loff);
-    else if (size == 1) aoStrCatFmt(buf, "strb w%i, [x29, #%i]\n\t", reg, loff);
+        aoStrCatFmt(buf, "str %s%i, [%s, #%i]\n\t", size == 4 ? "s" : "d",
+                    reg, base, loff);
+    else if (size >= 8) aoStrCatFmt(buf, "str x%i, [%s, #%i]\n\t", reg, base, loff);
+    else if (size == 4) aoStrCatFmt(buf, "str w%i, [%s, #%i]\n\t", reg, base, loff);
+    else if (size == 2) aoStrCatFmt(buf, "strh w%i, [%s, #%i]\n\t", reg, base, loff);
+    else if (size == 1) aoStrCatFmt(buf, "strb w%i, [%s, #%i]\n\t", reg, base, loff);
     else loggerPanic("ir-cg-aarch64: %d-byte struct param chunk not "
                      "supported\n", size);
 }
@@ -1251,9 +1312,15 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                     else
                         aoStrCatFmt(ctx->buf, "ldr %s, [%s, %s]\n\t",
                                     fr, base_reg, idx_reg);
-                } else if (instr->disp != 0) {
+                } else if (instr->disp != 0 &&
+                           aarch64IsMemDisp(instr->disp,
+                               (u32)irValueByteSize(instr->dst))) {
                     aoStrCatFmt(ctx->buf, "ldr %s, [%s, #%i]\n\t",
                                 fr, base_reg, (int)instr->disp);
+                } else if (instr->disp != 0) {
+                    aarch64EmitMovImm(ctx->buf, "x10", (s64)instr->disp);
+                    aoStrCatFmt(ctx->buf, "ldr %s, [%s, x10]\n\t",
+                                fr, base_reg);
                 } else {
                     aoStrCatFmt(ctx->buf, "ldr %s, [%s]\n\t", fr, base_reg);
                 }
@@ -1306,9 +1373,15 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                     else
                         aoStrCatFmt(ctx->buf, "str %s, [%s, %s]\n\t",
                                     fr, base_reg, idx_reg);
-                } else if (instr->disp != 0) {
+                } else if (instr->disp != 0 &&
+                           aarch64IsMemDisp(instr->disp,
+                               (u32)irValueByteSize(instr->r1))) {
                     aoStrCatFmt(ctx->buf, "str %s, [%s, #%i]\n\t",
                                 fr, base_reg, (int)instr->disp);
+                } else if (instr->disp != 0) {
+                    aarch64EmitMovImm(ctx->buf, "x10", (s64)instr->disp);
+                    aoStrCatFmt(ctx->buf, "str %s, [%s, x10]\n\t",
+                                fr, base_reg);
                 } else {
                     aoStrCatFmt(ctx->buf, "str %s, [%s]\n\t", fr, base_reg);
                 }
@@ -1386,12 +1459,7 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                 aarch64GlobalAddr(ctx->cc, ctx->buf, name, "x0");
             } else if (instr->r1) {
                 int loff = irCgGetLoff(&ctx->fn->ra, instr->r1);
-                if (loff < 0 || aarch64IsAddImm(loff)) {
-                    aoStrCatFmt(ctx->buf, "add x0, x29, #%i\n\t", loff);
-                } else {
-                    aarch64EmitMovImm(ctx->buf, "x9", loff);
-                    aoStrCatFmt(ctx->buf, "add x0, x29, x9\n\t");
-                }
+                aarch64EmitFrameAddr(ctx->buf, "x0", loff);
             }
             aarch64SpillDst(ctx, instr, "x0");
             break;
@@ -1575,23 +1643,34 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                 int loff = irCgGetLoff(&ctx->fn->ra, instr->dst);
                 int re = 0, rc = 0;
                 AapcsClass rcls = astAapcsClassify(t, &re, &rc);
+                /* Big frames put the slot beyond ldur/ldr immediate
+                 * range; rebase onto x9 so every chunk offset below
+                 * is small. x9 is dead here (return regs are x0/x1
+                 * or v0..; the epilogue touches only sp/x29/x30). */
+                const char *rbase = "x29";
+                if (loff < -240 || loff > 240) {
+                    aarch64EmitFrameAddr(ctx->buf, "x9", loff);
+                    rbase = "x9";
+                    loff = 0;
+                }
                 if (rcls == AAPCS_HFA) {
                     for (int k = 0; k < rc; ++k)
-                        aoStrCatFmt(ctx->buf, "ldr %s%i, [x29, #%i]\n\t",
-                                    re == 4 ? "s" : "d", k, loff + k * re);
+                        aoStrCatFmt(ctx->buf, "ldr %s%i, [%s, #%i]\n\t",
+                                    re == 4 ? "s" : "d", k, rbase,
+                                    loff + k * re);
                 } else { /* INTEGER, <=16 bytes -> x0,(x1) */
                     int ngp = (t->size + 7) / 8;
                     for (int k = 0; k < ngp; ++k) {
                         int off = k * 8, rem = t->size - off;
                         int at = loff + off;
                         if (rem >= 8)
-                            aoStrCatFmt(ctx->buf, "ldr x%i, [x29, #%i]\n\t", k, at);
+                            aoStrCatFmt(ctx->buf, "ldr x%i, [%s, #%i]\n\t", k, rbase, at);
                         else if (rem == 4)
-                            aoStrCatFmt(ctx->buf, "ldr w%i, [x29, #%i]\n\t", k, at);
+                            aoStrCatFmt(ctx->buf, "ldr w%i, [%s, #%i]\n\t", k, rbase, at);
                         else if (rem == 2)
-                            aoStrCatFmt(ctx->buf, "ldrh w%i, [x29, #%i]\n\t", k, at);
+                            aoStrCatFmt(ctx->buf, "ldrh w%i, [%s, #%i]\n\t", k, rbase, at);
                         else
-                            aoStrCatFmt(ctx->buf, "ldrb w%i, [x29, #%i]\n\t", k, at);
+                            aoStrCatFmt(ctx->buf, "ldrb w%i, [%s, #%i]\n\t", k, rbase, at);
                     }
                 }
             } else if (instr->dst) {
@@ -1712,7 +1791,8 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                                                    force_va_stack);
             int stack_bytes = (n_stack * 8 + 15) & ~15;
             if (stack_bytes > 0) {
-                aoStrCatFmt(ctx->buf, "sub sp, sp, #%i\n\t", stack_bytes);
+                aarch64EmitAddSubImm(ctx->buf, "sub", "sp", "sp",
+                                     stack_bytes);
             }
             int stack_idx = 0;
             for (u64 i = 0; i < n; ++i) {
@@ -1752,7 +1832,8 @@ static void aarch64EmitInstr(IrCgCtx *ctx, IrInstr *instr) {
                 aoStrCatFmt(ctx->buf, "bl  %s\n\t", normalised);
             }
             if (stack_bytes > 0) {
-                aoStrCatFmt(ctx->buf, "add sp, sp, #%i\n\t", stack_bytes);
+                aarch64EmitAddSubImm(ctx->buf, "add", "sp", "sp",
+                                     stack_bytes);
             }
             if (instr->dst && instr->dst->type != IR_TYPE_VOID) {
                 if (irIsFloat(instr->dst->type)) {
@@ -1844,7 +1925,7 @@ static void aarch64EmitFunctionPrologue(Cctrl *cc, AoStr *buf, Ast *func,
                 "mov x29, sp\n\t");
     if (total_stack > 0) {
         u32 aligned = ((u32)total_stack + 15u) & ~15u;
-        aoStrCatFmt(buf, "sub sp, sp, #%u\n\t", aligned);
+        aarch64EmitAddSubImm(buf, "sub", "sp", "sp", (s64)aligned);
     }
 }
 
@@ -1854,7 +1935,7 @@ static void aarch64Epilogue(IrCgCtx *ctx, int frame_size, int omit_frame) {
         return;
     }
     if (frame_size > 0) {
-        aoStrCatFmt(ctx->buf, "add sp, sp, #%i\n\t", frame_size);
+        aarch64EmitAddSubImm(ctx->buf, "add", "sp", "sp", frame_size);
     }
     aoStrCatFmt(ctx->buf,
                 "ldp x29, x30, [sp], #16\n\t"

--- a/src/arena.c
+++ b/src/arena.c
@@ -90,6 +90,26 @@ void arenaClear(Arena *arena) {
     }
 }
 
+/* Reset for REUSE: free the overflow blocks and rewind the head block
+ * to empty. Unlike arenaClear - which is arenaRelease's destructor
+ * half and leaves head/tail dangling - the arena is as-new afterwards.
+ * The per-message arena pattern: allocate freely, arenaReset between
+ * messages, arenaRelease at the end. */
+void arenaReset(Arena *arena) {
+    if (arena == NULL) return;
+    ArenaBlock *block = arena->tail;
+    while (block) {
+        ArenaBlock *next = block->next;
+        arenaBlockRelease(block);
+        block = next;
+    }
+    arena->tail = NULL;
+    ArenaBlock *head = arena->head;
+    head->mem = ((char *)head->mem) - head->used;
+    head->used = 0;
+    arena->used = 0;
+}
+
 void arenaRelease(Arena *arena) {
     if (arena) {
         arenaClear(arena);

--- a/src/arena.h
+++ b/src/arena.h
@@ -19,7 +19,10 @@ typedef struct Arena {
 } Arena;
 
 void arenaInit(Arena *arena, u32 capacity);
+/* Destructor half of arenaRelease - the arena is UNUSABLE after. */
 void arenaClear(Arena *arena);
+/* Reset for reuse: drop overflow blocks, rewind the head block. */
+void arenaReset(Arena *arena);
 Arena *arenaNew(u32 capacity);
 void *arenaAlloc(Arena *arena, u32 size);
 void arenaRelease(Arena *arena);

--- a/src/asm/enc_arm64.c
+++ b/src/asm/enc_arm64.c
@@ -3868,7 +3868,15 @@ aarch64_encode_instr(AsmEnc *e, AsmLine *ln)
         aarch64_enc_branch(e, ln, 0, 1, cc);
         return;
     }
-    asm_err_at(e, ln, "unsupported arm64 mnemonic");
+    char err_buf[256];
+    if (ln->mnemonic) {
+        snprintf(err_buf, sizeof(err_buf), "unsupported arm64 mnemonic %s", ln->mnemonic);
+    } else if (ln->label_name) {
+        snprintf(err_buf, sizeof(err_buf), "unsupported arm64 mnemonic %s", ln->label_name);
+    } else {
+        snprintf(err_buf, sizeof(err_buf), "unsupported arm64 mnemonic");
+    }
+    asm_err_at(e, ln, err_buf);
 }
 
 /* ---------- entry ---------- */

--- a/src/ast.c
+++ b/src/ast.c
@@ -139,9 +139,16 @@ Ast *ast_forever_sentinal = &(Ast){ .kind = AST_LITERAL,
 void _astToString(AoStr *str, Ast *ast, int depth);
 char *_astToStringRec(Ast *ast, int depth);
 
+int ast_line_hint = 0;
+int ast_col_hint = 0;
+u32 ast_file_hint = 0;
+
 Ast *astNew(void) {
     Ast *ast = astAlloc();
     memset(ast,0,sizeof(Ast));
+    ast->line = ast_line_hint;
+    ast->col = ast_col_hint;
+    ast->file_id = ast_file_hint;
     return ast;
 }
 

--- a/src/ast.h
+++ b/src/ast.h
@@ -161,6 +161,13 @@ typedef struct AstType {
     /* Alignment of a struct or union */
     u32 alignment;
 
+    /* Provenance of the DEFINITION (class/union tag token) for
+     * jump-to-definition; 0 = unknown/builtin. Only stamped for
+     * named class/union definitions - see parseClassOrUnion. */
+    int line;
+    int col;
+    u32 file_id;
+
     /* Value signed or unsigned? */
     int issigned;
 
@@ -216,6 +223,13 @@ typedef struct Ast {
     u64 flags;
     AstType *type;
     int loff;
+    /* Source line of the token being consumed when this node was
+     * created (statement-level accuracy). 0 = unknown/synthetic. */
+    int line;
+    /* 1-based column of that token's first byte. 0 = unknown. */
+    int col;
+    /* Which file (cctrlLookUpFile) - 0 = unknown. */
+    u32 file_id;
     s64 deref_symbol;
     union {
         struct {
@@ -416,6 +430,16 @@ typedef struct Ast {
         };
     };
 } Ast;
+
+/* Source line of the token the parser is currently consuming -
+ * published by cctrlTokenGet, stamped onto every astNew node so the
+ * IR (and ultimately JIT line tables) can attribute code to source. */
+extern int ast_line_hint;
+/* 1-based column of the token being consumed (Lexeme->col). */
+extern int ast_col_hint;
+/* Which cc->file_map entry the parser is currently consuming tokens
+ * from - resolve with cctrlLookUpFile. 0 = unknown. */
+extern u32 ast_file_hint;
 
 extern AstType *ast_int_type;
 extern AstType *ast_uint_type;

--- a/src/cctrl.c
+++ b/src/cctrl.c
@@ -248,6 +248,7 @@ Cctrl *cctrlNew(enum CliTarget target) {
     Cctrl *cc = (Cctrl *)malloc(sizeof(Cctrl));
 
     cc->flags = 0;
+    cc->file_map = mapNew(16, &map_u32_to_aostr_type);
     cc->global_env = mapNew(32, &map_ast_type);
     cc->clsdefs = mapNew(32, &map_asttype_type);
     cc->uniondefs = mapNew(32, &map_asttype_type);
@@ -504,6 +505,27 @@ void cctrlTokenRewind(Cctrl *cc) {
     }
 }
 
+/* Register `filename` in cc->file_map, returning its 1-based id -
+ * or the existing id if this file was seen before (linear scan;
+ * registration is once per file push, and files are few). */
+u32 cctrlRegisterFile(Cctrl *cc, AoStr *filename) {
+    if (cc == NULL || filename == NULL) return 0;
+    MapIter mi;
+    mapIterInit(cc->file_map, &mi);
+    while (mapIterNext(&mi)) {
+        if (aoStrEq((AoStr *)mi.node->value, filename))
+            return (u32)(u64)mi.node->key;
+    }
+    u32 id = (u32)cc->file_map->size + 1;
+    mapAddIntOrErr(cc->file_map, id, aoStrDup(filename));
+    return id;
+}
+
+AoStr *cctrlLookUpFile(Cctrl *cc, u32 file_id) {
+    if (cc == NULL || file_id == 0) return NULL;
+    return (AoStr *)mapGetInt(cc->file_map, file_id);
+}
+
 Lexeme *cctrlTokenGet(Cctrl *cc) {
     Lexeme *token = tokenRingBufferPeek(cc->token_buffer);
     while (token) {
@@ -518,6 +540,16 @@ Lexeme *cctrlTokenGet(Cctrl *cc) {
             cctrLoadNextTokens(cc,5);
         }
         cc->lineno = token->line;
+        ast_line_hint = token->line;
+        ast_col_hint = token->col;
+        /* Register the lexer's current file lazily; the id rides on
+         * every astNew until the lexer crosses a file boundary. */
+        if (cc->lexer_ && cc->lexer_->cur_file) {
+            LexFile *f = cc->lexer_->cur_file;
+            if (f->file_id == 0)
+                f->file_id = cctrlRegisterFile(cc, f->filename);
+            ast_file_hint = f->file_id;
+        }
         return cctrlMaybeExpandToken(cc, token);
     }
     return NULL;
@@ -990,9 +1022,16 @@ void cctrlIce(Cctrl *cc, char *fmt, ...) {
     va_list ap;
     va_start(ap,fmt);
     AoStr *buf = cctrlMessagVnsPrintF(cc,fmt,ap,CCTRL_ICE);
+    va_end(ap);
+    /* An embedder (REPL/LSP) with a recovery point armed wants the ICE
+     * as a recoverable diagnostic, not a process exit. */
+    if (cc && cc->current_recovery) {
+        CctrlDiagnostic *d = cctrlMakeDiag(cc, CCTRL_ERROR, buf, NULL);
+        cctrlDiagPush(cc, d);
+        cctrlTerminate(cc);
+    }
     fprintf(stderr,"%s\n",buf->data);
     aoStrRelease(buf);
-    va_end(ap);
     exit(EXIT_FAILURE);
 }
 

--- a/src/cctrl.h
+++ b/src/cctrl.h
@@ -84,6 +84,10 @@ typedef struct Cctrl {
     /* key words defined in the language */
     Map *symbol_table;
 
+    /* Every file this compile has lexed: `Map<u32, AoStr *>` keyed by
+     * the 1-based id stamped onto Ast->file_id (0 = unknown). */
+    Map *file_map;
+
     /* Class definitions */
     Map *clsdefs;
 
@@ -220,6 +224,10 @@ typedef struct Cctrl {
 Cctrl *cctrlNew(enum CliTarget target);
 /* Slimmed down Cctrl, for expanding macros */
 Cctrl *ccMacroProcessor(Map *macro_defs);
+/* File-id registry over cc->file_map; ids are what Ast->file_id holds. */
+u32 cctrlRegisterFile(Cctrl *cc, AoStr *filename);
+AoStr *cctrlLookUpFile(Cctrl *cc, u32 file_id);
+
 Lexeme *cctrlTokenGet(Cctrl *cc);
 Lexeme *cctrlAsmTokenGet(Cctrl *cc);
 Lexeme *cctrlTokenPeek(Cctrl *cc);

--- a/src/cli.c
+++ b/src/cli.c
@@ -114,6 +114,7 @@ static CliParser parsers[] = {
     {str_lit("-jit"),       0, CLI_JIT, "-jit", "JIT-compile and run main() in-process (aarch64 & x86_64)", &cliParseNop},
     {str_lit("-Memsafe"),   0, CLI_MEMSAFE, "-Memsafe", "With -jit: track MAlloc/Free, report double/wild frees and leaks at exit (the REPL always tracks)", &cliParseNop},
     {str_lit("-repl"),      0, CLI_REPL, "-repl", "Start an interactive HolyC REPL on top of the JIT (aarch64 & x86_64)", &cliParseNop},
+    {str_lit("-lsp"),       0, CLI_LSP, "-lsp", "Run a Language Server Protocol server over stdio (for editor integration)", &cliParseNop},
     {str_lit("-o"),         1, CLI_OUTPUT_FILENAME, "-o <binary_name>", "Output filename: `-o <name> ./<file>.HC`", &cliParseString},
     {str_lit("-o-"),        0, CLI_TO_STDOUT, "-o-", "Output assembly to stdout, only for use with -S", &cliParseNop},
     {str_lit("-transpile"), 0, CLI_TRANSPILE, "-transpile", "Transpile the code to C, this is best effort", &cliParseNop},
@@ -451,6 +452,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
             case CLI_JIT:                args->jit = 1; break;
             case CLI_MEMSAFE:            args->memsafe = 1; break;
             case CLI_REPL:               args->repl = 1; break;
+            case CLI_LSP:                args->lsp = 1; break;
             case CLI_ASSEMBLE:           args->assemble = 1; break;
             case CLI_TRANSPILE:          args->transpile = 1; break;
             case CLI_TO_STDOUT:          args->to_stdout = 1; break;
@@ -507,8 +509,9 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
                  "printing assembly to stdout\n");
     }
 
-    /* The REPL reads from stdin - it's the one mode with no input file. */
-    if (args->infile == NULL && !args->repl) {
+    /* The REPL and the LSP read from stdin - the two modes with no
+     * input file. */
+    if (args->infile == NULL && !args->repl && !args->lsp) {
         cliNoInputFiles();
     }
     return 1;

--- a/src/cli.h
+++ b/src/cli.h
@@ -37,6 +37,7 @@ enum CliArgType {
     CLI_HELP,
     CLI_INSTALL_DIR,
     CLI_JIT,
+    CLI_LSP,
     CLI_MEMSAFE,
     CLI_MEM_STATS,
     CLI_OUTPUT_FILENAME,
@@ -87,6 +88,7 @@ typedef struct CliArgs {
     int emit_object;
     int run;
     int jit;
+    int lsp;
     int memsafe;
     int repl;
     int assemble;

--- a/src/containers.c
+++ b/src/containers.c
@@ -1419,6 +1419,27 @@ MapType map_cstring_opaque_type = {
     .value_type      = "void *",
 };
 
+static AoStr *mapAoStrValueToString(void *v) {
+    return aoStrDup((AoStr *)v);
+}
+
+static void mapAoStrValueRelease(void *v) {
+    aoStrRelease((AoStr *)v);
+}
+
+/* `Map<u32, AoStr *>` - e.g. Cctrl's file_map (file id -> filename). */
+MapType map_u32_to_aostr_type = {
+    .match           = mapIntKeyMatch,
+    .hash            = mapIntKeyHash,
+    .get_key_len     = mapIntKeyLen,
+    .key_to_string   = mapIntToString,
+    .key_release     = NULL,
+    .value_to_string = mapAoStrValueToString,
+    .value_release   = mapAoStrValueRelease,
+    .key_type        = "u32",
+    .value_type      = "AoStr *",
+};
+
 /* `Map<u64, u64>` */
 MapType map_uint_to_uint_type = {
     .match           = mapIntKeyMatch,

--- a/src/containers.h
+++ b/src/containers.h
@@ -178,6 +178,8 @@ extern MapType map_cstring_cstring_type;
 extern MapType map_cstring_opaque_type;
 /* `Map<u64, u64>` */
 extern MapType map_uint_to_uint_type;
+/* `Map<u32, AoStr *>` - e.g. Cctrl's file_map (file id -> filename) */
+extern MapType map_u32_to_aostr_type;
 
 /*================== Generic SET =============================================*/
 typedef struct Set Set;

--- a/src/holyc-lib/json.HC
+++ b/src/holyc-lib/json.HC
@@ -178,7 +178,8 @@ static I64 CountNumberLen(JsonParser *p, U8 *ptr, Bool *is_hex)
   U8 *start = ptr;
   I32 seen_e = 0, seen_dec = 0, seen_X = 0;
 
-  while (*ptr != ',' && *ptr != ']' && *ptr != '\0' && *ptr != '\n' && *ptr != ' ') {
+  while (*ptr != ',' && *ptr != ']' && *ptr != '}' && *ptr != '\0' &&
+         *ptr != '\n' && *ptr != '\r' && *ptr != '\t' && *ptr != ' ') {
     switch (*ptr) {
       case 'e':
       case 'E':

--- a/src/ir-debug.c
+++ b/src/ir-debug.c
@@ -620,7 +620,11 @@ AoStr *irBlockToString(IrFunction *func, IrBlock *bb) {
         listForEach(bb->instructions) {
             IrInstr *ir_instr = (IrInstr *)it->value;
             AoStr *ir_instr_str = irInstrToString(ir_instr);
-            aoStrCatFmt(buf, "    %S\n", ir_instr_str);
+            if (ir_instr->line)
+                aoStrCatFmt(buf, "    %S  ; line %i\n", ir_instr_str,
+                            ir_instr->line);
+            else
+                aoStrCatFmt(buf, "    %S\n", ir_instr_str);
             aoStrRelease(ir_instr_str);
         }
     }

--- a/src/ir-types.c
+++ b/src/ir-types.c
@@ -775,6 +775,8 @@ void irCtxAddFunction(IrCtx *ctx, IrFunction *func) {
     vecPush(ctx->prog->functions, func);
 }
 
+int ir_line_hint = 0;
+
 IrInstr *irInstrNew(IrOp op, IrValue *dst, IrValue *r1, IrValue *r2) {
     IrInstr *instr = irAlloc(sizeof(IrInstr));
     memset(instr, 0, sizeof(IrInstr));
@@ -783,6 +785,7 @@ IrInstr *irInstrNew(IrOp op, IrValue *dst, IrValue *r1, IrValue *r2) {
     instr->dst = dst;
     instr->r1 = r1;
     instr->r2 = r2;
+    instr->line = ir_line_hint;
     return instr;
 }
 

--- a/src/ir-types.h
+++ b/src/ir-types.h
@@ -293,6 +293,11 @@ struct IrInstr {
     IrValue *idx;
     u8 scale;
 
+    /* Source line of the Ast being lowered when this instruction was
+     * created (statement-level accuracy). 0 = unknown/synthetic. The
+     * JIT backends turn these into per-chunk pc->line tables. */
+    int line;
+
     union {
         IrBlockPair blocks;
         IrCmpKind cmp_kind;
@@ -498,6 +503,10 @@ Map *irVarValueMapNew(void);
 IrBlockMapping *irBlockMappingNew(int id);
 IrBlock *irBlockNew(void);
 IrValue *irTmp(IrValueType type, u16 size);
+/* Source line currently being lowered - set by ir.c's dispatchers
+ * from Ast->line, stamped onto every irInstrNew instruction. */
+extern int ir_line_hint;
+
 IrInstr *irInstrNew(IrOp op, IrValue *dst, IrValue *r1, IrValue *r2);
 IrFunction *irFunctionNew(AoStr *fname);
 IrValue *irValueNew(IrValueType type, IrValueKind kind);

--- a/src/ir.c
+++ b/src/ir.c
@@ -1725,6 +1725,11 @@ IrValue *irLowerUnOp(IrCtx *ctx, Ast *ast) {
 }
 
 IrValue *irExpr(IrCtx *ctx, Ast *ast) {
+    /* Variable references are SHARED Ast nodes stamped with their
+     * declaration line - letting them touch the hint would attribute
+     * the rest of the statement (and anything after) to the decl. */
+    if (ast && ast->line && ast->kind != AST_LVAR && ast->kind != AST_GVAR)
+        ir_line_hint = ast->line;
     switch (ast->kind) {
         case AST_BINOP: {
             if (astIsBinOpKind(ast, AST_BIN_OP_ASSIGN) ||
@@ -2427,6 +2432,8 @@ void irLowerSwitch(IrCtx *ctx, Ast *ast) {
 
 void irLowerAst(IrCtx *ctx, Ast *ast) {
     if (!ast) return;
+    if (ast->line && ast->kind != AST_LVAR && ast->kind != AST_GVAR)
+        ir_line_hint = ast->line;
 
     /* Once a block is sealed (it ended in ret/jmp/br) any subsequent
      * statement is unreachable; just drop it. AST_LABEL / AST_CASE /
@@ -2759,6 +2766,10 @@ static Set *irCollectEscapingLVars(Ast *ast_func) {
 }
 
 IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
+    /* Prologue instructions attribute to the definition, not to
+     * whatever line the previous function ended on. */
+    ir_line_hint = ast_func->line;
+
     IrFunction *func = irFunctionNew(ast_func->fname);
     IrBlock *entry = irBlockNew();
     IrBlock *exit_block = irBlockNew();

--- a/src/jit-common.c
+++ b/src/jit-common.c
@@ -562,10 +562,12 @@ int hccJitCompileChunk(HccJit *jit, Ast *extra_fn) {
      * (REPL inputs can add them at any point). */
     jitLoadSharedObjects(cc);
 
-    /* Reset the per-chunk encoder + internal-function set. */
+    /* Reset the per-chunk encoder + internal-function set. Pending
+     * line notes from a failed previous chunk die with it. */
     asm_enc_free(&jit->enc);
     asm_enc_init(&jit->enc);
     mapClear(jit->chunk_fns);
+    jit->n_pending = 0;
 
     /* First unconsumed nodes. The cursors advance immediately: even if
      * this chunk fails, the next call must not recompile its ASTs. */
@@ -663,6 +665,31 @@ int hccJitCompileChunk(HccJit *jit, Ast *extra_fn) {
     }
     listAppend(jit->chunks, code);
 
+    /* Rebase this chunk's pending (enc offset, line) notes onto the
+     * finalized mapping and publish them for pc->line lookups. */
+    if (jit->n_pending) {
+        if (jit->n_lines + jit->n_pending > jit->cap_lines) {
+            jit->cap_lines = jit->cap_lines ? jit->cap_lines * 2 : 128;
+            while (jit->cap_lines < jit->n_lines + jit->n_pending)
+                jit->cap_lines *= 2;
+            jit->lines = realloc(jit->lines,
+                    jit->cap_lines * sizeof(HccJitLine));
+        }
+        for (u32 i = 0; i < jit->n_pending; ++i) {
+            jit->lines[jit->n_lines].addr =
+                (uintptr_t)code->code + jit->pending_lines[i].addr;
+            jit->lines[jit->n_lines].line = jit->pending_lines[i].line;
+            /* HCC_DEBUG_LINES=1 dumps the table as chunks finalize -
+             * pairs with `Uf` output when debugging attribution. */
+            if (getenv("HCC_DEBUG_LINES"))
+                fprintf(stderr, "line-table: %p line %d\n",
+                        (void *)jit->lines[jit->n_lines].addr,
+                        jit->lines[jit->n_lines].line);
+            jit->n_lines++;
+        }
+        jit->n_pending = 0;
+    }
+
     /* Each public label now points at (code base + label byte_offset).
      * Register in `symbols` (hccJitLookup) and in `host_symbols` so
      * later chunks' emit-time addressing and finalize-time resolver
@@ -756,6 +783,45 @@ const char *hccJitFindSymbolForAddr(HccJit *jit, void *pc, size_t *off_out) {
     return best;
 }
 
+void hccJitNoteLine(HccJit *jit, int line) {
+    if (!jit || line <= 0) return;
+    /* Collapse runs: only the line CHANGES matter. */
+    if (jit->n_pending &&
+        jit->pending_lines[jit->n_pending - 1].line == line)
+    {
+        return;
+    }
+    if (jit->n_pending == jit->cap_pending) {
+        jit->cap_pending = jit->cap_pending ? jit->cap_pending * 2 : 64;
+        jit->pending_lines = realloc(jit->pending_lines,
+                jit->cap_pending * sizeof(HccJitLine));
+    }
+    jit->pending_lines[jit->n_pending].addr = (uintptr_t)jit->enc.len;
+    jit->pending_lines[jit->n_pending].line = line;
+    jit->n_pending++;
+}
+
+int hccJitFindLineForAddr(HccJit *jit, void *pc) {
+    if (!jit || !jit->lines) return 0;
+    AsmJitCode *chunk = hccJitFindChunk(jit, pc);
+    if (chunk == NULL) return 0;
+    uintptr_t lo = (uintptr_t)chunk->code;
+    uintptr_t hi = lo + chunk->size; /* veneers carry no lines */
+    uintptr_t p = (uintptr_t)pc;
+    if (p >= hi) return 0;
+    int best_line = 0;
+    uintptr_t best_addr = 0;
+    for (u32 i = 0; i < jit->n_lines; ++i) {
+        HccJitLine *e = &jit->lines[i];
+        if (e->addr < lo || e->addr >= hi) continue; /* other chunk */
+        if (e->addr <= p && e->addr >= best_addr) {
+            best_addr = e->addr;
+            best_line = e->line;
+        }
+    }
+    return best_line;
+}
+
 void hccJitDefineSymbol(HccJit *jit, const char *name, void *addr) {
     if (!jit || !name) return;
     /* Register BOTH spellings: HolyC-compiled call sites arrive
@@ -787,6 +853,8 @@ int hccJitRunMain(HccJit *jit, int argc, char **argv) {
 
 void hccJitFree(HccJit *jit) {
     if (!jit) return;
+    free(jit->lines);
+    free(jit->pending_lines);
     asm_enc_free(&jit->enc);
     if (jit->chunks) {
         listForEach(jit->chunks) {

--- a/src/jit-common.h
+++ b/src/jit-common.h
@@ -61,7 +61,21 @@ typedef struct HccJit {
     /* Per-function epilogue label local_num. Key = fn_uuid. */
     Map *epi_local;
     int  next_local;
+
+    /* pc -> source line. Backends note (enc offset, line) as they emit
+     * (pending_lines); hccJitCompileChunk rebases the offsets onto the
+     * finalized chunk's address and appends to `lines`. Consulted only
+     * when reporting (faults, memsafe), so a linear scan is fine. */
+    struct HccJitLine *lines;
+    u32 n_lines, cap_lines;
+    struct HccJitLine *pending_lines;
+    u32 n_pending, cap_pending;
 } HccJit;
+
+typedef struct HccJitLine {
+    uintptr_t addr; /* absolute pc in `lines`; enc offset in pending */
+    int line;
+} HccJitLine;
 
 /* What a per-arch backend plugs into the shared compile pipeline. */
 typedef struct HccJitBackend {
@@ -111,6 +125,14 @@ AsmJitCode *hccJitFindChunk(HccJit *jit, void *pc);
  * hccJitFindChunk to tell "veneer" from "not ours"). *off_out gets
  * pc - symbol. */
 const char *hccJitFindSymbolForAddr(HccJit *jit, void *pc, size_t *off_out);
+
+/* Record "code emitted from enc offset jit->enc.len onward is source
+ * line `line`" - called by the backends per IR instruction; consecutive
+ * duplicates collapse. line 0 (synthetic) is ignored. */
+void hccJitNoteLine(HccJit *jit, int line);
+
+/* Source line for a pc inside JIT code, 0 when unknown. */
+int hccJitFindLineForAddr(HccJit *jit, void *pc);
 
 /* Register a host-provided symbol (e.g. printf, malloc, a libtos hook)
  * so JITted code can call it. Overrides dlsym for that name. */

--- a/src/json-test.c
+++ b/src/json-test.c
@@ -1,0 +1,124 @@
+/* Unit tests for the hand-rolled JSON reader (json.c). Standalone:
+ *   cc -o json-test json-test.c json.c aostr.c arena.c memory.c mempool.c \
+ *      containers.c list.c util.c  (see the build line in the repo Makefile
+ *   comments if this drifts)
+ * Prints one PASSED/FAILED line per case and exits non-zero on failure. */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "arena.h"
+#include "aostr.h"
+#include "json.h"
+
+/* aostr.c/containers.c reference these from the wider compiler; stub
+ * them so the test links standalone. */
+int is_terminal = 0;
+void *astLValueToAoStr(void *ast, unsigned long flags) {
+    (void)ast; (void)flags;
+    return NULL;
+}
+
+static int g_failures = 0;
+
+static void check(int ok, const char *name) {
+    printf("%s: %s\n", ok ? "PASSED" : "FAILED", name);
+    if (!ok) g_failures++;
+}
+
+static Json *parse(Arena *a, const char *s) {
+    return jsonParse(a, s, strlen(s), NULL);
+}
+
+int main(void) {
+    Arena *a = arenaNew(1 << 16);
+
+    /* scalars */
+    Json *j = parse(a, "42");
+    check(j && j->kind == JSON_INT && j->as.i == 42, "int");
+    j = parse(a, "-7");
+    check(j && j->kind == JSON_INT && j->as.i == -7, "negative int");
+    j = parse(a, "3.5");
+    check(j && j->kind == JSON_FLOAT && j->as.f == 3.5, "float");
+    j = parse(a, "2e3");
+    check(j && j->kind == JSON_FLOAT && j->as.f == 2000.0, "exponent");
+    j = parse(a, "true");
+    check(j && j->kind == JSON_BOOL && j->as.boolean == 1, "true");
+    j = parse(a, "false");
+    check(j && j->kind == JSON_BOOL && j->as.boolean == 0, "false");
+    j = parse(a, "null");
+    check(j && j->kind == JSON_NULL, "null");
+
+    /* strings + escapes */
+    j = parse(a, "\"hi\"");
+    check(j && j->kind == JSON_STRING && strcmp(j->as.str, "hi") == 0,
+          "plain string");
+    j = parse(a, "\"a\\\"b\\\\c\\nd\\te\"");
+    check(j && strcmp(j->as.str, "a\"b\\c\nd\te") == 0, "escapes");
+    j = parse(a, "\"\\u0041\\u00e9\"");
+    check(j && strcmp(j->as.str, "A\xc3\xa9") == 0, "unicode escapes");
+    j = parse(a, "\"\\ud83d\\ude00\"");
+    check(j && strcmp(j->as.str, "\xf0\x9f\x98\x80") == 0,
+          "surrogate pair (emoji)");
+    j = parse(a, "\"tail\\\\\"");
+    check(j && strcmp(j->as.str, "tail\\") == 0,
+          "backslash before closing quote");
+
+    /* containers */
+    j = parse(a, "[1, 2, 3]");
+    check(j && j->kind == JSON_ARRAY && j->as.size == 3 &&
+          jsonArrayAt(j, 2) && jsonArrayAt(j, 2)->as.i == 3, "array");
+    j = parse(a, "[]");
+    check(j && j->kind == JSON_ARRAY && j->as.size == 0, "empty array");
+    j = parse(a, "{}");
+    check(j && j->kind == JSON_OBJECT && j->as.size == 0, "empty object");
+    j = parse(a, "{\"a\": 1, \"b\": \"x\"}");
+    check(j && jsonIntOr(j, "a", -1) == 1 &&
+          strcmp(jsonStrOr(j, "b", "?"), "x") == 0, "object accessors");
+    check(jsonObjGet(j, "missing") == NULL, "missing key");
+
+    /* an LSP-shaped message */
+    const char *msg =
+        "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"textDocument/didOpen\","
+        "\"params\":{\"textDocument\":{\"uri\":\"file:///a.HC\","
+        "\"languageId\":\"holyc\",\"version\":1,\"text\":\"U0 Main(){}\\n\"}}}";
+    j = parse(a, msg);
+    Json *td = jsonObjGet(jsonObjGet(j, "params"), "textDocument");
+    check(j && strcmp(jsonStrOr(j, "method", "?"),
+                      "textDocument/didOpen") == 0 &&
+          strcmp(jsonStrOr(td, "uri", "?"), "file:///a.HC") == 0 &&
+          strcmp(jsonStrOr(td, "text", "?"), "U0 Main(){}\n") == 0 &&
+          jsonIntOr(j, "id", -1) == 1,
+          "LSP didOpen shape");
+
+    /* malformed input must fail, not crash */
+    const char *bad[] = {
+        "", "{", "[1,", "{\"a\"}", "{\"a\":}", "\"unterminated",
+        "tru", "01x", "{\"a\":1}garbage", "\"\\u12g4\"", "-",
+    };
+    int all_bad_rejected = 1;
+    for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); ++i) {
+        if (parse(a, bad[i]) != NULL) {
+            printf("  accepted malformed: %s\n", bad[i]);
+            all_bad_rejected = 0;
+        }
+    }
+    check(all_bad_rejected, "malformed inputs rejected");
+
+    /* deep nesting must be refused, not overflow the stack */
+    AoStr *deep = aoStrNew();
+    for (int i = 0; i < 4096; ++i) aoStrPutChar(deep, '[');
+    check(jsonParse(a, deep->data, deep->len, NULL) == NULL,
+          "hostile nesting refused");
+    aoStrRelease(deep);
+
+    /* escaping round-trip */
+    AoStr *esc = aoStrNew();
+    jsonEscapeInto(esc, "a\"b\\c\nd\x01", 8);
+    check(strcmp(esc->data, "a\\\"b\\\\c\\nd\\u0001") == 0, "jsonEscapeInto");
+    aoStrRelease(esc);
+
+    arenaRelease(a);
+    printf("%s\n", g_failures ? "FAILURES" : "ALL PASSED");
+    return g_failures ? 1 : 0;
+}

--- a/src/json.c
+++ b/src/json.c
@@ -1,0 +1,373 @@
+/* Hand-rolled JSON reader - see json.h for scope and the arena
+ * ownership model. Recursive descent with a depth cap so hostile
+ * nesting can't blow the C stack. */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "aostr.h"
+#include "arena.h"
+#include "json.h"
+
+#define JSON_MAX_DEPTH 128
+
+typedef struct JsonParser {
+    const char *s;
+    size_t len;
+    size_t pos;
+    Arena *arena;
+    const char *err;
+    int depth;
+} JsonParser;
+
+static Json *jsonValue(JsonParser *p);
+
+static int jsonAtEnd(JsonParser *p) { return p->pos >= p->len; }
+static char jsonPeek(JsonParser *p) {
+    return jsonAtEnd(p) ? '\0' : p->s[p->pos];
+}
+
+static void jsonSkipWs(JsonParser *p) {
+    while (!jsonAtEnd(p)) {
+        char c = p->s[p->pos];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r') p->pos++;
+        else break;
+    }
+}
+
+static Json *jsonNode(JsonParser *p, JsonKind kind) {
+    Json *j = (Json *)arenaAlloc(p->arena, sizeof(Json));
+    memset(j, 0, sizeof(*j));
+    j->kind = kind;
+    return j;
+}
+
+static int jsonLiteral(JsonParser *p, const char *lit) {
+    size_t n = strlen(lit);
+    if (p->pos + n > p->len) return 0;
+    if (memcmp(p->s + p->pos, lit, n) != 0) return 0;
+    p->pos += n;
+    return 1;
+}
+
+static int jsonHex4(JsonParser *p, u32 *out) {
+    if (p->pos + 4 > p->len) return 0;
+    u32 v = 0;
+    for (int i = 0; i < 4; ++i) {
+        char c = p->s[p->pos + i];
+        v <<= 4;
+        if      (c >= '0' && c <= '9') v |= (u32)(c - '0');
+        else if (c >= 'a' && c <= 'f') v |= (u32)(c - 'a' + 10);
+        else if (c >= 'A' && c <= 'F') v |= (u32)(c - 'A' + 10);
+        else return 0;
+    }
+    p->pos += 4;
+    *out = v;
+    return 1;
+}
+
+static void jsonUtf8Encode(char *dst, u32 cp, u32 *n) {
+    if (cp < 0x80) {
+        dst[(*n)++] = (char)cp;
+    } else if (cp < 0x800) {
+        dst[(*n)++] = (char)(0xC0 | (cp >> 6));
+        dst[(*n)++] = (char)(0x80 | (cp & 0x3F));
+    } else if (cp < 0x10000) {
+        dst[(*n)++] = (char)(0xE0 | (cp >> 12));
+        dst[(*n)++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+        dst[(*n)++] = (char)(0x80 | (cp & 0x3F));
+    } else {
+        dst[(*n)++] = (char)(0xF0 | (cp >> 18));
+        dst[(*n)++] = (char)(0x80 | ((cp >> 12) & 0x3F));
+        dst[(*n)++] = (char)(0x80 | ((cp >> 6) & 0x3F));
+        dst[(*n)++] = (char)(0x80 | (cp & 0x3F));
+    }
+}
+
+/* Consumes the opening quote onward. The unescaped form is never
+ * longer than the raw span (\uXXXX: 6 bytes -> at most 4), so one
+ * arena allocation of the raw length always fits. */
+static int jsonString(JsonParser *p, char **out, u32 *out_len) {
+    p->pos++; /* '"' */
+    size_t start = p->pos;
+    /* Find the closing quote to size the buffer, honouring escape
+     * parity (`\\"` closes, `\"` doesn't). */
+    size_t end = start;
+    while (end < p->len && p->s[end] != '"') {
+        if (p->s[end] == '\\') end++; /* skip the escaped byte */
+        end++;
+    }
+    if (end >= p->len) {
+        p->err = "unterminated string";
+        return 0;
+    }
+
+    char *buf = (char *)arenaAlloc(p->arena, (u32)(end - start) + 1);
+    u32 n = 0;
+    while (!jsonAtEnd(p)) {
+        char c = p->s[p->pos];
+        if (c == '"') {
+            p->pos++;
+            buf[n] = '\0';
+            *out = buf;
+            *out_len = n;
+            return 1;
+        }
+        if (c != '\\') {
+            buf[n++] = c;
+            p->pos++;
+            continue;
+        }
+        p->pos++; /* '\' */
+        if (jsonAtEnd(p)) break;
+        char e = p->s[p->pos++];
+        switch (e) {
+            case '"':  buf[n++] = '"';  break;
+            case '\\': buf[n++] = '\\'; break;
+            case '/':  buf[n++] = '/';  break;
+            case 'b':  buf[n++] = '\b'; break;
+            case 'f':  buf[n++] = '\f'; break;
+            case 'n':  buf[n++] = '\n'; break;
+            case 'r':  buf[n++] = '\r'; break;
+            case 't':  buf[n++] = '\t'; break;
+            case 'u': {
+                u32 cp;
+                if (!jsonHex4(p, &cp)) {
+                    p->err = "bad \\u escape";
+                    return 0;
+                }
+                /* Surrogate pair: high followed by \uDC00-\uDFFF. */
+                if (cp >= 0xD800 && cp <= 0xDBFF &&
+                    p->pos + 6 <= p->len &&
+                    p->s[p->pos] == '\\' && p->s[p->pos + 1] == 'u')
+                {
+                    p->pos += 2;
+                    u32 lo;
+                    if (!jsonHex4(p, &lo) || lo < 0xDC00 || lo > 0xDFFF) {
+                        p->err = "bad surrogate pair";
+                        return 0;
+                    }
+                    cp = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                }
+                jsonUtf8Encode(buf, cp, &n);
+                break;
+            }
+            default:
+                p->err = "bad escape";
+                return 0;
+        }
+    }
+    p->err = "unterminated string";
+    return 0;
+}
+
+static Json *jsonNumber(JsonParser *p) {
+    size_t start = p->pos;
+    int is_float = 0;
+    if (jsonPeek(p) == '-') p->pos++;
+    while (!jsonAtEnd(p)) {
+        char c = p->s[p->pos];
+        if (c >= '0' && c <= '9') {
+            p->pos++;
+            continue;
+        }
+        if (c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+            is_float = 1;
+            p->pos++;
+            continue;
+        }
+        break;
+    }
+    if (p->pos == start || (p->pos == start + 1 && p->s[start] == '-')) {
+        p->err = "bad number";
+        return NULL;
+    }
+    /* strtoll/strtod stop at the first non-numeric byte, so pointing
+     * them at the slice start (NUL-free) is safe. */
+    Json *j;
+    if (is_float) {
+        j = jsonNode(p, JSON_FLOAT);
+        j->as.f = strtod(p->s + start, NULL);
+    } else {
+        j = jsonNode(p, JSON_INT);
+        j->as.i = (s64)strtoll(p->s + start, NULL, 10);
+    }
+    return j;
+}
+
+static Json *jsonArray(JsonParser *p) {
+    p->pos++; /* '[' */
+    Json *j = jsonNode(p, JSON_ARRAY);
+    JsonPair *tail = NULL;
+    jsonSkipWs(p);
+    if (jsonPeek(p) == ']') {
+        p->pos++;
+        return j;
+    }
+    for (;;) {
+        Json *v = jsonValue(p);
+        if (v == NULL) return NULL;
+        JsonPair *pair = (JsonPair *)arenaAlloc(p->arena, sizeof(JsonPair));
+        pair->key = NULL;
+        pair->value = v;
+        pair->next = NULL;
+        if (tail) tail->next = pair;
+        else      j->as.head = pair;
+        tail = pair;
+        j->as.size++;
+
+        jsonSkipWs(p);
+        char c = jsonPeek(p);
+        if (c == ',') { p->pos++; continue; }
+        if (c == ']') { p->pos++; return j; }
+        p->err = "expected ',' or ']'";
+        return NULL;
+    }
+}
+
+static Json *jsonObject(JsonParser *p) {
+    p->pos++; /* '{' */
+    Json *j = jsonNode(p, JSON_OBJECT);
+    JsonPair *tail = NULL;
+    jsonSkipWs(p);
+    if (jsonPeek(p) == '}') {
+        p->pos++;
+        return j;
+    }
+    for (;;) {
+        jsonSkipWs(p);
+        if (jsonPeek(p) != '"') {
+            p->err = "expected object key";
+            return NULL;
+        }
+        char *key;
+        u32 key_len;
+        if (!jsonString(p, &key, &key_len)) return NULL;
+        jsonSkipWs(p);
+        if (jsonPeek(p) != ':') {
+            p->err = "expected ':'";
+            return NULL;
+        }
+        p->pos++;
+        Json *v = jsonValue(p);
+        if (v == NULL) return NULL;
+
+        JsonPair *pair = (JsonPair *)arenaAlloc(p->arena, sizeof(JsonPair));
+        pair->key = key;
+        pair->value = v;
+        pair->next = NULL;
+        if (tail) tail->next = pair;
+        else      j->as.head = pair;
+        tail = pair;
+        j->as.size++;
+
+        jsonSkipWs(p);
+        char c = jsonPeek(p);
+        if (c == ',') { p->pos++; continue; }
+        if (c == '}') { p->pos++; return j; }
+        p->err = "expected ',' or '}'";
+        return NULL;
+    }
+}
+
+static Json *jsonValue(JsonParser *p) {
+    if (++p->depth > JSON_MAX_DEPTH) {
+        p->err = "nesting too deep";
+        return NULL;
+    }
+    jsonSkipWs(p);
+    Json *j = NULL;
+    char c = jsonPeek(p);
+    if (c == '{') {
+        j = jsonObject(p);
+    } else if (c == '[') {
+        j = jsonArray(p);
+    } else if (c == '"') {
+        char *s;
+        u32 n;
+        if (jsonString(p, &s, &n)) {
+            j = jsonNode(p, JSON_STRING);
+            j->as.str = s;
+            j->as.str_len = n;
+        }
+    } else if (c == 't') {
+        if (jsonLiteral(p, "true")) {
+            j = jsonNode(p, JSON_BOOL);
+            j->as.boolean = 1;
+        } else p->err = "bad literal";
+    } else if (c == 'f') {
+        if (jsonLiteral(p, "false")) {
+            j = jsonNode(p, JSON_BOOL);
+            j->as.boolean = 0;
+        } else p->err = "bad literal";
+    } else if (c == 'n') {
+        if (jsonLiteral(p, "null")) j = jsonNode(p, JSON_NULL);
+        else p->err = "bad literal";
+    } else if (c == '-' || (c >= '0' && c <= '9')) {
+        j = jsonNumber(p);
+    } else {
+        p->err = jsonAtEnd(p) ? "unexpected end of input"
+                              : "unexpected character";
+    }
+    p->depth--;
+    return j;
+}
+
+Json *jsonParse(Arena *arena, const char *s, size_t len, const char **err) {
+    JsonParser p = { .s = s, .len = len, .pos = 0, .arena = arena,
+                     .err = NULL, .depth = 0 };
+    Json *j = jsonValue(&p);
+    if (j) {
+        jsonSkipWs(&p);
+        if (!jsonAtEnd(&p)) {
+            p.err = "trailing bytes after value";
+            j = NULL;
+        }
+    }
+    if (err) *err = p.err;
+    return j;
+}
+
+Json *jsonObjGet(Json *obj, const char *key) {
+    if (obj == NULL || obj->kind != JSON_OBJECT) return NULL;
+    for (JsonPair *p = obj->as.head; p; p = p->next) {
+        if (p->key && strcmp(p->key, key) == 0) return p->value;
+    }
+    return NULL;
+}
+
+Json *jsonArrayAt(Json *arr, u32 idx) {
+    if (arr == NULL || arr->kind != JSON_ARRAY || idx >= arr->as.size)
+        return NULL;
+    JsonPair *p = arr->as.head;
+    while (idx--) p = p->next;
+    return p->value;
+}
+
+const char *jsonStrOr(Json *obj, const char *key, const char *dflt) {
+    Json *v = jsonObjGet(obj, key);
+    return (v && v->kind == JSON_STRING) ? v->as.str : dflt;
+}
+
+s64 jsonIntOr(Json *obj, const char *key, s64 dflt) {
+    Json *v = jsonObjGet(obj, key);
+    return (v && v->kind == JSON_INT) ? v->as.i : dflt;
+}
+
+void jsonEscapeInto(AoStr *buf, const char *s, size_t len) {
+    for (size_t i = 0; i < len; ++i) {
+        unsigned char c = (unsigned char)s[i];
+        switch (c) {
+            case '"':  aoStrCatLen(buf, "\\\"", 2); break;
+            case '\\': aoStrCatLen(buf, "\\\\", 2); break;
+            case '\b': aoStrCatLen(buf, "\\b", 2);  break;
+            case '\f': aoStrCatLen(buf, "\\f", 2);  break;
+            case '\n': aoStrCatLen(buf, "\\n", 2);  break;
+            case '\r': aoStrCatLen(buf, "\\r", 2);  break;
+            case '\t': aoStrCatLen(buf, "\\t", 2);  break;
+            default:
+                if (c < 0x20) aoStrCatPrintf(buf, "\\u%04x", c);
+                else          aoStrPutChar(buf, (char)c);
+        }
+    }
+}

--- a/src/json.h
+++ b/src/json.h
@@ -1,0 +1,79 @@
+#ifndef JSON_H__
+#define JSON_H__
+
+#include <stddef.h>
+
+#include "aostr.h"
+#include "arena.h"
+#include "types.h"
+
+/* Small hand-rolled JSON reader for the LSP (see lsp.c). Scoped to
+ * what LSP traffic actually contains: objects, arrays, strings with
+ * full escape/\uXXXX handling, 64-bit ints, doubles, bools, null. No
+ * comments, no NaN/Inf. Every node and string is allocated from the
+ * caller's Arena, so an entire message tree is freed by clearing the
+ * arena - there is no per-node release.
+ *
+ * Emission needs no counterpart: responses are built with
+ * aoStrCatPrintf plus jsonEscapeInto for string payloads. */
+
+typedef enum JsonKind {
+    JSON_NULL,
+    JSON_BOOL,
+    JSON_INT,
+    JSON_FLOAT,
+    JSON_STRING,
+    JSON_ARRAY,
+    JSON_OBJECT,
+} JsonKind;
+
+typedef struct Json Json;
+typedef struct JsonPair JsonPair;
+
+/* Object member or array element; arena-allocated singly linked
+ * chain. `key` is NULL for array elements. */
+struct JsonPair {
+    char *key;
+    Json *value;
+    JsonPair *next;
+};
+
+struct Json {
+    JsonKind kind;
+    union {
+        int boolean;
+        s64 i;
+        double f;
+        struct {
+            char *str; /* unescaped, NUL-terminated, arena-owned */
+            u32 str_len;
+        };
+        struct {
+            JsonPair *head; /* object members / array elements */
+            u32 size;
+        };
+    } as;
+};
+
+/* Parse `len` bytes of JSON. Returns NULL on malformed input, with
+ * *err (when non-NULL) pointing at a static description. */
+Json *jsonParse(Arena *arena, const char *s, size_t len, const char **err);
+
+/* NULL when `obj` isn't an object or lacks `key`. Linear scan - LSP
+ * objects are small. */
+Json *jsonObjGet(Json *obj, const char *key);
+
+/* NULL when `arr` isn't an array or idx is out of range. */
+Json *jsonArrayAt(Json *arr, u32 idx);
+
+/* Typed conveniences over jsonObjGet; the default is returned on any
+ * shape mismatch. The string is arena-owned - copy it to keep it
+ * beyond the message. */
+const char *jsonStrOr(Json *obj, const char *key, const char *dflt);
+s64 jsonIntOr(Json *obj, const char *key, s64 dflt);
+
+/* Append `len` bytes of `s` onto `buf`, JSON-escaped (quotes NOT
+ * added by this helper). */
+void jsonEscapeInto(AoStr *buf, const char *s, size_t len);
+
+#endif

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -711,6 +711,7 @@ void lexPushFile(Lexer *l, AoStr *filename) {
     f->lineno = 1;
     f->line_start_ptr = src_code->data;
     f->filename = filename;
+    f->file_id = 0; /* registered lazily by cctrlTokenGet */
     setAdd(l->seen_files,filename->data);
     if (l->cur_file) {
         /* Snapshot the outgoing file's cursor state so column maths
@@ -744,6 +745,7 @@ void lexPushString(Lexer *l, char *name, char *src, s64 len) {
     f->lineno = 1;
     f->line_start_ptr = src_code->data;
     f->filename = aoStrDupRaw(name, strlen(name));
+    f->file_id = 0; /* registered lazily by cctrlTokenGet */
     if (l->cur_file) {
         l->cur_file->ptr = l->ptr;
         l->cur_file->lineno = l->lineno;
@@ -778,12 +780,14 @@ static void lexSkipCodeComment(Lexer *l) {
             }
             l->ptr++;
         }
-        /* Walked off EOF without seeing the closing delimiter.
-         * Bail here rather than silently returning, which leaves
-         * the parser staring at an empty token stream and crashing
-         * on the next peek. */
-        l->lineno = start_line;
-        lexRaise(l, "unterminated block comment");
+        /* Walked off EOF without seeing the closing delimiter: treat
+         * the comment as running to EOF and keep going. This is the
+         * editor reality (the user just typed the opener) - and
+         * raising here proved fatal to embedders: the raise can fire
+         * during token PREFILL when no recovery point is armed, and
+         * cctrlTerminate's fallback is exit(). The parser reports the
+         * truncated input on its own. */
+        (void)start_line;
     }
 }
 
@@ -1100,6 +1104,19 @@ int lexNumeric(Lexer *l, int _isfloat) {
 LexerType *lexPreProcDirective(Lexer *l) {
     Lexeme le;
     if (!lex(l,&le)) return 0;
+
+    /* TempleOS documentation/assertion directives: `#help_index "..."`,
+     * `#help_file "..."` and `#assert <expr>` have no meaning here -
+     * consume to end of line so TempleOS-origin sources parse. NULL
+     * tells the caller to keep lexing. */
+    if ((le.len == 10 && !memcmp(le.start, str_lit("help_index"))) ||
+        (le.len == 9  && !memcmp(le.start, str_lit("help_file")))  ||
+        (le.len == 6  && !memcmp(le.start, str_lit("assert"))))
+    {
+        while (*l->ptr != '\0' && *l->ptr != '\n') l->ptr++;
+        return NULL;
+    }
+
     char buffer[32];
     s64 len = snprintf(buffer,sizeof(buffer),"#%.*s",le.len,le.start);
     LexerType *type = mapGetLen(l->symbol_table,buffer,len);
@@ -1406,6 +1423,11 @@ static int lexCore(Lexer *l, Lexeme *le) {
                     return 1;
                 }
                 type = lexPreProcDirective(l);
+                if (type == NULL) {
+                    /* Skipped directive (#help_index et al) - the
+                     * line is consumed; hand back the next token. */
+                    return lex(l, le);
+                }
                 le->tk_type = TK_KEYWORD;
                 le->i64 = type->kind;
                 return 1;
@@ -1484,6 +1506,24 @@ void lexInclude(Lexer *l) {
         aoStrRelease(ident);
     } else if (next.tk_type == TK_STR) {
         include_path = aoStrDupRaw(next.start, next.len);
+        /* Resolve a relative include against the INCLUDING file's
+         * directory, not the process cwd - and record the joined path
+         * so consumers (LSP uris, diagnostics) get a real location.
+         * Absolute includes pass through untouched. */
+        if (include_path->data[0] != '/' && l->cur_file &&
+            l->cur_file->filename)
+        {
+            char *base = l->cur_file->filename->data;
+            char *slash = strrchr(base, '/');
+            if (slash) {
+                const char *rel = include_path->data;
+                if (rel[0] == '.' && rel[1] == '/') rel += 2;
+                AoStr *joined = aoStrPrintf("%.*s/%s",
+                        (int)(slash - base), base, rel);
+                aoStrRelease(include_path);
+                include_path = joined;
+            }
+        }
     } else {
         lexRaise(l,
                 "Syntax is: #include \"<value>\" got: %s",
@@ -1607,6 +1647,12 @@ Lexeme *lexDefine(Map *macro_defs, Lexer *l) {
     /* Turn off the flag */
     l->flags &= ~CCF_ACCEPT_NEWLINES;
 
+    if (tokens->size == 0) {
+        /* `#define NAME` then newline/EOF: a bare flag define. */
+        mapAdd(macro_defs,ident->data,lexemeSentinal());
+        vecRelease(tokens);
+        return NULL;
+    }
     start = tokens->entries[0]; 
     end = tokens->entries[tokens->size - 1];
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -196,6 +196,9 @@ struct Cctrl;
 
 typedef struct LexFile {
     AoStr *filename; /* name of the file */
+    /* cctrlRegisterFile id, assigned lazily on first token consumed
+     * from this file; 0 = not yet registered. */
+    u32 file_id;
     char *ptr; /* Where we are in the file */
     int lineno; /* line number in the file */
     /* First byte of the current line in `src->data`. Saved/restored

--- a/src/lsp.c
+++ b/src/lsp.c
@@ -1,0 +1,1284 @@
+/* LSP server - see lsp.h for scope.
+ *
+ * Model: ONE persistent Cctrl with CCTRL_REPL set (redefinition
+ * replaces instead of erroring - the REPL's proven trick), full
+ * document text stored per uri, and a full re-parse per change.
+ * There is no incremental compilation and no symbol invalidation to
+ * get wrong; hcc's parser is fast enough for HolyC-sized files that
+ * "reparse the world" IS the incremental strategy.
+ *
+ * Every parse is wrapped in a signal guard: the server is fed
+ * half-typed garbage at keystroke rate, so a parser crash becomes a
+ * diagnostic on the document (plus a fresh Cctrl, since the old one's
+ * state is suspect) rather than a dead server.
+ *
+ * The guard alone is not enough - see lspCanaryParse: every input is
+ * first parsed in a fork()ed child, and only inputs that don't kill
+ * the child are parsed by the persistent Cctrl.
+ *
+ * Positions: we advertise positionEncoding utf-8 (LSP 3.17). Clients
+ * stuck on utf-16 will see columns drift on lines containing
+ * multibyte characters - exact for ASCII HolyC. */
+
+#include <ctype.h>
+#include <limits.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <setjmp.h>
+#include <signal.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <sys/wait.h>
+#include <time.h>
+#include <unistd.h>
+
+#include "aostr.h"
+#include "arena.h"
+#include "ast.h"
+#include "cctrl.h"
+#include "cli.h"
+#include "containers.h"
+#include "json.h"
+#include "lexer.h"
+#include "lsp.h"
+#include "parser.h"
+#include "util.h"
+#include "version.h"
+
+/* ---------------- state ---------------- */
+
+/* Everything the server knows, threaded through every handler. The
+ * one instance lives on lspRun's stack. */
+typedef struct LspCtx {
+    Cctrl *cc;              /* the ONE persistent compiler */
+    int cc_dirty;           /* crashed mid-parse; rebuild under guard */
+    Map *docs;              /* uri (char*) -> AoStr* text */
+    char *root_dir;         /* builtin include root for <...> */
+    enum CliTarget target;
+    int shutdown_requested;
+    int log_on;
+    Vec *pending;           /* uris awaiting a debounced analyze */
+    s64 pending_since_ms;   /* when the oldest pending uri landed */
+} LspCtx;
+
+/* Crash guard around parses. Stays global: the signal handler gets no
+ * context argument. */
+static sigjmp_buf lsp_parse_env;
+static volatile sig_atomic_t lsp_in_parse = 0;
+static volatile int lsp_crash_sig = 0;
+
+static void lspLog(LspCtx *ctx, const char *fmt, ...) {
+    if (!ctx->log_on) return;
+    va_list ap;
+    va_start(ap, fmt);
+    vfprintf(stderr, fmt, ap);
+    va_end(ap);
+    fputc('\n', stderr);
+}
+
+/* ---------------- transport ---------------- */
+
+/* One framed message: `Content-Length: N\r\n...\r\n\r\n<N bytes>`.
+ * Returns a malloc'd body (caller frees) or NULL on EOF/garbage. */
+static char *lspReadMessage(size_t *len_out) {
+    char header[512];
+    long content_length = -1;
+    for (;;) {
+        if (fgets(header, sizeof(header), stdin) == NULL) return NULL;
+        if (strcmp(header, "\r\n") == 0 || strcmp(header, "\n") == 0) break;
+        if (strncasecmp(header, "Content-Length:", 15) == 0) {
+            content_length = strtol(header + 15, NULL, 10);
+        }
+        /* Content-Type etc.: ignored. */
+    }
+    if (content_length <= 0 || content_length > (64 << 20)) return NULL;
+    char *body = (char *)malloc((size_t)content_length + 1);
+    size_t got = fread(body, 1, (size_t)content_length, stdin);
+    if (got != (size_t)content_length) {
+        free(body);
+        return NULL;
+    }
+    body[content_length] = '\0';
+    *len_out = (size_t)content_length;
+    return body;
+}
+
+static void lspWrite(AoStr *body) {
+    printf("Content-Length: %llu\r\n\r\n%s",
+           (unsigned long long)body->len, body->data);
+    fflush(stdout);
+}
+
+/* JSON-RPC ids may be numbers or strings; re-emit whichever came in. */
+static void lspCatId(AoStr *buf, Json *id) {
+    if (id == NULL || id->kind == JSON_NULL) {
+        aoStrCatLen(buf, "null", 4);
+    } else if (id->kind == JSON_STRING) {
+        aoStrPutChar(buf, '"');
+        jsonEscapeInto(buf, id->as.str, id->as.str_len);
+        aoStrPutChar(buf, '"');
+    } else {
+        aoStrCatPrintf(buf, "%lld", (long long)id->as.i);
+    }
+}
+
+/* `result` is spliced in verbatim - build it with jsonEscapeInto for
+ * any string payloads. */
+static void lspRespond(Json *id, const char *result) {
+    AoStr *body = aoStrNew();
+    aoStrCatPrintf(body, "{\"jsonrpc\":\"2.0\",\"id\":");
+    lspCatId(body, id);
+    aoStrCatPrintf(body, ",\"result\":%s}", result);
+    lspWrite(body);
+    aoStrRelease(body);
+}
+
+static void lspRespondError(Json *id, int code, const char *message) {
+    AoStr *body = aoStrNew();
+    aoStrCatPrintf(body, "{\"jsonrpc\":\"2.0\",\"id\":");
+    lspCatId(body, id);
+    aoStrCatPrintf(body, ",\"error\":{\"code\":%d,\"message\":\"", code);
+    jsonEscapeInto(body, message, strlen(message));
+    aoStrCatPrintf(body, "\"}}");
+    lspWrite(body);
+    aoStrRelease(body);
+}
+
+/* ---------------- uris ---------------- */
+
+/* file:///a%20b.HC -> /a b.HC. Everything else passes through. */
+static char *lspUriToPath(const char *uri) {
+    const char *p = uri;
+    if (strncmp(p, str_lit("file://")) == 0) p += 7;
+    size_t n = strlen(p);
+    char *out = (char *)malloc(n + 1);
+    size_t o = 0;
+    for (size_t i = 0; i < n; ++i) {
+        if (p[i] == '%' && i + 2 < n + 1 && i + 2 < n) {
+            int hi = p[i + 1], lo = p[i + 2];
+            int h = (hi >= '0' && hi <= '9') ? hi - '0'
+                  : (hi >= 'a' && hi <= 'f') ? hi - 'a' + 10
+                  : (hi >= 'A' && hi <= 'F') ? hi - 'A' + 10 : -1;
+            int l = (lo >= '0' && lo <= '9') ? lo - '0'
+                  : (lo >= 'a' && lo <= 'f') ? lo - 'a' + 10
+                  : (lo >= 'A' && lo <= 'F') ? lo - 'A' + 10 : -1;
+            if (h >= 0 && l >= 0) {
+                out[o++] = (char)((h << 4) | l);
+                i += 2;
+                continue;
+            }
+        }
+        out[o++] = p[i];
+    }
+    out[o] = '\0';
+    return out;
+}
+
+/* ---------------- the compiler ---------------- */
+
+static void lspCrashHandler(int sig, siginfo_t *si, void *uc) {
+    (void)si;
+    (void)uc;
+    if (lsp_in_parse) {
+        lsp_crash_sig = sig;
+        lsp_in_parse = 0;
+        siglongjmp(lsp_parse_env, 1);
+    }
+    signal(sig, SIG_DFL);
+}
+
+static void lspInstallCrashHandlers(void) {
+    struct sigaction sa;
+    memset(&sa, 0, sizeof(sa));
+    sa.sa_sigaction = lspCrashHandler;
+    sa.sa_flags = SA_SIGINFO;
+    sigemptyset(&sa.sa_mask);
+    static const int sigs[] = { SIGSEGV, SIGBUS, SIGILL, SIGFPE, SIGABRT,
+                                SIGTRAP };
+    for (size_t i = 0; i < sizeof(sigs) / sizeof(sigs[0]); ++i)
+        sigaction(sigs[i], &sa, NULL);
+}
+
+/* Parse the stdlib header so MAlloc/StrNew/... exist - without this
+ * every stdlib call in every document gets a false "not defined"
+ * squiggle, and hover/completion have nothing to serve. Mirrors
+ * replBootstrap; stdlib diagnostics are discarded. */
+static void lspBootstrap(LspCtx *ctx, Cctrl *cc) {
+    AoStr *builtin = aoStrPrintf("%stos.HH", ctx->root_dir);
+    if (access(builtin->data, R_OK) != 0) {
+        lspLog(ctx, "lsp: %s not found; stdlib symbols unavailable",
+               builtin->data);
+        aoStrRelease(builtin);
+        return;
+    }
+    Lexer *l = (Lexer *)malloc(sizeof(Lexer));
+    lexInit(l, NULL, CCF_PRE_PROC);
+    l->cc = cc; /* lex-time raises route through diagnostics, not exit */
+    lexSetBuiltinRoot(l, ctx->root_dir);
+    lexPushFile(l, builtin);
+
+    cctrlDiagClear(cc);
+    cctrlResetTokenBuffer(cc);
+    jmp_buf lex_recovery;
+    jmp_buf *prev_recovery = cc->current_recovery;
+    cc->current_recovery = &lex_recovery;
+    if (setjmp(lex_recovery) == 0) {
+        cctrlInitParse(cc, l);
+        parseToAst(cc);
+    }
+    cc->current_recovery = prev_recovery;
+    cctrlDiagClear(cc);
+    lexerRelease(l);
+}
+
+static Cctrl *lspFreshCctrl(LspCtx *ctx) {
+    Cctrl *cc = cctrlNew(ctx->target);
+    cc->flags |= CCTRL_REPL; /* redefinition replaces - re-parses work */
+    cctrlAddDefine(cc, "__HCC_AOT__");
+    lspBootstrap(ctx, cc);
+    return cc;
+}
+
+/* Parse `text` as `path`, leaving diagnostics on ctx->cc->diagnostics.
+ * Returns 0 normally, the killing signal if the parser crashed. */
+static int lspParse(LspCtx *ctx, const char *path, AoStr *text) {
+    Lexer *l = (Lexer *)malloc(sizeof(Lexer));
+    lexInit(l, NULL, CCF_PRE_PROC);
+    l->cc = ctx->cc; /* lex-time raises route through diagnostics */
+    lexSetBuiltinRoot(l, ctx->root_dir);
+    lexPushString(l, (char *)path, text->data, text->len);
+
+    cctrlDiagClear(ctx->cc);
+    cctrlResetTokenBuffer(ctx->cc);
+
+    int crashed = 0;
+    lsp_crash_sig = 0;
+    if (sigsetjmp(lsp_parse_env, 1) == 0) {
+        lsp_in_parse = 1;
+        /* A previous parse crashed: rebuild the Cctrl HERE, inside the
+         * guard - the rebuild re-parses the stdlib header through the
+         * same possibly-corrupted globals and can crash too. The old
+         * Cctrl leaks (they have no release), the right trade against
+         * corrupting every later parse. */
+        if (ctx->cc_dirty) {
+            ctx->cc = lspFreshCctrl(ctx);
+            ctx->cc_dirty = 0;
+        }
+        /* Lex-time raises longjmp through cc->current_recovery; give
+         * them somewhere to land (mirrors replParse). */
+        jmp_buf lex_recovery;
+        jmp_buf *prev_recovery = ctx->cc->current_recovery;
+        ctx->cc->current_recovery = &lex_recovery;
+        if (setjmp(lex_recovery) == 0) {
+            cctrlInitParse(ctx->cc, l);
+            parseToAst(ctx->cc);
+        }
+        ctx->cc->current_recovery = prev_recovery;
+    } else {
+        crashed = lsp_crash_sig;
+        ctx->cc_dirty = 1;
+    }
+    lsp_in_parse = 0;
+    lexerRelease(l);
+    return crashed;
+}
+
+/* The signal guard makes a parser crash survivable but not clean:
+ * siglongjmp rewinds control flow while the heap keeps whatever
+ * half-finished state the crash interrupted (an arena mid-bump, a
+ * pool mid-link, a malloc mid-splice), and after enough recoveries
+ * some allocation outside the guard dies. A process boundary is the
+ * only real undo, so every input is first parsed in a fork()ed
+ * child - a copy-on-write clone whose compiler state is
+ * byte-identical to the parent's, answering "would this crash us?"
+ * with perfect fidelity, its exit status the only IPC. The parent
+ * parses an input only after its canary comes back clean; a crashing
+ * input never touches the parent's heap, which keeps serving hover/
+ * definition/completion from the last good parse. Fork-safety is
+ * free (the server is single-threaded); the cost is a CoW fork and
+ * a duplicate parse per change - negligible at HolyC file sizes. */
+
+/* Wildly generous next to ~1ms parses, but a rebuild-after-crash
+ * re-parses the whole stdlib header first. */
+#define HCC_LSP_CANARY_TIMEOUT_SECS 5
+
+static int lspCanaryParse(LspCtx *ctx, const char *path, AoStr *text) {
+    fflush(stdout);
+    pid_t pid = fork();
+    if (pid < 0) {
+        lspLog(ctx, "lsp: fork failed; parsing unisolated");
+        return lspParse(ctx, path, text);
+    }
+    if (pid == 0) {
+        /* A crashing child's buffered stdio must never reach the LSP
+         * transport - point stdout at the void. The parse stays
+         * guarded here so a crash becomes a quiet exit code rather
+         * than a crash report per keystroke. */
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) dup2(devnull, STDOUT_FILENO);
+        /* A parser infinite loop would otherwise hang child and
+         * parent alike. SIGALRM isn't in the crash handler's set, so
+         * its default disposition kills the child and the parent
+         * sees WIFSIGNALED - a hang reports like any other crash. */
+        alarm(HCC_LSP_CANARY_TIMEOUT_SECS);
+        _exit(lspParse(ctx, path, text) & 0x7f);
+    }
+    int status = 0;
+    while (waitpid(pid, &status, 0) < 0) {
+        if (errno == EINTR) continue;
+        lspLog(ctx, "lsp: waitpid failed; parsing unisolated");
+        return lspParse(ctx, path, text);
+    }
+    if (WIFSIGNALED(status)) return WTERMSIG(status); /* guard missed */
+    if (WIFEXITED(status) && WEXITSTATUS(status) != 0)
+        return WEXITSTATUS(status);                   /* guard caught */
+    /* Proven safe against exactly the state the parent has. The
+     * parent's own guard stays armed as belt-and-braces. */
+    return lspParse(ctx, path, text);
+}
+
+/* ---------------- diagnostics ---------------- */
+
+static int lspSeverity(int cctrl_severity) {
+    switch (cctrl_severity) {
+        case CCTRL_WARN: return 2; /* Warning */
+        case CCTRL_INFO: return 3; /* Information */
+        default:         return 1; /* Error (incl. ICE) */
+    }
+}
+
+/* 1-based (or 0 = unknown) -> 0-based, clamped. */
+static int lspZero(int v) {
+    return v > 0 ? v - 1 : 0;
+}
+
+static void lspCatDiagnostic(AoStr *body, CctrlDiagnostic *d,
+                             int remote_file, const char *remote_name) {
+    int sl = lspZero(d->line);
+    int sc = lspZero(d->col);
+    int el = lspZero(d->end_line);
+    int ec = lspZero(d->end_col);
+    if (remote_file) {
+        /* Fault is in an #include - pin it to the top of the open
+         * document and name the real location in the message. */
+        sl = sc = el = 0;
+        ec = 1;
+    } else if (el < sl || (el == sl && ec <= sc)) {
+        el = sl;
+        ec = sc + 1;
+    }
+    aoStrCatPrintf(body,
+        "{\"range\":{\"start\":{\"line\":%d,\"character\":%d},"
+        "\"end\":{\"line\":%d,\"character\":%d}},"
+        "\"severity\":%d,\"source\":\"hcc\",\"message\":\"",
+        sl, sc, el, ec, lspSeverity(d->severity));
+    if (remote_file) {
+        AoStr *loc = aoStrPrintf("in included file %s:%d: ",
+                                 remote_name, d->line);
+        jsonEscapeInto(body, loc->data, loc->len);
+        aoStrRelease(loc);
+    }
+    /* The stored message is the terminal rendering: severity prefix,
+     * then a `--> file:line` caret diagram. In an editor the range
+     * and severity already say all that - keep the first line only,
+     * minus the prefix. */
+    const char *m = d->message->data;
+    size_t mlen = d->message->len;
+    if (strncmp(m, str_lit("error: ")) == 0)        { m += 7; mlen -= 7; }
+    else if (strncmp(m, str_lit("warning: ")) == 0) { m += 9; mlen -= 9; }
+    const char *nl = memchr(m, '\n', mlen);
+    if (nl) mlen = (size_t)(nl - m);
+    jsonEscapeInto(body, m, mlen);
+    if (d->suggestion) {
+        aoStrCatLen(body, "\\n", 2);
+        jsonEscapeInto(body, d->suggestion->data, d->suggestion->len);
+    }
+    aoStrCatPrintf(body, "\"}");
+}
+
+static void lspPublishDiagnostics(LspCtx *ctx, const char *uri,
+                                  const char *path) {
+    AoStr *body = aoStrNew();
+    aoStrCatPrintf(body,
+        "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\","
+        "\"params\":{\"uri\":\"");
+    jsonEscapeInto(body, uri, strlen(uri));
+    aoStrCatPrintf(body, "\",\"diagnostics\":[");
+
+    int emitted = 0;
+    Vec *diags = ctx->cc->diagnostics;
+    for (u64 i = 0; diags && i < diags->size; ++i) {
+        CctrlDiagnostic *d = vecGet(CctrlDiagnostic *, diags, i);
+        const char *dfile = (d->file && d->file->filename)
+                          ? d->file->filename->data : NULL;
+        int remote = dfile != NULL && strcmp(dfile, path) != 0;
+        if (emitted++) aoStrPutChar(body, ',');
+        lspCatDiagnostic(body, d, remote, dfile ? dfile : "?");
+    }
+    aoStrCatPrintf(body, "]}}");
+    lspWrite(body);
+    aoStrRelease(body);
+    lspLog(ctx, "lsp: published %d diagnostic(s) for %s", emitted, path);
+}
+
+static void lspAnalyze(LspCtx *ctx, const char *uri) {
+    AoStr *text = (AoStr *)mapGet(ctx->docs, (void *)uri);
+    if (text == NULL) return;
+    char *path = lspUriToPath(uri);
+
+    int crash_sig = lspCanaryParse(ctx, path, text);
+    if (crash_sig) {
+        /* One synthetic diagnostic instead of a dead server. */
+        AoStr *body = aoStrNew();
+        aoStrCatPrintf(body,
+            "{\"jsonrpc\":\"2.0\","
+            "\"method\":\"textDocument/publishDiagnostics\","
+            "\"params\":{\"uri\":\"");
+        jsonEscapeInto(body, uri, strlen(uri));
+        aoStrCatPrintf(body,
+            "\",\"diagnostics\":[{\"range\":{\"start\":{\"line\":0,"
+            "\"character\":0},\"end\":{\"line\":0,\"character\":1}},"
+            "\"severity\":1,\"source\":\"hcc\",\"message\":\"internal: ");
+        if (crash_sig == SIGALRM) {
+            aoStrCatPrintf(body,
+                "the hcc parser hung on this input (killed after %ds)",
+                HCC_LSP_CANARY_TIMEOUT_SECS);
+        } else {
+            aoStrCatPrintf(body,
+                "the hcc parser crashed on this input (signal %d)",
+                crash_sig);
+        }
+        aoStrCatPrintf(body, " - please report this file\"}]}}");
+        lspWrite(body);
+        aoStrRelease(body);
+        lspLog(ctx, "lsp: parser %s (signal %d) on %s",
+               crash_sig == SIGALRM ? "hung" : "crashed", crash_sig, path);
+    } else {
+        lspPublishDiagnostics(ctx, uri, path);
+    }
+    free(path);
+}
+
+/* ---------------- debounced analysis ---------------- */
+
+/* A keystroke storm costs one parse, not one per keystroke: didChange
+ * only stores the text and schedules the uri here; the main loop runs
+ * the analyses once stdin has been quiet for HCC_LSP_DEBOUNCE_MS, capped
+ * at HCC_LSP_DEBOUNCE_MAX_MS so a chatty client can't starve diagnostics
+ * forever. Position requests flush first, so a query never sees parse
+ * state older than the text it queries against. */
+#define HCC_LSP_DEBOUNCE_MS     150
+#define HCC_LSP_DEBOUNCE_MAX_MS 1000
+
+static s64 lspNowMs(void) {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (s64)ts.tv_sec * 1000 + (s64)(ts.tv_nsec / 1000000);
+}
+
+/* 1 = stdin has input (or EOF - a read will not block), 0 = quiet for
+ * timeout_ms. */
+static int lspInputWait(int timeout_ms) {
+    struct pollfd pfd = { .fd = STDIN_FILENO, .events = POLLIN };
+    for (;;) {
+        int rc = poll(&pfd, 1, timeout_ms);
+        if (rc < 0 && errno == EINTR) continue;
+        return rc > 0;
+    }
+}
+
+static void lspDeferAnalysis(LspCtx *ctx, const char *uri) {
+    if (vecEmpty(ctx->pending)) ctx->pending_since_ms = lspNowMs();
+    if (!vecHas(ctx->pending, (void *)uri))
+        vecPush(ctx->pending, strdup(uri));
+}
+
+static void lspFlushPending(LspCtx *ctx) {
+    for (u64 i = 0; i < ctx->pending->size; ++i)
+        lspAnalyze(ctx, vecGet(char *, ctx->pending, i));
+    vecClear(ctx->pending);
+}
+
+/* ---------------- document sync ---------------- */
+
+/* Position queries against a document the client never opened (e.g. a
+ * jump target buffer the editor didn't attach to): read it from disk
+ * and cache it, so hover/definition keep working. No diagnostics are
+ * published - the doc's symbols are already in the Cctrl if anything
+ * ever included it (tos.HH always is, via the bootstrap). */
+static AoStr *lspDocGetOrLoad(LspCtx *ctx, const char *uri) {
+    AoStr *text = (AoStr *)mapGet(ctx->docs, (void *)uri);
+    if (text) return text;
+    char *path = lspUriToPath(uri);
+    FILE *f = fopen(path, "rb");
+    free(path);
+    if (f == NULL) return NULL;
+    AoStr *buf = aoStrNew();
+    char chunk[4096];
+    size_t n;
+    while ((n = fread(chunk, 1, sizeof(chunk), f)) > 0)
+        aoStrCatLen(buf, chunk, n);
+    fclose(f);
+    mapAdd(ctx->docs, strdup(uri), buf);
+    return buf;
+}
+
+static void lspDocSet(LspCtx *ctx, const char *uri, const char *text,
+                      size_t len) {
+    AoStr *old = (AoStr *)mapGet(ctx->docs, (void *)uri);
+    if (old) {
+        mapRemove(ctx->docs, (void *)uri);
+        aoStrRelease(old);
+    }
+    mapAdd(ctx->docs, strdup(uri), aoStrDupRaw((char *)text, len));
+}
+
+static void lspDidOpen(LspCtx *ctx, Json *params) {
+    Json *td = jsonObjGet(params, "textDocument");
+    const char *uri = jsonStrOr(td, "uri", NULL);
+    const char *text = jsonStrOr(td, "text", NULL);
+    if (uri == NULL || text == NULL) return;
+    Json *tv = jsonObjGet(td, "text");
+    lspDocSet(ctx, uri, text, tv->as.str_len);
+    lspAnalyze(ctx, uri);
+}
+
+static void lspDidChange(LspCtx *ctx, Json *params) {
+    Json *td = jsonObjGet(params, "textDocument");
+    const char *uri = jsonStrOr(td, "uri", NULL);
+    Json *changes = jsonObjGet(params, "contentChanges");
+    if (uri == NULL || changes == NULL || changes->as.size == 0) return;
+    /* Full sync: the last change wins and carries the whole text. */
+    Json *last = jsonArrayAt(changes, changes->as.size - 1);
+    Json *tv = jsonObjGet(last, "text");
+    if (tv == NULL || tv->kind != JSON_STRING) return;
+    lspDocSet(ctx, uri, tv->as.str, tv->as.str_len);
+    lspDeferAnalysis(ctx, uri);
+}
+
+static void lspDidClose(LspCtx *ctx, Json *params) {
+    Json *td = jsonObjGet(params, "textDocument");
+    const char *uri = jsonStrOr(td, "uri", NULL);
+    if (uri == NULL) return;
+    vecRemove(ctx->pending, (void *)uri);
+    AoStr *old = (AoStr *)mapGet(ctx->docs, (void *)uri);
+    if (old) {
+        mapRemove(ctx->docs, (void *)uri);
+        aoStrRelease(old);
+    }
+    /* Clear the squiggles. */
+    AoStr *body = aoStrNew();
+    aoStrCatPrintf(body,
+        "{\"jsonrpc\":\"2.0\",\"method\":\"textDocument/publishDiagnostics\","
+        "\"params\":{\"uri\":\"");
+    jsonEscapeInto(body, uri, strlen(uri));
+    aoStrCatPrintf(body, "\",\"diagnostics\":[]}}");
+    lspWrite(body);
+    aoStrRelease(body);
+}
+
+/* ---------------- hover & completion ---------------- */
+
+static int lspIsIdentChar(char c) {
+    return isalnum((unsigned char)c) || c == '_';
+}
+
+/* The identifier spanning (line, character) in `text`, copied into
+ * `out`. `prefix_only` stops at the cursor (completion wants the
+ * typed prefix; hover wants the whole word). 0 when there isn't one. */
+static int lspIdentAt(AoStr *text, int line, int character, int prefix_only,
+                      char *out, size_t out_size) {
+    const char *s = text->data;
+    size_t n = text->len;
+    size_t i = 0;
+    for (int l = 0; l < line && i < n; ++i)
+        if (s[i] == '\n') l++;
+    size_t line_start = i;
+    size_t line_end = i;
+    while (line_end < n && s[line_end] != '\n') line_end++;
+
+    size_t pos = line_start + (size_t)character;
+    if (pos > line_end) pos = line_end;
+
+    size_t start = pos;
+    while (start > line_start && lspIsIdentChar(s[start - 1])) start--;
+    size_t end = pos;
+    if (!prefix_only)
+        while (end < line_end && lspIsIdentChar(s[end])) end++;
+
+    if (end <= start || end - start >= out_size) return 0;
+    if (isdigit((unsigned char)s[start])) return 0;
+    memcpy(out, s + start, end - start);
+    out[end - start] = '\0';
+    return 1;
+}
+
+/* Uri + position out of a request's params; 1 on success. */
+static int lspTextDocPosition(Json *params, const char **uri,
+                              int *line, int *character) {
+    *uri = jsonStrOr(jsonObjGet(params, "textDocument"), "uri", NULL);
+    Json *pos = jsonObjGet(params, "position");
+    if (*uri == NULL || pos == NULL) return 0;
+    *line = (int)jsonIntOr(pos, "line", -1);
+    *character = (int)jsonIntOr(pos, "character", -1);
+    return *line >= 0 && *character >= 0;
+}
+
+static void lspHover(LspCtx *ctx, Json *id, Json *params) {
+    const char *uri;
+    int line, character;
+    char ident[256];
+    AoStr *text;
+    if (ctx->cc_dirty || /* crashed mid-parse; symbol tables suspect */
+        !lspTextDocPosition(params, &uri, &line, &character) ||
+        (text = lspDocGetOrLoad(ctx, uri)) == NULL ||
+        !lspIdentAt(text, line, character, 0, ident, sizeof(ident)))
+    {
+        lspRespond(id, "null");
+        return;
+    }
+    s64 ilen = (s64)strlen(ident);
+
+    /* Render whatever the name is: a class/union layout, a function
+     * prototype, a global's type, or a macro. */
+    AoStr *rendered = aoStrNew();
+    AstType *cls = mapGetLen(ctx->cc->clsdefs, ident, ilen);
+    AstType *uni = cls ? NULL : mapGetLen(ctx->cc->uniondefs, ident, ilen);
+    Ast *entry = NULL;
+    if (cls || uni) {
+        AoStr *body = astClassToAoStr(cls ? cls : uni);
+        aoStrCatLen(rendered, body->data, body->len);
+        aoStrRelease(body);
+    } else if ((entry = mapGetLen(ctx->cc->global_env, ident, ilen)) ||
+               (entry = mapGetLen(ctx->cc->asm_funcs, ident, ilen))) {
+        /* asm_funcs: `public _extern _LABEL ...` prototypes (most of
+         * the stdlib) live there rather than in global_env. */
+        if (astIsFnLike(entry)) {
+            char *proto = astFunctionToString(entry);
+            aoStrCatPrintf(rendered, "%s", proto);
+        } else if (entry->type) {
+            aoStrCatPrintf(rendered, "%s %s", astTypeToString(entry->type),
+                           ident);
+        }
+    } else if (mapGetLen(ctx->cc->macro_defs, ident, ilen)) {
+        aoStrCatPrintf(rendered, "#define %s", ident);
+    }
+
+    if (rendered->len == 0) {
+        lspRespond(id, "null");
+        aoStrRelease(rendered);
+        return;
+    }
+    AoStr *result = aoStrNew();
+    aoStrCatPrintf(result,
+                   "{\"contents\":{\"kind\":\"markdown\",\"value\":\"");
+    AoStr *md = aoStrPrintf("```holyc\n%s\n```", rendered->data);
+    jsonEscapeInto(result, md->data, md->len);
+    aoStrCatPrintf(result, "\"}}");
+    lspRespond(id, result->data);
+    aoStrRelease(md);
+    aoStrRelease(rendered);
+    aoStrRelease(result);
+}
+
+static const char *lsp_keywords[] = {
+    "I8", "I16", "I32", "I64", "U8", "U16", "U32", "U64", "F64", "U0",
+    "Bool",  "break", "case", "class", "default", "do", "else", "extern",
+    "_extern", "for", "goto", "if", "public", "return", "sizeof", "static",
+    "switch", "union", "while",
+    /* Added */
+    "auto", "continue", "typeof", "F32", "alignof",
+};
+
+#define HCC_LSP_FUNCTION     3
+#define HCC_LSP_VARIABLE     6
+#define HCC_LSP_CLASS        7
+/* tbh we could double up with out usage of class here */
+#define HCC_LSP_UNION_STRUCT 22
+#define HCC_LSP_CONSTANT     21
+#define HCC_LSP_KEYWORD      24
+
+/* One CompletionItem; label escaped, detail optional. */
+static void lspCatCompletion(AoStr *body, int *emitted, const char *label,
+                             int kind, const char *detail) {
+    if ((*emitted)++) aoStrPutChar(body, ',');
+    aoStrCatPrintf(body, "{\"label\":\"");
+    jsonEscapeInto(body, label, strlen(label));
+    aoStrCatPrintf(body, "\",\"kind\":%d", kind);
+    if (detail) {
+        aoStrCatPrintf(body, ",\"detail\":\"");
+        jsonEscapeInto(body, detail, strlen(detail));
+        aoStrPutChar(body, '"');
+    }
+    aoStrPutChar(body, '}');
+}
+
+/* Handles global variables and non-asm functions */
+static char *lspGlobalSuggestionResolver(Ast *entry, int *_type) {
+    if (astIsFnLike(entry)) {
+        *_type = HCC_LSP_FUNCTION;
+        return astFunctionToString(entry);
+    } else {
+        *_type = HCC_LSP_VARIABLE;
+        return entry->type ? astTypeToString(entry->type) : NULL;
+    }
+}
+
+static char *lspAsmFunctionSuggestionResolver(Ast *entry, int *_type) {
+    *_type = HCC_LSP_FUNCTION;
+    return astIsFnLike(entry) ? astFunctionToString(entry) : NULL;
+}
+
+static char *lspClassSuggestionResolver(Ast *entry, int *_type) {
+    (void)entry;
+    *_type = HCC_LSP_CLASS;
+    return "class";
+}
+
+static char *lspUnionSuggestionResolver(Ast *entry, int *_type) {
+    (void)entry;
+    *_type = HCC_LSP_UNION_STRUCT;
+    return "union";
+}
+
+static char *lspConstantSuggestionResolver(Ast *entry, int *_type) {
+    (void)entry;
+    *_type = HCC_LSP_CONSTANT;
+    return "#define";
+}
+
+/* Find matching prefix in a symbol table */
+void lspScanMapForSuggestion(Map *suggestions,
+                             char *prefix,
+                             int plen,
+                             AoStr *body,
+                             int *_emitted,
+                             char *(lsp_suggestion_resolver)(Ast *entry, int *_type)) {
+    MapIter mi;
+    int emitted = *_emitted;
+    mapIterInit(suggestions, &mi);
+    while (mapIterNext(&mi) && emitted < 1000) {
+        const char *name = (const char *)mi.node->key;
+        if (strncmp(name, prefix, plen) != 0) continue;
+        Ast *entry = (Ast *)mi.node->value;
+        int type = 0;
+        char *str_suggestion = lsp_suggestion_resolver(entry, &type);
+        lspCatCompletion(body, &emitted, name, type, str_suggestion);
+    }
+    *_emitted = emitted;
+}
+
+static void lspCompletion(LspCtx *ctx, Json *id, Json *params) {
+    const char *uri;
+    int line, character;
+    char prefix[256];
+    AoStr *text;
+    prefix[0] = '\0';
+    if (ctx->cc_dirty ||
+        !lspTextDocPosition(params, &uri, &line, &character) ||
+        (text = lspDocGetOrLoad(ctx, uri)) == NULL)
+    {
+        lspRespond(id, "null");
+        return;
+    }
+    /* No identifier under the cursor = empty prefix = offer everything
+     * (the client filters as the user types). */
+    lspIdentAt(text, line, character, 1, prefix, sizeof(prefix));
+    size_t plen = strlen(prefix);
+
+    AoStr *body = aoStrNew();
+    aoStrCatPrintf(body, "{\"isIncomplete\":false,\"items\":[");
+    int emitted = 0;
+
+    lspScanMapForSuggestion(ctx->cc->global_env, prefix, plen, body, &emitted,
+                            &lspGlobalSuggestionResolver);
+
+    lspScanMapForSuggestion(ctx->cc->asm_funcs, prefix, plen, body, &emitted,
+                            &lspAsmFunctionSuggestionResolver);
+
+    lspScanMapForSuggestion(ctx->cc->clsdefs, prefix, plen, body, &emitted,
+                            &lspClassSuggestionResolver);
+
+    lspScanMapForSuggestion(ctx->cc->uniondefs, prefix, plen, body, &emitted,
+                            &lspUnionSuggestionResolver);
+
+    lspScanMapForSuggestion(ctx->cc->macro_defs, prefix, plen, body, &emitted,
+                            &lspConstantSuggestionResolver);
+
+    for (size_t i = 0; i < sizeof(lsp_keywords) / sizeof(lsp_keywords[0]); ++i) {
+        if (strncmp(lsp_keywords[i], prefix, plen) != 0) continue;
+        lspCatCompletion(body, &emitted, lsp_keywords[i], HCC_LSP_KEYWORD, NULL);
+    }
+
+    aoStrCatPrintf(body, "]}");
+    lspRespond(id, body->data);
+    aoStrRelease(body);
+    lspLog(ctx, "lsp: completion '%s' -> %d item(s)", prefix, emitted);
+}
+
+/* Jump-to-definition for functions and globals: their definition Asts
+ * carry file_id/line stamped at parse. (Classes/unions are AstTypes,
+ * which don't carry provenance yet - they respond null for now.) */
+/* Resolve `ident` as a VALUE at (doc, cursor): locals/params of the
+ * enclosing function (nearest preceding declaration wins), then
+ * globals, then asm-bound prototypes. *in_doc is set when the hit
+ * came from the enclosing function - its file is the document by
+ * construction. */
+static Ast *lspResolveValue(LspCtx *ctx, u32 doc_id, int cursor_line,
+                            const char *ident, s64 ilen, int *in_doc) {
+    Ast *entry = NULL;
+    *in_doc = 0;
+
+    Ast *encl = NULL;
+    MapIter mi;
+    mapIterInit(ctx->cc->global_env, &mi);
+    while (mapIterNext(&mi)) {
+        Ast *fn = (Ast *)mi.node->value;
+        if (!astIsFnLike(fn) || fn->file_id != doc_id) continue;
+        if (fn->line > 0 && fn->line <= cursor_line &&
+            (encl == NULL || fn->line > encl->line))
+        {
+            encl = fn;
+        }
+    }
+    if (encl) {
+        if (encl->params) {
+            for (u64 i = 0; i < encl->params->size; ++i) {
+                Ast *v = vecGet(Ast *, encl->params, i);
+                if (v && v->kind == AST_LVAR && v->lname &&
+                    (s64)v->lname->len == ilen &&
+                    memcmp(v->lname->data, ident, ilen) == 0)
+                {
+                    entry = v;
+                }
+            }
+        }
+        if (encl->locals) {
+            listForEach(encl->locals) {
+                Ast *v = (Ast *)it->value;
+                /* Declarations may arrive wrapped. */
+                if (v && v->kind == AST_DECL && v->declvar) v = v->declvar;
+                if (v && v->kind == AST_LVAR && v->lname &&
+                    (s64)v->lname->len == ilen &&
+                    memcmp(v->lname->data, ident, ilen) == 0 &&
+                    v->line > 0 && v->line <= cursor_line &&
+                    (entry == NULL || v->line >= entry->line))
+                {
+                    entry = v;
+                }
+            }
+        }
+    }
+    if (entry) {
+        *in_doc = 1;
+        return entry;
+    }
+    entry = (Ast *)mapGetLen(ctx->cc->global_env, (char *)ident, ilen);
+    if (entry == NULL)
+        entry = (Ast *)mapGetLen(ctx->cc->asm_funcs, (char *)ident, ilen);
+    return entry;
+}
+
+/* Walk back over one balanced `(...)` / `[...]` group ending at
+ * end-1; returns the opener's index or (size_t)-1. Single-line. */
+static size_t lspSkipGroupBack(const char *s, size_t line_start, size_t end) {
+    char close = s[end - 1];
+    char open = close == ')' ? '(' : '[';
+    int depth = 0;
+    size_t i = end;
+    while (i > line_start) {
+        char c = s[--i];
+        if (c == close) depth++;
+        else if (c == open) {
+            depth--;
+            if (depth == 0) return i;
+        }
+    }
+    return (size_t)-1;
+}
+
+#define HCC_LSP_SEG_PLAIN 0
+#define HCC_LSP_SEG_CALL  1 /* name(...)  - resolve via the return type */
+#define HCC_LSP_SEG_INDEX 2 /* name[...]  - canonical chase handles it */
+
+/* If the identifier at (line, character) is written as
+ * `a->b(x).c[i]->ident`, extract the receiver chain (leftmost first)
+ * with each segment's shape. Returns segment count, 0 when not a
+ * member access or a segment is something we can't type textually. */
+#define HCC_LSP_MAX_CHAIN 8
+static int lspMemberChain(AoStr *text, int line, int character,
+                          char out[HCC_LSP_MAX_CHAIN][256],
+                          u8 kinds[HCC_LSP_MAX_CHAIN]) {
+    const char *s = text->data;
+    size_t n = text->len;
+    size_t i = 0;
+    for (int l = 0; l < line && i < n; ++i)
+        if (s[i] == '\n') l++;
+    size_t line_start = i;
+    size_t line_end = i;
+    while (line_end < n && s[line_end] != '\n') line_end++;
+    size_t pos = line_start + (size_t)character;
+    if (pos > line_end) pos = line_end;
+    size_t start = pos;
+    while (start > line_start && lspIsIdentChar(s[start - 1])) start--;
+
+    int nseg = 0;
+    size_t cur = start;
+    while (nseg < HCC_LSP_MAX_CHAIN) {
+        size_t r_end;
+        if (cur >= line_start + 2 && s[cur - 2] == '-' && s[cur - 1] == '>')
+            r_end = cur - 2;
+        else if (cur >= line_start + 1 && s[cur - 1] == '.')
+            r_end = cur - 1;
+        else
+            break;
+        /* Trailing (...) / [...] groups on this segment. */
+        u8 kind = HCC_LSP_SEG_PLAIN;
+        while (r_end > line_start &&
+               (s[r_end - 1] == ')' || s[r_end - 1] == ']'))
+        {
+            if (s[r_end - 1] == ')') kind = HCC_LSP_SEG_CALL;
+            else if (kind == HCC_LSP_SEG_PLAIN) kind = HCC_LSP_SEG_INDEX;
+            size_t opener = lspSkipGroupBack(s, line_start, r_end);
+            if (opener == (size_t)-1) return 0;
+            r_end = opener;
+        }
+        size_t r_start = r_end;
+        while (r_start > line_start && lspIsIdentChar(s[r_start - 1]))
+            r_start--;
+        if (r_end <= r_start || r_end - r_start >= 256) return 0;
+        if (isdigit((unsigned char)s[r_start])) return 0;
+        for (int k = nseg; k > 0; --k) {
+            memcpy(out[k], out[k - 1], 256);
+            kinds[k] = kinds[k - 1];
+        }
+        memcpy(out[0], s + r_start, r_end - r_start);
+        out[0][r_end - r_start] = '\0';
+        kinds[0] = kind;
+        nseg++;
+        cur = r_start;
+    }
+    return nseg;
+}
+
+/* Pointer-chase to the canonical class/union carrying ->fields. An
+ * incomplete reference (fields NULL, clsname set) resolves through
+ * clsdefs/uniondefs. */
+static AstType *lspCanonicalClass(LspCtx *ctx, AstType *t) {
+    while (t && (t->kind == AST_TYPE_POINTER || t->kind == AST_TYPE_ARRAY))
+        t = t->ptr;
+    if (t && t->fields == NULL && t->clsname) {
+        AstType *c = (AstType *)mapGetLen(ctx->cc->clsdefs,
+                t->clsname->data, t->clsname->len);
+        if (c == NULL)
+            c = (AstType *)mapGetLen(ctx->cc->uniondefs,
+                    t->clsname->data, t->clsname->len);
+        if (c) t = c;
+    }
+    return t;
+}
+
+/* If `line` in `text` is an `#include "..."` / `#include <...>`
+ * directive, respond with the top of the included file - resolved the
+ * way lexInclude does: <> against the builtin include root, "" against
+ * the INCLUDING file's directory (leading ./ stripped), absolute paths
+ * untouched. Purely textual, so it works even while ctx->cc is dirty.
+ * Returns 1 when the line was an include (response sent - null when
+ * the target file doesn't exist; the path fragments under the cursor
+ * must not fall through to identifier lookup), 0 otherwise. */
+static int lspIncludeDefinition(LspCtx *ctx, Json *id, const char *uri,
+                                AoStr *text, int line) {
+    const char *s = text->data;
+    size_t n = text->len;
+    size_t i = 0;
+    for (int l = 0; l < line && i < n; ++i)
+        if (s[i] == '\n') l++;
+    size_t end = i;
+    while (end < n && s[end] != '\n') end++;
+
+    while (i < end && (s[i] == ' ' || s[i] == '\t')) i++;
+    if (end - i < 8 || strncmp(s + i, str_lit("#include")) != 0) return 0;
+    i += 8;
+    while (i < end && (s[i] == ' ' || s[i] == '\t')) i++;
+    if (i >= end || (s[i] != '"' && s[i] != '<')) return 0;
+    char close = s[i] == '<' ? '>' : '"';
+    char open = s[i];
+    i++;
+    size_t p0 = i;
+    while (i < end && s[i] != close) i++;
+    if (i >= end || i == p0) return 0;
+    int plen = (int)(i - p0);
+
+    AoStr *target;
+    if (open == '<') {
+        /* ctx->root_dir carries its trailing slash. */
+        target = aoStrPrintf("%s%.*s", ctx->root_dir, plen, s + p0);
+    } else if (s[p0] == '/') {
+        target = aoStrDupRaw((char *)s + p0, (size_t)plen);
+    } else {
+        const char *rel = s + p0;
+        if (plen > 2 && rel[0] == '.' && rel[1] == '/') {
+            rel += 2;
+            plen -= 2;
+        }
+        char *doc_path = lspUriToPath(uri);
+        char *slash = strrchr(doc_path, '/');
+        if (slash) {
+            target = aoStrPrintf("%.*s/%.*s", (int)(slash - doc_path),
+                                 doc_path, plen, rel);
+        } else {
+            target = aoStrDupRaw((char *)rel, (size_t)plen);
+        }
+        free(doc_path);
+    }
+
+    char abs_path[PATH_MAX];
+    const char *out_path = target->data;
+    if (realpath(target->data, abs_path) != NULL) out_path = abs_path;
+    if (access(out_path, R_OK) != 0) {
+        lspLog(ctx, "lsp: include target %s unreadable", target->data);
+        aoStrRelease(target);
+        lspRespond(id, "null");
+        return 1;
+    }
+    AoStr *result = aoStrNew();
+    aoStrCatPrintf(result, "{\"uri\":\"file://");
+    jsonEscapeInto(result, out_path, strlen(out_path));
+    aoStrCatPrintf(result,
+        "\",\"range\":{\"start\":{\"line\":0,\"character\":0},"
+        "\"end\":{\"line\":0,\"character\":0}}}");
+    lspRespond(id, result->data);
+    lspLog(ctx, "lsp: definition -> include %s", out_path);
+    aoStrRelease(result);
+    aoStrRelease(target);
+    return 1;
+}
+
+static void lspDefinition(LspCtx *ctx, Json *id, Json *params) {
+    const char *uri;
+    int line, character;
+    char ident[256];
+    AoStr *text;
+    if (!lspTextDocPosition(params, &uri, &line, &character) ||
+        (text = lspDocGetOrLoad(ctx, uri)) == NULL)
+    {
+        lspRespond(id, "null");
+        return;
+    }
+    /* Anywhere on an #include line jumps to the file itself. */
+    if (lspIncludeDefinition(ctx, id, uri, text, line)) return;
+    if (ctx->cc_dirty || /* crashed mid-parse; symbol tables suspect */
+        !lspIdentAt(text, line, character, 0, ident, sizeof(ident)))
+    {
+        lspRespond(id, "null");
+        return;
+    }
+    s64 ilen = (s64)strlen(ident);
+
+    AoStr path_s = {
+        .data = (char *)lspUriToPath(uri),
+        .len = 0,
+        .capacity = 0
+    };
+    path_s.len = strlen(path_s.data);
+    u32 doc_id = cctrlRegisterFile(ctx->cc, &path_s);
+    free(path_s.data);
+    int cursor_line = line + 1; /* ast lines are 1-based */
+
+    int def_line = 0, def_col = 0;
+    u32 def_file = 0;
+    u32 fallback_id = 0;
+    int in_doc = 0;
+
+    /* Member access `a->b.ident`: type the chain left-to-right from
+     * the head variable, hopping class fields, and jump to the FIELD.
+     * The canonical class AstTypes are shared with clsdefs, so fields
+     * carry the provenance stamped at parse. */
+    char chain[HCC_LSP_MAX_CHAIN][256];
+    u8 kinds[HCC_LSP_MAX_CHAIN];
+    int nseg = lspMemberChain(text, line, character, chain, kinds);
+    if (nseg > 0) {
+        Ast *r = lspResolveValue(ctx, doc_id, cursor_line, chain[0],
+                                 (s64)strlen(chain[0]), &in_doc);
+        AstType *t = NULL;
+        if (r) {
+            /* `Foo()->x`: the head is a call - hop via the return
+             * type. Indexing needs nothing special: the canonical
+             * chase strips pointer/array levels to reach the class. */
+            if (kinds[0] == HCC_LSP_SEG_CALL)
+                t = (r->type && r->type->rettype)
+                  ? lspCanonicalClass(ctx, r->type->rettype) : NULL;
+            else
+                t = lspCanonicalClass(ctx, r->type);
+        }
+        for (int seg = 1; seg < nseg && t && t->fields; ++seg) {
+            AstType *f = (AstType *)mapGetLen(t->fields, chain[seg],
+                    (s64)strlen(chain[seg]));
+            if (f && kinds[seg] == HCC_LSP_SEG_CALL)
+                f = f->rettype; /* fn-pointer field call */
+            t = f ? lspCanonicalClass(ctx, f) : NULL;
+        }
+        if (t && t->fields) {
+            AstType *field = (AstType *)mapGetLen(t->fields, ident, ilen);
+            if (field && field->line > 0) {
+                def_line = field->line;
+                def_col = field->col;
+                def_file = field->file_id;
+            }
+        }
+    }
+
+    /* Plain identifier: values first, then types. A member access
+     * that failed to resolve stays null - a field name is not a
+     * variable reference, and guessing jumps to wrong classes. */
+    if (nseg == 0 && def_line == 0) {
+        in_doc = 0;
+        Ast *entry = lspResolveValue(ctx, doc_id, cursor_line, ident, ilen,
+                                     &in_doc);
+        if (entry) {
+            def_line = entry->line;
+            def_col = entry->col;
+            def_file = entry->file_id;
+        } else {
+            AstType *ty = (AstType *)mapGetLen(ctx->cc->clsdefs, ident, ilen);
+            if (ty == NULL)
+                ty = (AstType *)mapGetLen(ctx->cc->uniondefs, ident, ilen);
+            if (ty) {
+                def_line = ty->line;
+                def_col = ty->col;
+                def_file = ty->file_id;
+            }
+        }
+    }
+    fallback_id = in_doc ? doc_id : 0;
+
+    AoStr *fname = NULL;
+    if (def_line > 0) {
+        fname = cctrlLookUpFile(ctx->cc, def_file);
+        if (fname == NULL && fallback_id)
+            fname = cctrlLookUpFile(ctx->cc, fallback_id);
+    }
+    if (fname == NULL) {
+        lspRespond(id, "null");
+        return;
+    }
+    /* With a column the range spans exactly the defining name; without
+     * one (synthetic nodes) fall back to line start. */
+    int c0 = def_col > 0 ? def_col - 1 : 0;
+    int c1 = def_col > 0 ? c0 + (int)ilen : 0;
+    /* file_map can hold a cwd-relative path (AOT-style invocations);
+     * a file:// uri must be absolute or the editor guesses. */
+    char abs_path[PATH_MAX];
+    const char *out_path = fname->data;
+    if (out_path[0] != '/' && realpath(out_path, abs_path) != NULL)
+        out_path = abs_path;
+    AoStr *result = aoStrNew();
+    aoStrCatPrintf(result, "{\"uri\":\"file://");
+    jsonEscapeInto(result, out_path, strlen(out_path));
+    aoStrCatPrintf(result,
+        "\",\"range\":{\"start\":{\"line\":%d,\"character\":%d},"
+        "\"end\":{\"line\":%d,\"character\":%d}}}",
+        def_line - 1, c0, def_line - 1, c1);
+    lspRespond(id, result->data);
+    aoStrRelease(result);
+}
+
+/* ---------------- lifecycle ---------------- */
+
+static void lspInitialize(Json *id) {
+    AoStr *result = aoStrNew();
+    aoStrCatPrintf(result,
+        "{\"capabilities\":{"
+        "\"positionEncoding\":\"utf-8\","
+        "\"textDocumentSync\":{\"openClose\":true,\"change\":1},"
+        "\"hoverProvider\":true,"
+        "\"definitionProvider\":true,"
+        "\"completionProvider\":{}"
+        "},\"serverInfo\":{\"name\":\"hcc\",\"version\":\"%s\"}}",
+        cctrlGetVersion());
+    lspRespond(id, result->data);
+    aoStrRelease(result);
+}
+
+int lspRun(CliArgs *args) {
+    LspCtx lsp_ctx = {0};
+    LspCtx *ctx = &lsp_ctx;
+    ctx->log_on = getenv("HCC_LSP_LOG") != NULL;
+    ctx->target = args->target;
+    ctx->root_dir = mprintf("%s/include/", args->install_dir);
+    ctx->docs = mapNew(16, &map_cstring_opaque_type);
+    ctx->pending = vecNew(&vec_cstring_owned_type);
+    ctx->cc = lspFreshCctrl(ctx);
+    lspInstallCrashHandlers();
+    /* The debounce poll()s fd 0; an stdio read-ahead buffer would make
+     * poll block on data the process already holds. Unbuffered stdin
+     * keeps the two views identical (headers are tens of bytes, and
+     * fread still pulls the body in bulk). */
+    setvbuf(stdin, NULL, _IONBF, 0);
+    lspLog(ctx, "lsp: hcc %s ready", cctrlGetVersion());
+
+    Arena *arena = arenaNew(1 << 16);
+    for (;;) {
+        if (!vecEmpty(ctx->pending)) {
+            if (lspNowMs() - ctx->pending_since_ms >= HCC_LSP_DEBOUNCE_MAX_MS ||
+                !lspInputWait(HCC_LSP_DEBOUNCE_MS))
+            {
+                lspFlushPending(ctx);
+                continue;
+            }
+        }
+        size_t len = 0;
+        char *raw = lspReadMessage(&len);
+        if (raw == NULL) break; /* EOF or framing error */
+
+        arenaReset(arena);
+        const char *jerr = NULL;
+        Json *msg = jsonParse(arena, raw, len, &jerr);
+        if (msg == NULL) {
+            lspLog(ctx, "lsp: bad JSON (%s)", jerr ? jerr : "?");
+            free(raw);
+            continue;
+        }
+
+        const char *method = jsonStrOr(msg, "method", "");
+        Json *id = jsonObjGet(msg, "id");
+        Json *params = jsonObjGet(msg, "params");
+        lspLog(ctx, "lsp: <- %s", method);
+
+        if (strcmp(method, "initialize") == 0) {
+            lspInitialize(id);
+        } else if (strcmp(method, "shutdown") == 0) {
+            ctx->shutdown_requested = 1;
+            lspRespond(id, "null");
+        } else if (strcmp(method, "exit") == 0) {
+            free(raw);
+            break;
+        } else if (strcmp(method, "textDocument/didOpen") == 0) {
+            lspDidOpen(ctx, params);
+        } else if (strcmp(method, "textDocument/didChange") == 0) {
+            lspDidChange(ctx, params);
+        } else if (strcmp(method, "textDocument/didClose") == 0) {
+            lspDidClose(ctx, params);
+        } else if (strcmp(method, "textDocument/hover") == 0) {
+            lspFlushPending(ctx); /* queries must not outrun edits */
+            lspHover(ctx, id, params);
+        } else if (strcmp(method, "textDocument/completion") == 0) {
+            lspFlushPending(ctx);
+            lspCompletion(ctx, id, params);
+        } else if (strcmp(method, "textDocument/definition") == 0) {
+            lspFlushPending(ctx);
+            lspDefinition(ctx, id, params);
+        } else if (id != NULL) {
+            /* Requests we don't implement yet; notifications
+             * (initialized, didSave, $/...) are silently fine. */
+            lspRespondError(id, -32601, "method not implemented");
+        }
+        free(raw);
+    }
+    arenaRelease(arena);
+    return ctx->shutdown_requested ? 0 : 1;
+}

--- a/src/lsp.h
+++ b/src/lsp.h
@@ -1,0 +1,10 @@
+#ifndef LSP_H__
+#define LSP_H__
+
+#include "cli.h"
+
+/* `hcc -lsp`: a Language Server Protocol server over stdio.
+ * 0 after a clean shutdown request, 1 otherwise. */
+int lspRun(CliArgs *args);
+
+#endif

--- a/src/main.c
+++ b/src/main.c
@@ -24,6 +24,7 @@
 #endif
 #include "lexer.h"
 #include "list.h"
+#include "lsp.h"
 #include "memory.h"
 #include "transpiler.h"
 #include "types.h"
@@ -271,8 +272,10 @@ void emitFile(Cctrl *cc, AoStr *asmbuf, CliArgs *args) {
                 cc->CC,
                 ASM_TMP_FILE,args->obj_outfile);
         safeSystem(cmd->data,1);
-        safeSystem(lib.dylib_cmd, 1);
+        /* The archive first: dylib_cmd's leading `cp` ships it, so
+         * running it second means shipping a stale (or absent) one. */
         safeSystem(lib.stylib_cmd, 1);
+        safeSystem(lib.dylib_cmd, 1);
         safeSystem(lib.install_cmd, 1);
     } else {
         AoStr *ofiles = aoStrNew();
@@ -410,6 +413,14 @@ int main(int argc, char **argv) {
     /* now parse cli options */
     args.install_dir = INSTALL_PREFIX;
     cliParseArgs(&args,argc,argv);
+
+    /* The LSP owns its Cctrl lifecycle (fresh one after a parser
+     * crash), so it dispatches before the shared `cc` is made. */
+    if (args.lsp) {
+        int rc = lspRun(&args);
+        memoryRelease();
+        return rc;
+    }
 
     cc = cctrlNew(args.target);
 

--- a/src/memsafe.c
+++ b/src/memsafe.c
@@ -93,8 +93,16 @@ static void memsafePrintSite(FILE *f, const uintptr_t *sites, int nsites) {
             ? hccJitFindSymbolForAddr(jit, (void *)sites[i], &off)
             : NULL;
         if (sym && memsafeIsAllocShim(sym)) continue;
-        if (sym) fprintf(f, "in `%s`+%zu", sym, off);
-        else     fprintf(f, "at %p", (void *)sites[i]);
+        if (sym) {
+            /* sites[] are return addresses - the CALL is the
+             * instruction before, so look the line up at addr-1 or
+             * the report reads one statement late. */
+            int line = hccJitFindLineForAddr(jit, (void *)(sites[i] - 1));
+            fprintf(f, "in `%s`+%zu", sym, off);
+            if (line) fprintf(f, ", line %d", line);
+        } else {
+            fprintf(f, "at %p", (void *)sites[i]);
+        }
         return;
     }
     fprintf(f, "at an unknown site");

--- a/src/parser.c
+++ b/src/parser.c
@@ -292,6 +292,10 @@ List *parseClassOrUnionFields(Cctrl *cc, AoStr *name,
     while (1) {
         /* Peek not a consume */
         tok_name = cctrlTokenPeek(cc);
+        if (tok_name == NULL) {
+            cctrlRaiseException(cc,
+                    "Unexpected end of input in class/union body");
+        }
         if (tokenPunctIs(tok_name,'}')) {
             break;
         } else if (cctrlIsKeyword(cc,tok_name->start,tok_name->len)) {
@@ -355,6 +359,11 @@ List *parseClassOrUnionFields(Cctrl *cc, AoStr *name,
             }
 
             field_type = astMakeClassField(next_type, 0);
+            /* Field provenance for jump-to-definition: the name token
+             * is in hand ('(' for fn-pointer fields - same line). */
+            field_type->line = tok_name->line;
+            field_type->col = tok_name->col;
+            field_type->file_id = ast_file_hint;
             if (next_type && next_type->clsname) {
                 field_type->clsname = next_type->clsname;
             }
@@ -562,8 +571,18 @@ AstType *parseClassOrUnion(Cctrl *cc, Map *env,
     Map *fields_dict;
     cc->localenv = cctrlCreateAstMap(cc->localenv);
 
+    if (tok == NULL) {
+        cctrlRaiseException(cc,
+                "Unexpected end of input in class/union definition");
+    }
+    /* Provenance of the tag token, for jump-to-definition. */
+    int tag_line = 0, tag_col = 0;
+    u32 tag_file = 0;
     if (tok->tk_type == TK_IDENT) {
         tag = aoStrDupRaw(tok->start,tok->len);
+        tag_line = tok->line;
+        tag_col = tok->col;
+        tag_file = ast_file_hint;
 
         tok = cctrlTokenGet(cc);
         if (tokenPunctIs(tok, ':')) { // Class inheritance
@@ -599,6 +618,9 @@ AstType *parseClassOrUnion(Cctrl *cc, Map *env,
     if (tag && !prev) {
         prev = astClassType(NULL, tag, 0, is_intrinsic);
         if (!is_class) prev->kind = AST_TYPE_UNION;
+        prev->line = tag_line;
+        prev->col = tag_col;
+        prev->file_id = tag_file;
         mapAdd(env, tag->data, prev);
     }
 
@@ -619,6 +641,13 @@ AstType *parseClassOrUnion(Cctrl *cc, Map *env,
         prev->fields = fields_dict;
         prev->size = aligned_size;
         prev->alignment = (u32)aligned;
+        /* A forward-declared tag now has its full definition HERE -
+         * repoint the provenance at it. */
+        if (tag_line > 0) {
+            prev->line = tag_line;
+            prev->col = tag_col;
+            prev->file_id = tag_file;
+        }
         return prev;
     }
 
@@ -632,6 +661,9 @@ AstType *parseClassOrUnion(Cctrl *cc, Map *env,
     }
     ref->alignment = (u32)aligned;
     if (!is_class) ref->kind = AST_TYPE_UNION;
+    ref->line = tag_line;
+    ref->col = tag_col;
+    ref->file_id = tag_file;
     if (tag) {
         mapAdd(env,tag->data,ref);
     }
@@ -736,6 +768,10 @@ Ast *parseDecl(Cctrl *cc) {
         return NULL;
     }
     var = astLVar(type,varname->start,varname->len);
+    /* astNew stamped the CURRENT token (post-name); anchor the decl
+     * to the name itself for jump-to-definition. */
+    var->line = varname->line;
+    var->col = varname->col;
     if (!mapAddOrErr(cc->localenv,var->lname->data,var)) {
         cctrlRaiseException(cc,"variable %s already declared",astLValueToString(var,0));
     }
@@ -750,6 +786,7 @@ Ast *parseDecl(Cctrl *cc) {
 }
 
 int parseValidPostControlFlowToken(Lexeme *tok) {
+    if (tok == NULL) return 0; /* EOF - caller raises */
     if (tok->tk_type == TK_IDENT) return 1;
     if (tok->tk_type == TK_STR) return 1;
     if (tok->tk_type == TK_PUNCT) {
@@ -800,6 +837,8 @@ static Ast *parseIfClause(Cctrl *cc, char *term_out) {
                 name ? name->len : 0, name ? name->start : "");
         }
         Ast *var = astLVar(type, name->start, name->len);
+        var->line = name->line;
+        var->col = name->col;
         if (!mapAddOrErr(cc->localenv, var->lname->data, var)) {
             cctrlRaiseException(cc, "variable %s already declared",
                                 astLValueToString(var, 0));
@@ -861,6 +900,9 @@ Ast *parseIfStatement(Cctrl *cc) {
     }
 
     Lexeme *peek = cctrlTokenPeek(cc);
+    if (peek == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input");
+    }
     if (!parseValidPostControlFlowToken(peek)) {
         cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing if body",
                 lexemeTypeToString(peek->tk_type), peek->len, peek->start);
@@ -1162,6 +1204,9 @@ Ast *parseForStatement(Cctrl *cc) {
     cctrlTokenExpect(cc,')');
 
     Lexeme *peek = cctrlTokenPeek(cc);
+    if (peek == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input");
+    }
     if (!parseValidPostControlFlowToken(peek)) {
         cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing for loop body", 
                 lexemeTypeToString(peek->tk_type), peek->len, peek->start);
@@ -1193,6 +1238,9 @@ Ast *parseWhileStatement(Cctrl *cc) {
     cctrlTokenExpect(cc,')');
 
     Lexeme *peek = cctrlTokenPeek(cc);
+    if (peek == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input");
+    }
     if (!parseValidPostControlFlowToken(peek)) {
         cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing while loop body", 
                 lexemeTypeToString(peek->tk_type), peek->len, peek->start);
@@ -1223,6 +1271,9 @@ Ast *parseDoWhileStatement(Cctrl *cc) {
     cc->localenv = cctrlCreateAstMap(cc->localenv);
 
     Lexeme *peek = cctrlTokenPeek(cc);
+    if (peek == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input");
+    }
     if (!parseValidPostControlFlowToken(peek)) {
         cctrlRewindUntilStrMatch(cc,peek->start,peek->len,NULL);
         cctrlRaiseException(cc,"Unexpected %s `%.*s` while parsing do while loop body", 
@@ -1528,6 +1579,10 @@ Ast *parseStatement(Cctrl *cc) {
     Map *env;
     tok = cctrlTokenGet(cc);
 
+    if (tok == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input, expected a "
+                "statement");
+    }
     if (tok->tk_type == TK_KEYWORD) {
         switch (tok->i64) {
             case KW_IF:       return parseIfStatement(cc);
@@ -1621,6 +1676,10 @@ Ast *parseStatement(Cctrl *cc) {
 
             case KW_GOTO: {
                 tok = cctrlTokenGet(cc);
+                if (tok == NULL) {
+                    cctrlRaiseException(cc,
+                            "Unexpected end of input after `goto`");
+                }
                 label = createFunctionLevelGotoLabel(cc,tok);
                 ret = astGoto(label);
                 cctrlTokenExpect(cc,';');
@@ -1757,6 +1816,8 @@ void parseCompoundStatementInternal(Cctrl *cc, Ast *body) {
                     }
                     type = parseArrayDimensions(cc,next_type);
                     var = astLVar(type,varname->start,varname->len);
+                    var->line = varname->line;
+                    var->col = varname->col;
                     var->pinned_kind = pinned_kind;
                     var->pinned_reg = pinned_reg;
                     if (!mapAddOrErr(cc->localenv,var->lname->data,var)) {
@@ -1955,6 +2016,10 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
     s64 fn_line = next ? next->line : cc->lineno;
     s64 fn_col  = next ? next->col  : 0;
     s64 fn_len  = next ? next->len  : 1;
+    if (next == NULL) {
+        cctrlRaiseException(cc,
+                "Unexpected end of input in function definition");
+    }
     if (next->tk_type == TK_KEYWORD && next->i64 == KW_ASM) {
         cctrlTokenGet(cc);
         Lexeme *peek = cctrlTokenPeek(cc);
@@ -2055,12 +2120,23 @@ Ast *parseFunctionDef(Cctrl *cc, AstType *rettype,
                     astMakeFunctionType(rettype, params),
                     asm_fname,asm_fname,params);
 
+            /* REPL/LSP: a reparse redefines; shadow rather than abort. */
             if (!mapAddOrErr(cc->asm_functions, asm_fname->data, asm_func)) {
-                cctrlIce(cc, "Already defined assembly function: %s", asm_fname->data);
+                if (cc->flags & CCTRL_REPL) {
+                    mapRemove(cc->asm_functions, asm_fname->data);
+                    mapAdd(cc->asm_functions, asm_fname->data, asm_func);
+                } else {
+                    cctrlIce(cc, "Already defined assembly function: %s", asm_fname->data);
+                }
             }
 
             if (!mapAddOrErr(cc->global_env, fname_duped->data, asm_func)) {
-                cctrlIce(cc, "Already defined assembly function: %s as a non Assembly function", asm_fname->data);
+                if (cc->flags & CCTRL_REPL) {
+                    mapRemove(cc->global_env, fname_duped->data);
+                    mapAdd(cc->global_env, fname_duped->data, asm_func);
+                } else {
+                    cctrlIce(cc, "Already defined assembly function: %s as a non Assembly function", asm_fname->data);
+                }
             }
 
             if (is_inline) {
@@ -2247,6 +2323,13 @@ Ast *parseExternFunctionProto(Cctrl *cc, AstType *rettype, char *fname, int len)
 }
 
 Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int is_inline) {
+    /* Anchor: the name token was just consumed, so the cursor still
+     * sits on its line - stamp the function Ast with the NAME's
+     * position, not the body's `{` (which is where the node is
+     * actually astNew'd). Jump-to-definition wants the name. */
+    int name_line = cc->lineno;
+    int name_col  = ast_col_hint; /* last consumed token = the name */
+    u32 name_file = ast_file_hint;
     int has_var_args = 0;
     cctrlTokenExpect(cc,'(');
     cc->localenv = cctrlCreateAstMap(cc->localenv);
@@ -2258,7 +2341,14 @@ Ast *parseFunctionOrDef(Cctrl *cc, AstType *rettype, char *fname, int len, int i
     Vec *params = parseParams(cc,')',&has_var_args,1);
     Lexeme *tok = cctrlTokenGet(cc);
     if (tokenPunctIs(tok, '{')) {
-        return parseFunctionDef(cc,rettype,fname,len,params,has_var_args,is_inline);
+        Ast *fn = parseFunctionDef(cc,rettype,fname,len,params,
+                                   has_var_args,is_inline);
+        if (fn) {
+            fn->line = name_line;
+            fn->col = name_col;
+            fn->file_id = name_file;
+        }
+        return fn;
     } else if (tokenPunctIs(tok, ';')) {
         if (rettype->kind == AST_TYPE_AUTO) {
             cctrlRaiseException(cc,"auto cannot be used with a function prototype %.*s() at this time",
@@ -2301,7 +2391,14 @@ Ast *parseAsmFunctionBinding(Cctrl *cc) {
                 tok->len,tok->start);
     }
 
-    asm_fname = aoStrDupRaw(tok->start,tok->len);
+    asm_fname = aoStrDupRaw(tok->start, tok->len);
+    /* No existence check here, deliberately: a binding's label is
+     * usually EXTERNAL - stdlib headers bind `_extern _MALLOC`-style
+     * labels whose bodies live in libtos, and the lib itself binds
+     * straight to C symbols (`_extern _opendir`). Only the linker can
+     * tell a dangling label from an external one; a parse-time raise
+     * broke every AOT compile. A typo'd in-file label still surfaces:
+     * the asm block's own errors are reported on their lines. */
     Ast *asm_blk = mapGetLen(cc->asm_functions, asm_fname->data, asm_fname->len);
 
     rettype = parseDeclSpec(cc);
@@ -2316,6 +2413,7 @@ Ast *parseAsmFunctionBinding(Cctrl *cc) {
         cctrlRaiseException(cc,"line %d: ASM function requires c function name");
     }
     c_fname = aoStrDupRaw(tok->start,tok->len);
+    int name_line = tok->line, name_col = tok->col;
     cc->localenv = cctrlCreateAstMap(cc->localenv);
     cctrlTokenExpect(cc,'(');
 
@@ -2324,6 +2422,10 @@ Ast *parseAsmFunctionBinding(Cctrl *cc) {
     asm_func = astAsmFunctionBind(
             astMakeFunctionType(rettype, params),
             asm_fname,c_fname,params);
+    /* Anchor to the C-name token so jump-to-def on e.g. MAlloc lands
+     * on the name inside the prototype. */
+    asm_func->line = name_line;
+    asm_func->col = name_col;
 
     /* update the assembly block so it knows the HC function name */
     if (asm_blk && asm_blk->fname == NULL) {
@@ -2412,8 +2514,10 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
                     type = parseFullType(cc);
                     name = cctrlTokenGet(cc);
                     
-                    ast = parseFunctionOrDef(cc,type,name->start,name->len,1); 
+                    ast = parseFunctionOrDef(cc,type,name->start,name->len,1);
                     ast->flags |= AST_FLAG_INLINE;
+                    ast->line = name->line;
+                    ast->col = name->col;
                     return ast;
                 }
                 case KW_PUBLIC:
@@ -2690,7 +2794,15 @@ Ast *parseToplevelDef(Cctrl *cc, int *is_global) {
         }
 
         if (tokenPunctIs(tok, '(')) {
-            return parseFunctionOrDef(cc,type,name->start,name->len,0); 
+            Ast *fn = parseFunctionOrDef(cc,type,name->start,name->len,0);
+            /* Anchor to the name token - covers prototypes too, and
+             * corrects the in-function anchor (a token get+rewind
+             * between name and call left the hint on the `(`). */
+            if (fn) {
+                fn->line = name->line;
+                fn->col = name->col;
+            }
+            return fn;
         }
 
         if (tokenPunctIs(tok,';') || tokenPunctIs(tok, ',')) {

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -50,10 +50,19 @@ Target prsAsmTasmArch(Cctrl *cc) {
 
 void prsAsmDiagSink(void *ctx, AsmLine *ln, const char *msg) {
     Cctrl *cc = (Cctrl *)ctx;
-    (void)ln;
-    /* libtasm pre-formats messages with their own file:line prefix. */
     AoStr *rendered = aoStrPrintf("%s", msg);
-    cctrlDiagPush(cc, cctrlMakeDiag(cc, CCTRL_ERROR, rendered, NULL));
+    CctrlDiagnostic *d = cctrlMakeDiag(cc, CCTRL_ERROR, rendered, NULL);
+    /* cctrlMakeDiag defaults the position to the current token, which
+     * for an asm error sits PAST the whole block - every mnemonic
+     * error then collapses onto the line after `}`. libtasm knows the
+     * real source line; use it so errors land on their instructions. */
+    if (ln && ln->line > 0) {
+        d->line = ln->line;
+        d->col = 0;
+        d->end_line = ln->line;
+        d->end_col = 0;
+    }
+    cctrlDiagPush(cc, d);
 }
 
 static const char *prsAsmSrcFile(Cctrl *cc) {
@@ -143,7 +152,16 @@ static void prsAsmFlushFunc(Cctrl *cc, List *funcs, AoStr *curfunc,
     Ast *fn = astAsmFunctionDef(curfunc, cur);
     listAppend(funcs, fn);
     if (!mapAddOrErr(cc->asm_functions, curfunc->data, fn)) {
-        cctrlIce(cc, "Already defined assembly function: %s", curfunc->data);
+        /* REPL/LSP reparse the same buffer against a persistent Cctrl,
+         * so the asm block is genuinely redefined - shadow it like a
+         * function redefinition rather than aborting. */
+        if (cc->flags & CCTRL_REPL) {
+            mapRemove(cc->asm_functions, curfunc->data);
+            mapAdd(cc->asm_functions, curfunc->data, fn);
+        } else {
+            cctrlIce(cc, "Already defined assembly function: %s",
+                     curfunc->data);
+        }
     }
 }
 
@@ -173,7 +191,11 @@ Ast *prsAsm(Cctrl *cc, int parse_one) {
                 cc->tmp_asm_fname = curfunc;
                 cur = aoStrNew();
                 prev_cur = 0;
-                func_line = (int)tok->line;
+                /* `cur` collects the body AFTER the `NAME::\n` label,
+                 * so its first line is the one below the label - anchor
+                 * validation there or every asm error reports one line
+                 * high. */
+                func_line = (int)tok->line + 1;
                 aoStrCatFmt(block_text, "%S::\n", curfunc);
                 prev_block = 0;
                 tok = cctrlAsmTokenGet(cc);

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -159,6 +159,10 @@ Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
         AoStr *pinned_reg;
         parseRegModifier(cc, &pinned_kind, &pinned_reg);
         pname = cctrlTokenGet(cc);
+        if (pname == NULL) {
+            cctrlRaiseException(cc,
+                    "Unexpected end of input in parameter list");
+        }
 
         if (tokenPunctIs(pname, ')') && arg_count == 0) {
             if (type->kind == AST_TYPE_VOID) {
@@ -228,6 +232,10 @@ Vec *parseParams(Cctrl *cc, s64 terminator, int *has_var_args, int store) {
             type = astMakePointerType(type->ptr);
         }
         var = astLVar(type,pname->start,pname->len);
+        /* Anchor the param to its name token (astNew stamped whatever
+         * token the parser had just consumed). */
+        var->line = pname->line;
+        var->col = pname->col;
         var->pinned_kind = pinned_kind;
         var->pinned_reg = pinned_reg;
 
@@ -291,6 +299,12 @@ AstType *parseBaseDeclSpec(Cctrl *cc) {
 
 AstType *parseDeclSpec(Cctrl *cc) {
     AstType *type = parseBaseDeclSpec(cc);
+    /* NULL means end-of-input (parseBaseDeclSpec's guard) - no caller
+     * can make progress with a missing type, and several deref it. */
+    if (type == NULL) {
+        cctrlRaiseException(cc,
+                "Unexpected end of input, expected a type");
+    }
     type = parsePointerType(cc,type);
     return type;
 }
@@ -674,6 +688,11 @@ Vec *parseArgv(Cctrl *cc, Ast *decl, s64 terminator, char *fname, int len) {
             break;
         }
 
+        if (tok == NULL) {
+            cctrlRaiseException(cc,
+                    "Unexpected end of input in call to `%.*s` "
+                    "(unterminated `( ... )`?)", len, fname);
+        }
         if (!tokenPunctIs(tok,',')) {
             cctrlRewindUntilPunctMatch(cc, tok->i64, NULL);
             /* We could have a malformed string as a function argument */
@@ -980,6 +999,12 @@ static Ast *parseIdentifierOrFunction(Cctrl *cc,
     if ((ast = cctrlGetVar(cc, name, len)) == NULL) {
         cctrlRewindUntilStrMatch(cc, name, len, NULL);
         peek = cctrlTokenPeek(cc);
+        if (tok == NULL) {
+            /* Identifier at end of input - nothing to suggest from. */
+            cctrlRaiseException(cc,
+                    "Variable or function `%.*s` has not been defined",
+                    len, name);
+        }
         if (tok->tk_type == TK_PUNCT) {
             switch (tok->i64) {
                 case '(': {
@@ -1029,8 +1054,10 @@ static Ast *parseIdentifierOrFunction(Cctrl *cc,
         return ast;
     }
 
-    /* Is a function call if the next char is '(' and the peek is not a type */
-    if (!cctrlIsKeyword(cc,peek->start,peek->len)) {
+    /* Is a function call if the next char is '(' and the peek is not a
+     * type. peek == NULL (end of input) counts as a call attempt - the
+     * argument parser raises the unterminated-`(` diagnostic. */
+    if (peek == NULL || !cctrlIsKeyword(cc,peek->start,peek->len)) {
         return parseFunctionArguments(cc,name,len,')');
     }
 
@@ -1212,6 +1239,10 @@ Ast *parseGetClassField(Cctrl *cc, Ast *cls) {
     type = cls->type;
 
     Lexeme *tok = cctrlTokenGet(cc);
+    if (tok == NULL) {
+        cctrlRaiseException(cc,
+                "Unexpected end of input after '->' or '.'");
+    }
     if (tok->tk_type != TK_IDENT) {
         cctrlRaiseExceptionFromTo(cc,NULL,'-',*tok->start,"Expected class member got %s `%.*s`",
                             lexemeTypeToString(tok->tk_type),
@@ -1452,7 +1483,13 @@ Ast *parseSizeof(Cctrl *cc) {
     AstType *type = NULL;
     Ast *ast = NULL;
 
-    if (tokenPunctIs(tok,'(') && cctrlIsKeyword(cc,peek->start,peek->len)) {
+    /* EOF right after `sizeof`: rewinding and re-parsing would re-read
+     * the `sizeof` keyword and recurse here forever (stack overflow). */
+    if (tok == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input after `sizeof`");
+    }
+    if (tokenPunctIs(tok,'(') && peek &&
+        cctrlIsKeyword(cc,peek->start,peek->len)) {
         type = parseFullType(cc);
         cctrlTokenExpect(cc,')');
     } else {
@@ -1486,7 +1523,12 @@ Ast *parseAlignof(Cctrl *cc) {
     Lexeme *peek = cctrlTokenPeek(cc);
     AstType *type = NULL;
 
-    if (tokenPunctIs(tok,'(') && cctrlIsKeyword(cc,peek->start,peek->len)) {
+    /* Same EOF-recursion hazard as parseSizeof. */
+    if (tok == NULL) {
+        cctrlRaiseException(cc, "Unexpected end of input after `alignof`");
+    }
+    if (tokenPunctIs(tok,'(') && peek &&
+        cctrlIsKeyword(cc,peek->start,peek->len)) {
         type = parseFullType(cc);
         cctrlTokenExpect(cc,')');
     } else {
@@ -1552,6 +1594,10 @@ Ast *parsePostFixExpr(Cctrl *cc) {
         /* Postfix type cast OR function pointer on a class */
         if (tokenPunctIs(tok,'(')) {
             peek = cctrlTokenPeek(cc);
+            if (peek == NULL) {
+                cctrlRaiseException(cc,
+                        "Unexpected end of input after '('");
+            }
             if (cctrlIsKeyword(cc,peek->start,peek->len)) {
                 type = parseDeclSpec(cc);
                 cctrlTokenExpect(cc,')');

--- a/src/repl.c
+++ b/src/repl.c
@@ -304,9 +304,14 @@ static void replReportFault(void) {
     const char *sym = jit ? hccJitFindSymbolForAddr(jit, pc, &off) : NULL;
     uint8_t *show = pc; /* where the disassembly window points */
 
-    if      (sym)   fprintf(stderr, " in `%s`+%zu\n", sym, off);
-    else if (chunk) fprintf(stderr, " in a call veneer\n");
-    else {
+    if (sym) {
+        int line = hccJitFindLineForAddr(jit, pc);
+        fprintf(stderr, " in `%s`+%zu", sym, off);
+        if (line) fprintf(stderr, ", line %d", line);
+        fprintf(stderr, "\n");
+    } else if (chunk) {
+        fprintf(stderr, " in a call veneer\n");
+    } else {
         /* pc is host/libc code - the handler already walked the frame
          * chain (while the faulting frames were still intact) to find
          * the HolyC frame that called out. */
@@ -316,8 +321,17 @@ static void replReportFault(void) {
             sym = hccJitFindSymbolForAddr(jit, (void *)frame, &off);
             show = (uint8_t *)frame;
             fprintf(stderr, " in host code,\n    called from ");
-            if (sym) fprintf(stderr, "`%s`+%zu\n", sym, off);
-            else     fprintf(stderr, "%p in JIT code\n", (void *)frame);
+            if (sym) {
+                /* `frame` is a return address - the call is the
+                 * instruction before it, so attribute to addr-1. */
+                int line = hccJitFindLineForAddr(jit,
+                                                 (void *)(frame - 1));
+                fprintf(stderr, "`%s`+%zu", sym, off);
+                if (line) fprintf(stderr, ", line %d", line);
+                fprintf(stderr, "\n");
+            } else {
+                fprintf(stderr, "%p in JIT code\n", (void *)frame);
+            }
         } else {
             fprintf(stderr, " (no JIT frame on the stack - possibly an hcc bug)\n");
         }

--- a/src/tests/63_big_stack_frames.HC
+++ b/src/tests/63_big_stack_frames.HC
@@ -1,0 +1,93 @@
+"Test - big stack frames: ";
+#include "testhelper.HC"
+
+/* aarch64 add/sub immediates encode 12 bits (optionally lsl #12);
+ * frames past 4095 bytes once emitted unencodable prologue/epilogue
+ * adjusts, `add x0, x29, #-big` local addresses, and out-of-range
+ * ldr/str displacements. Every function here carries an 8KB pad so
+ * all of those paths run in the >4095 regime. */
+
+class BigPair
+{
+  I64 a;
+  I64 b;
+};
+
+class BigHfa
+{
+  F64 x;
+  F64 y;
+};
+
+class BigFive
+{
+  I64 vals[5];
+};
+
+I64 correct = 0;
+I64 tests = 10;
+
+I64 SumByValue(BigFive f)
+{ /* 40-byte by-value param copied into a big frame */
+  U8 pad[8192];
+  pad[0] = 7;
+  pad[8191] = 9;
+  I64 s = 0;
+  for (I64 i = 0; i < 5; i++) s = s + f.vals[i];
+  return s + pad[0] + pad[8191];
+}
+
+BigPair MakePair(I64 base)
+{ /* <=16-byte INTEGER-class return out of a big frame */
+  U8 pad[8192];
+  pad[100] = 1;
+  BigPair p;
+  p.a = base + pad[100];
+  p.b = base * 2;
+  return p;
+}
+
+BigHfa MakeHfa()
+{ /* HFA return out of a big frame */
+  U8 pad[8192];
+  pad[50] = 2;
+  I64 t = pad[50];
+  BigHfa h;
+  h.x = 1.5 + t;
+  h.y = 2.5;
+  return h;
+}
+
+U0 Main()
+{
+  U8 buf[8192];      /* prologue/epilogue immediate split */
+  I64 sentinel = 42; /* scalar slot at a deep offset */
+  buf[0] = 11;
+  buf[8191] = 22;    /* constant-index store, disp > 4095 */
+  U8 *p = &buf[8191]; /* address-of at a deep offset */
+  I64 mid = 4000;
+  buf[mid] = 33;      /* register-indexed store */
+
+  BigFive five;
+  for (I64 i = 0; i < 5; i++) five.vals[i] = i + 1;
+
+  if (buf[0] == 11) correct++;
+  if (buf[8191] == 22) correct++;
+  if (*p == 22) correct++;
+  if (buf[mid] == 33) correct++;
+  if (sentinel == 42) correct++;
+  if (SumByValue(five) == 31) correct++; /* 15 + 7 + 9 */
+
+  BigPair pr = MakePair(10);
+  if (pr.a == 11) correct++;
+  if (pr.b == 20) correct++;
+
+  BigHfa h = MakeHfa();
+  if (h.x == 3.5) correct++;
+  if (h.y == 2.5) correct++;
+}
+Main;
+
+PrintResult(correct, tests);
+'===\n';
+Exit(0);

--- a/src/tests/lsp/run_lsp_tests.HC
+++ b/src/tests/lsp/run_lsp_tests.HC
@@ -1,0 +1,811 @@
+/* End-to-end tests for `hcc -lsp` over its real stdio transport,
+ * written in HolyC and driven by the local build - run via
+ * `make lsp-test`, which compiles this with <repo>/hcc (mirroring
+ * src/tests/run.HC: always test what was just built, never an
+ * installed hcc).
+ *
+ * The harness forks the server on a pipe pair, frames JSON-RPC with
+ * Content-Length headers, and parses replies with libtos's JsonParse/
+ * JsonSelect. Every cursor position is COMPUTED from the fixture text
+ * with PosOf() - never hardcoded. (Three separate debugging sessions
+ * were lost to hand-counted coordinates pointing at whitespace.)
+ *
+ * Covers, one fresh server per group:
+ *   handshake   initialize capabilities, clean shutdown exit code
+ *   sync        didOpen publishes once; clean file = 0 diagnostics;
+ *               broken file = an error on the right line; didClose
+ *               clears
+ *   definition  functions, locals (decl line), fields via typed
+ *               member chains, #include jump-to-file (plain / ./ /
+ *               subdir / missing->null / <builtin> when installed)
+ *   hover       function prototype; null off the end of a line
+ *   completion  prefix filter; symbols added by a didChange are
+ *               visible to an IMMEDIATE completion (flush-before-
+ *               query)
+ *   debounce    a keystroke storm publishes ONCE after quiet;
+ *               continuous typing still publishes via the max-age cap
+ *   survival    a parser-crashing input (function-like macro) yields
+ *               diagnostics, not a dead server; queries keep
+ *               answering through a crash storm
+ *
+ * Allocation discipline: this is a short-lived test process, so
+ * allocations are deliberately never freed - keeps the harness free
+ * of ownership bookkeeping that could itself be buggy.
+ *
+ * Stack discipline: buffers bigger than ~1KB live on the heap; the
+ * aarch64 backend cannot encode add/sub immediates over 4095, so a
+ * huge frame miscompiles at the assembler stage. */
+
+extern "c" I32 pipe(I32 *fds);
+extern "c" I32 fork();
+extern "c" I32 dup2(I32 from, I32 to);
+extern "c" I32 execv(U8 *path, U8 **argv);
+extern "c" I32 close(I32 fd);
+extern "c" I32 waitpid(I32 pid, I32 *status, I32 options);
+extern "c" I32 usleep(U32 usec);
+extern "c" I32 getpid();
+extern "c" U8 *strstr(U8 *big, U8 *little);
+extern "c" I32 poll(U0 *fds, U64 nfds, I32 timeout);
+extern "c" U8 *realpath(U8 *path, U8 *resolved);
+extern "c" I32 access(U8 *path, I32 mode);
+extern "c" I64 snprintf(U8 *buf, U64 len, U8 *fmt, ...);
+
+class LspPollFd
+{ /* struct pollfd */
+  I32 fd;
+  I16 events;
+  I16 revents;
+};
+
+#define LSP_POLLIN     0x0001
+#define REQ_TIMEOUT_MS 10000
+
+I64 g_pass;
+I64 g_fail;
+U8 *g_dir;  /* fixture dir, realpath'd */
+U8 *g_hcc;  /* absolute path of the hcc under test */
+
+/* ---------------- fixtures ---------------- */
+
+U8 *LIB_HC;
+U8 *DEEP_HC;
+U8 *MAIN_HC;
+U8 *BAD_INCLUDE_HC;
+U8 *BROKEN_HC;
+U8 *CRASHER_HC;
+
+U0 InitFixtures()
+{
+  LIB_HC =
+    "I64 LibAdd(I64 a, I64 b) {\n"
+    "  return a + b;\n"
+    "}\n"
+    "class LibPoint {\n"
+    "  I64 x;\n"
+    "  I64 y;\n"
+    "};\n";
+  DEEP_HC = "I64 DeepFn() { return 1; }\n";
+  MAIN_HC =
+    "#include \"lib.HC\"\n"
+    "#include \"./lib.HC\"\n"
+    "#include \"sub/deep.HC\"\n"
+    "I64 Main() {\n"
+    "  I64 total = LibAdd(1, 2);\n"
+    "  LibPoint p;\n"
+    "  p.x = total;\n"
+    "  return p.x;\n"
+    "}\n";
+  BAD_INCLUDE_HC = "#include \"missing.HC\"\n";
+  BROKEN_HC =
+    "I64 Main() {\n"
+    "  return not_a_symbol;\n"
+    "}\n";
+  /* The known parser-crasher: function-like macros. The point is NOT
+   * the crash (fixing it should keep this green) - it is that a
+   * hostile input produces diagnostics and a live server. */
+  CRASHER_HC =
+    "#define F(x) ((x)*2)\n"
+    "I64 Main() {\n"
+    "  return F(2);\n"
+    "}\n";
+}
+
+/* ---------------- small helpers ---------------- */
+
+U0 Check(U8 *name, Bool ok)
+{
+  if (ok) {
+    g_pass++;
+    "  \033[0;32mok\033[0;0m %s\n", name;
+  } else {
+    g_fail++;
+    "  \033[0;31mFAILED\033[0;0m %s\n", name;
+  }
+}
+
+I64 NowMs()
+{
+  timeval tv;
+  gettimeofday(&tv, NULL);
+  return tv.tv_sec * 1000 + tv.tv_usec / 1000;
+}
+
+/* 0-based (line, character) of `needle` in `text`, plus `within`
+ * characters. Positions always derive from the text so a fixture
+ * edit cannot silently point a query at whitespace. */
+Bool PosOf(U8 *text, U8 *needle, I64 within, I64 *line, I64 *chr)
+{
+  U8 *hit = strstr(text, needle);
+  if (hit == NULL) return FALSE;
+  I64 ln = 0;
+  U8 *line_start = text;
+  U8 *p = text;
+  while (p < hit) {
+    if (*p == '\n') {
+      ln++;
+      line_start = p + 1;
+    }
+    p++;
+  }
+  *line = ln;
+  *chr = hit - line_start + within;
+  return TRUE;
+}
+
+/* JSON string-escape `s` (quotes, backslashes, \n \r \t). */
+U8 *JsonEscapeText(U8 *s)
+{
+  I64 len = StrLen(s);
+  U8 *out = MAlloc(len * 2 + 1);
+  I64 o = 0;
+  for (I64 i = 0; i < len; i++) {
+    U8 c = s[i];
+    if (c == 0x22 || c == 0x5C) { /* " or \ */
+      out[o] = 0x5C;
+      o++;
+      out[o] = c;
+      o++;
+    } else if (c == 10) {
+      out[o] = 0x5C;
+      o++;
+      out[o] = 'n';
+      o++;
+    } else if (c == 13) {
+      out[o] = 0x5C;
+      o++;
+      out[o] = 'r';
+      o++;
+    } else if (c == 9) {
+      out[o] = 0x5C;
+      o++;
+      out[o] = 't';
+      o++;
+    } else {
+      out[o] = c;
+      o++;
+    }
+  }
+  out[o] = 0;
+  return out;
+}
+
+U8 *UriOf(U8 *rel)
+{
+  U8 *uri = MAlloc(StrLen(g_dir) + StrLen(rel) + 16);
+  snprintf(uri, StrLen(g_dir) + StrLen(rel) + 16, "file://%s/%s",
+           g_dir, rel);
+  return uri;
+}
+
+/* ---------------- the client ---------------- */
+
+class LspClient
+{
+  I32 pid;
+  I32 wfd;            /* requests go here (server stdin) */
+  I32 rfd;            /* replies come from here (server stdout) */
+  U8 *buf;            /* unconsumed transport bytes, NUL-terminated */
+  I64 len;
+  I64 cap;
+  I64 next_id;
+  I64 publishes;      /* every publishDiagnostics seen, ever */
+  Json *last_publish; /* the most recent one */
+};
+
+U0 LspSendBody(LspClient *l, U8 *body)
+{
+  U8 hdr[64];
+  I64 blen = StrLen(body);
+  I64 hlen = snprintf(hdr, 64, "Content-Length: %lld\r\n\r\n", blen);
+  Write(l->wfd, hdr, hlen);
+  Write(l->wfd, body, blen);
+}
+
+U0 LspNotify(LspClient *l, U8 *method, U8 *params)
+{
+  I64 cap = StrLen(method) + StrLen(params) + 64;
+  U8 *body = MAlloc(cap);
+  snprintf(body, cap, "{\"jsonrpc\":\"2.0\",\"method\":\"%s\",\"params\":%s}",
+           method, params);
+  LspSendBody(l, body);
+}
+
+/* One poll+read; TRUE if bytes arrived within timeout_ms. */
+Bool LspPump(LspClient *l, I64 timeout_ms)
+{
+  LspPollFd pfd;
+  pfd.fd = l->rfd;
+  pfd.events = LSP_POLLIN;
+  pfd.revents = 0;
+  if (poll(&pfd, 1, timeout_ms) <= 0) return FALSE;
+  if (l->cap - l->len < 8193) {
+    l->cap = l->cap * 2;
+    U8 *bigger = MAlloc(l->cap);
+    MemCpy(bigger, l->buf, l->len);
+    l->buf = bigger;
+  }
+  I64 got = read(l->rfd, l->buf + l->len, 8192);
+  if (got <= 0) return FALSE;
+  l->len += got;
+  l->buf[l->len] = 0;
+  return TRUE;
+}
+
+/* The next complete framed message, parsed - or NULL. Consumes it
+ * from the transport buffer. */
+Json *LspNextMsg(LspClient *l)
+{
+  U8 *sep = strstr(l->buf, "\r\n\r\n");
+  if (sep == NULL) return NULL;
+  U8 *cl = strstr(l->buf, "Content-Length:");
+  if (cl == NULL || cl > sep) return NULL;
+  I64 blen = Atoi(cl + 15);
+  U8 *body = sep + 4;
+  I64 have = l->len - (body - l->buf);
+  if (have < blen) return NULL;
+  Json *msg = JsonParse(body, blen);
+  I64 consumed = body - l->buf + blen;
+  I64 rest = l->len - consumed;
+  for (I64 i = 0; i < rest; i++) l->buf[i] = l->buf[consumed + i];
+  l->len = rest;
+  l->buf[l->len] = 0;
+  return msg;
+}
+
+/* Next buffered non-publish message; publishes are counted and
+ * stashed on the way past. */
+Json *LspTake(LspClient *l)
+{
+  while (TRUE) {
+    Json *msg = LspNextMsg(l);
+    if (msg == NULL) return NULL;
+    Json *method = JsonSelect(msg, ".method:s");
+    if (method != NULL &&
+        StrCmp(method->str, "textDocument/publishDiagnostics") == 0)
+    {
+      l->publishes++;
+      l->last_publish = msg;
+      continue;
+    }
+    return msg;
+  }
+}
+
+/* The response to request `id`; publishes arriving first are
+ * absorbed. NULL on timeout. */
+Json *LspCollectId(LspClient *l, I64 id, I64 timeout_ms)
+{
+  I64 deadline = NowMs() + timeout_ms;
+  while (TRUE) {
+    Json *msg = LspTake(l);
+    if (msg != NULL) {
+      Json *mid = JsonSelect(msg, ".id:i");
+      if (mid != NULL && mid->i64 == id) return msg;
+      continue; /* stray response; drop */
+    }
+    I64 remain = deadline - NowMs();
+    if (remain <= 0) return NULL;
+    LspPump(l, remain);
+  }
+}
+
+Json *LspRequest(LspClient *l, U8 *method, U8 *params,
+                 I64 timeout_ms=REQ_TIMEOUT_MS)
+{
+  l->next_id++;
+  I64 cap = StrLen(method) + StrLen(params) + 96;
+  U8 *body = MAlloc(cap);
+  snprintf(body, cap,
+           "{\"jsonrpc\":\"2.0\",\"id\":%lld,\"method\":\"%s\",\"params\":%s}",
+           l->next_id, method, params);
+  LspSendBody(l, body);
+  return LspCollectId(l, l->next_id, timeout_ms);
+}
+
+/* Absorb everything the server says for a fixed quiet window - for
+ * counting debounced publishes, where returning early would lie. */
+U0 LspSettle(LspClient *l, I64 window_ms)
+{
+  I64 deadline = NowMs() + window_ms;
+  while (TRUE) {
+    Json *stray = LspTake(l);
+    if (stray != NULL) continue;
+    I64 remain = deadline - NowMs();
+    if (remain <= 0) return;
+    LspPump(l, remain);
+  }
+}
+
+/* Wait until the running publish count reaches `target`. */
+Bool LspWaitPublishes(LspClient *l, I64 target, I64 timeout_ms)
+{
+  I64 deadline = NowMs() + timeout_ms;
+  while (l->publishes < target) {
+    Json *stray = LspTake(l);
+    if (stray != NULL) continue;
+    I64 remain = deadline - NowMs();
+    if (remain <= 0) return FALSE;
+    LspPump(l, remain);
+  }
+  return TRUE;
+}
+
+LspClient *LspStart()
+{
+  I32 to_child[2];
+  I32 from_child[2];
+  if (pipe(to_child) != 0 || pipe(from_child) != 0) {
+    "\033[0;31mFAILED\033[0;0m: pipe()\n";
+    Exit(1);
+  }
+  I32 pid = fork();
+  if (pid == 0) {
+    dup2(to_child[0], 0);
+    dup2(from_child[1], 1);
+    /* The server logs intentional-fixture errors on stderr; keep the
+     * test output clean. O_WRONLY == 1. */
+    I32 devnull = open("/dev/null", 1, 0);
+    if (devnull >= 0) dup2(devnull, 2);
+    close(to_child[1]);
+    close(from_child[0]);
+    U8 *args[3];
+    args[0] = g_hcc;
+    args[1] = "-lsp";
+    args[2] = NULL;
+    execv(g_hcc, args);
+    Exit(127);
+  }
+  close(to_child[0]);
+  close(from_child[1]);
+  LspClient *l = MAlloc(sizeof(LspClient));
+  l->pid = pid;
+  l->wfd = to_child[1];
+  l->rfd = from_child[0];
+  l->cap = 1 << 16;
+  l->buf = MAlloc(l->cap);
+  l->len = 0;
+  l->buf[0] = 0;
+  l->next_id = 0;
+  l->publishes = 0;
+  l->last_publish = NULL;
+  Json *resp = LspRequest(l, "initialize", "{}");
+  if (resp == NULL) {
+    "\033[0;31mFAILED\033[0;0m: no initialize response\n";
+    Exit(1);
+  }
+  return l;
+}
+
+/* shutdown + exit; the server's exit code, or -1 if it died on a
+ * signal. */
+I64 LspClose(LspClient *l)
+{
+  LspRequest(l, "shutdown", "{}", 5000);
+  LspNotify(l, "exit", "{}");
+  close(l->wfd);
+  close(l->rfd);
+  I32 status = 0;
+  waitpid(l->pid, &status, 0);
+  if (status & 0x7f) return -1;
+  return (status >> 8) & 0xFF;
+}
+
+U0 LspDidOpen(LspClient *l, U8 *uri, U8 *text)
+{
+  U8 *esc = JsonEscapeText(text);
+  I64 cap = StrLen(esc) + StrLen(uri) + 128;
+  U8 *params = MAlloc(cap);
+  snprintf(params, cap,
+           "{\"textDocument\":{\"uri\":\"%s\",\"languageId\":\"holyc\","
+           "\"version\":1,\"text\":\"%s\"}}",
+           uri, esc);
+  LspNotify(l, "textDocument/didOpen", params);
+  /* didOpen analyzes immediately - wait for its publish. */
+  LspWaitPublishes(l, l->publishes + 1, 5000);
+}
+
+U0 LspDidChange(LspClient *l, U8 *uri, U8 *text)
+{
+  U8 *esc = JsonEscapeText(text);
+  I64 cap = StrLen(esc) + StrLen(uri) + 128;
+  U8 *params = MAlloc(cap);
+  snprintf(params, cap,
+           "{\"textDocument\":{\"uri\":\"%s\"},"
+           "\"contentChanges\":[{\"text\":\"%s\"}]}",
+           uri, esc);
+  LspNotify(l, "textDocument/didChange", params);
+}
+
+Json *LspPositionRequest(LspClient *l, U8 *method, U8 *uri,
+                         I64 line, I64 chr)
+{
+  U8 params[512];
+  snprintf(params, 512,
+           "{\"textDocument\":{\"uri\":\"%s\"},"
+           "\"position\":{\"line\":%lld,\"character\":%lld}}",
+           uri, line, chr);
+  return LspRequest(l, method, params);
+}
+
+/* MAIN_HC plus one appended declaration - for keystroke storms. */
+U8 *MainPlusFn(U8 *name, I64 i)
+{
+  I64 cap = StrLen(MAIN_HC) + 64;
+  U8 *text = MAlloc(cap);
+  snprintf(text, cap, "%s\nI64 %s%lld() { return %lld; }\n",
+           MAIN_HC, name, i, i);
+  return text;
+}
+
+/* ---------------- response predicates ---------------- */
+
+Bool IsNullResult(Json *resp)
+{
+  if (resp == NULL) return FALSE;
+  return JsonSelect(resp, ".result:!") != NULL;
+}
+
+Bool LocEq(Json *resp, U8 *want_uri, I64 want_line, I64 want_chr,
+           Bool check_chr)
+{
+  if (resp == NULL) return FALSE;
+  Json *u = JsonSelect(resp, ".result.uri:s");
+  Json *ln = JsonSelect(resp, ".result.range.start.line:i");
+  Json *ch = JsonSelect(resp, ".result.range.start.character:i");
+  if (u == NULL || ln == NULL || ch == NULL) return FALSE;
+  if (StrCmp(u->str, want_uri) != 0) return FALSE;
+  if (ln->i64 != want_line) return FALSE;
+  if (check_chr && ch->i64 != want_chr) return FALSE;
+  return TRUE;
+}
+
+Bool HoverContains(Json *resp, U8 *needle)
+{
+  if (resp == NULL) return FALSE;
+  Json *val = JsonSelect(resp, ".result.contents.value:s");
+  if (val == NULL) return FALSE;
+  return strstr(val->str, needle) != NULL;
+}
+
+/* All labels start with `prefix`; `must1`/`must2` are present
+ * (must2 may be NULL). */
+Bool LabelsOk(Json *resp, U8 *prefix, U8 *must1, U8 *must2)
+{
+  Json *items = JsonSelect(resp, ".result.items:a");
+  if (items == NULL) return FALSE;
+  Bool has1 = FALSE;
+  Bool has2 = FALSE;
+  if (must2 == NULL) has2 = TRUE;
+  Json *it = items->array;
+  while (it != NULL) {
+    Json *lab = JsonSelect(it, ".label:s");
+    if (lab == NULL) return FALSE;
+    if (StrNCmp(lab->str, prefix, StrLen(prefix)) != 0) return FALSE;
+    if (StrCmp(lab->str, must1) == 0) has1 = TRUE;
+    if (must2 != NULL && StrCmp(lab->str, must2) == 0) has2 = TRUE;
+    it = it->next;
+  }
+  return has1 && has2;
+}
+
+/* Diagnostics array of the LAST publish is empty. */
+Bool LastPublishClean(LspClient *l)
+{
+  if (l->last_publish == NULL) return FALSE;
+  Json *diags = JsonSelect(l->last_publish, ".params.diagnostics:a");
+  if (diags == NULL) return FALSE;
+  return diags->array == NULL;
+}
+
+/* ---------------- test groups ---------------- */
+
+U0 TestHandshake()
+{
+  "handshake\n";
+  LspClient *l = LspStart();
+  Json *resp = LspRequest(l, "initialize", "{}");
+  Bool ok = FALSE;
+  if (resp != NULL) {
+    Json *df = JsonSelect(resp, ".result.capabilities.definitionProvider:b");
+    Json *hv = JsonSelect(resp, ".result.capabilities.hoverProvider:b");
+    Json *cp = JsonSelect(resp, ".result.capabilities.completionProvider:o");
+    if (df != NULL && df->boolean && hv != NULL && hv->boolean &&
+        cp != NULL)
+    {
+      ok = TRUE;
+    }
+  }
+  Check("advertises definition/hover/completion", ok);
+  Check("clean shutdown exit code", LspClose(l) == 0);
+}
+
+U0 TestSync()
+{
+  "document sync\n";
+  LspClient *l = LspStart();
+  U8 *uri = UriOf("main.HC");
+  I64 before = l->publishes;
+  LspDidOpen(l, uri, MAIN_HC);
+  LspSettle(l, 300);
+  Check("didOpen publishes exactly once", l->publishes - before == 1);
+  Check("clean file has 0 diagnostics", LastPublishClean(l));
+
+  U8 *buri = UriOf("broken.HC");
+  LspDidOpen(l, buri, BROKEN_HC);
+  I64 line;
+  I64 chr;
+  PosOf(BROKEN_HC, "not_a_symbol", 0, &line, &chr);
+  Bool on_line = FALSE;
+  if (l->last_publish != NULL) {
+    Json *sev = JsonSelect(l->last_publish,
+                           ".params.diagnostics[0].severity:i");
+    Json *dl = JsonSelect(l->last_publish,
+                          ".params.diagnostics[0].range.start.line:i");
+    if (sev != NULL && sev->i64 == 1 && dl != NULL && dl->i64 == line) {
+      on_line = TRUE;
+    }
+  }
+  Check("broken file gets an error diagnostic on the right line", on_line);
+
+  U8 params[512];
+  snprintf(params, 512, "{\"textDocument\":{\"uri\":\"%s\"}}", buri);
+  LspNotify(l, "textDocument/didClose", params);
+  LspWaitPublishes(l, l->publishes + 1, 5000);
+  Check("didClose clears diagnostics", LastPublishClean(l));
+  Check("clean shutdown", LspClose(l) == 0);
+}
+
+U0 TestDefinition()
+{
+  "definition\n";
+  LspClient *l = LspStart();
+  U8 *uri = UriOf("main.HC");
+  U8 *lib_uri = UriOf("lib.HC");
+  LspDidOpen(l, uri, MAIN_HC);
+
+  I64 line;
+  I64 chr;
+  I64 want_line;
+  I64 want_chr;
+
+  /* Symbol: the LibAdd call site -> its defining name in lib.HC. */
+  PosOf(MAIN_HC, "LibAdd(1, 2)", 2, &line, &chr);
+  Json *resp = LspPositionRequest(l, "textDocument/definition", uri,
+                                  line, chr);
+  PosOf(LIB_HC, "LibAdd", 0, &want_line, &want_chr);
+  Check("function resolves into the included file",
+        LocEq(resp, lib_uri, want_line, want_chr, TRUE));
+
+  /* Local: the `total` usage in `p.x = total;` -> its declaration. */
+  PosOf(MAIN_HC, "total;", 2, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+  PosOf(MAIN_HC, "I64 total", 0, &want_line, &want_chr);
+  Check("local resolves to its declaration",
+        LocEq(resp, uri, want_line, want_chr, FALSE));
+
+  /* Field: p.x -> the x member of LibPoint in lib.HC. */
+  PosOf(MAIN_HC, "p.x = total", 2, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+  PosOf(LIB_HC, "I64 x", 0, &want_line, &want_chr);
+  Check("field resolves through the member chain",
+        LocEq(resp, lib_uri, want_line, want_chr, FALSE));
+
+  /* Include jumps: anywhere on the line, to the top of the file. */
+  PosOf(MAIN_HC, "#include \"lib.HC\"", 4, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+  Check("include jump: plain relative", LocEq(resp, lib_uri, 0, 0, TRUE));
+
+  PosOf(MAIN_HC, "#include \"./lib.HC\"", 4, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+  Check("include jump: dot-slash", LocEq(resp, lib_uri, 0, 0, TRUE));
+
+  PosOf(MAIN_HC, "#include \"sub/deep.HC\"", 4, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+  Check("include jump: subdirectory",
+        LocEq(resp, UriOf("sub/deep.HC"), 0, 0, TRUE));
+
+  /* A missing target answers null - never an identifier fallthrough
+   * on the path fragments. */
+  U8 *buri = UriOf("bad.HC");
+  LspDidOpen(l, buri, BAD_INCLUDE_HC);
+  PosOf(BAD_INCLUDE_HC, "missing", 0, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/definition", buri, line, chr);
+  Check("missing include target answers null", IsNullResult(resp));
+
+  /* Builtin <tos.HH>: only when a stdlib is installed to point at. */
+  if (access("/usr/local/include/tos.HH", 0) == 0) {
+    I64 cap = StrLen(MAIN_HC) + 32;
+    U8 *with_tos = MAlloc(cap);
+    snprintf(with_tos, cap, "%s#include <tos.HH>\n", MAIN_HC);
+    LspDidChange(l, uri, with_tos);
+    PosOf(with_tos, "#include <tos.HH>", 11, &line, &chr);
+    resp = LspPositionRequest(l, "textDocument/definition", uri, line, chr);
+    Check("include jump: <tos.HH> via builtin root",
+          LocEq(resp, "file:///usr/local/include/tos.HH", 0, 0, TRUE));
+  } else {
+    "  (skipped <tos.HH> jump: no installed stdlib)\n";
+  }
+  Check("clean shutdown", LspClose(l) == 0);
+}
+
+U0 TestHoverCompletion()
+{
+  "hover & completion\n";
+  LspClient *l = LspStart();
+  U8 *uri = UriOf("main.HC");
+  LspDidOpen(l, uri, MAIN_HC);
+
+  I64 line;
+  I64 chr;
+  PosOf(MAIN_HC, "LibAdd(1, 2)", 2, &line, &chr);
+  Json *resp = LspPositionRequest(l, "textDocument/hover", uri, line, chr);
+  Check("hover shows the function prototype", HoverContains(resp, "LibAdd"));
+
+  PosOf(MAIN_HC, "I64 Main", 0, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/hover", uri, line, 999);
+  Check("hover past end of line is null", IsNullResult(resp));
+
+  /* Prefix "Lib" - cursor after the 3rd char of the call site. */
+  PosOf(MAIN_HC, "LibAdd(1, 2)", 3, &line, &chr);
+  resp = LspPositionRequest(l, "textDocument/completion", uri, line, chr);
+  Check("completion is prefix-filtered",
+        LabelsOk(resp, "Lib", "LibAdd", "LibPoint"));
+
+  /* Flush-before-query: a symbol added by an edit must be visible to
+   * an IMMEDIATE completion, no quiet period. */
+  I64 cap = StrLen(MAIN_HC) + 64;
+  U8 *with_mul = MAlloc(cap);
+  snprintf(with_mul, cap, "%s\nI64 LibMul(I64 a, I64 b) { return a * b; }\n",
+           MAIN_HC);
+  LspDidChange(l, uri, with_mul);
+  resp = LspPositionRequest(l, "textDocument/completion", uri, line, chr);
+  Check("completion right after an edit sees the new symbol",
+        LabelsOk(resp, "Lib", "LibMul", NULL));
+  Check("clean shutdown", LspClose(l) == 0);
+}
+
+U0 TestDebounce()
+{
+  "debounce\n";
+  LspClient *l = LspStart();
+  U8 *uri = UriOf("main.HC");
+  LspDidOpen(l, uri, MAIN_HC);
+
+  /* 15 keystrokes 20ms apart: all inside the idle window, done well
+   * before the max-age cap -> exactly one analysis. */
+  I64 before = l->publishes;
+  for (I64 i = 0; i < 15; i++) {
+    LspDidChange(l, uri, MainPlusFn("S", i));
+    usleep(20000);
+  }
+  LspSettle(l, 1000);
+  Check("keystroke storm publishes exactly once",
+        l->publishes - before == 1);
+
+  /* ~1.5s of continuous typing, never quiet: the max-age cap must
+   * force diagnostics through mid-storm, and once more at the end. */
+  before = l->publishes;
+  for (I64 i = 0; i < 36; i++) {
+    LspDidChange(l, uri, MainPlusFn("C", i));
+    LspSettle(l, 40);
+  }
+  I64 mid = l->publishes - before;
+  before = l->publishes;
+  LspSettle(l, 1000);
+  I64 tail = l->publishes - before;
+  Check("continuous typing still publishes via the max-age cap",
+        mid >= 1 && tail == 1);
+  Check("clean shutdown", LspClose(l) == 0);
+}
+
+U0 TestSurvival()
+{
+  "crash survival\n";
+  LspClient *l = LspStart();
+  U8 *uri = UriOf("main.HC");
+  U8 *curi = UriOf("crash.HC");
+  LspDidOpen(l, uri, MAIN_HC);
+
+  /* A hostile document: diagnostics of SOME kind, never silence. */
+  I64 before = l->publishes;
+  LspDidOpen(l, curi, CRASHER_HC);
+  Check("hostile input produces diagnostics", l->publishes - before >= 1);
+
+  /* A crash storm; the canary contains it and features keep serving
+   * from the last good parse. */
+  for (I64 i = 0; i < 10; i++) {
+    I64 cap = StrLen(CRASHER_HC) + 32;
+    U8 *text = MAlloc(cap);
+    snprintf(text, cap, "%s\nI64 K%lld();\n", CRASHER_HC, i);
+    LspDidChange(l, curi, text);
+  }
+  LspSettle(l, 1300);
+
+  I64 line;
+  I64 chr;
+  PosOf(MAIN_HC, "LibAdd(1, 2)", 2, &line, &chr);
+  Json *resp = LspPositionRequest(l, "textDocument/hover", uri, line, chr);
+  Check("hover still answers after a crash storm",
+        HoverContains(resp, "LibAdd"));
+  Check("server survives to shut down cleanly", LspClose(l) == 0);
+}
+
+/* ---------------- driver ---------------- */
+
+I32 Main()
+{
+  InitFixtures();
+  g_pass = 0;
+  g_fail = 0;
+
+  /* Test the LOCAL build: this runner lives in src/tests/lsp and is
+   * compiled+run from there by `make lsp-test`. */
+  g_hcc = MAlloc(1024);
+  if (realpath("../../../hcc", g_hcc) == NULL ||
+      access(g_hcc, 1) != 0)
+  {
+    "\033[0;31mFAILED\033[0;0m: ../../../hcc not built or not "
+    "executable (run `make` first, and run this via `make lsp-test`)\n";
+    return 1;
+  }
+
+  U8 tmp[128];
+  snprintf(tmp, 128, "/tmp/hcc_lsp_test_%d", getpid());
+  U8 cmd[256];
+  snprintf(cmd, 256, "mkdir -p %s/sub", tmp);
+  System(cmd);
+  g_dir = MAlloc(1024);
+  realpath(tmp, g_dir);
+
+  U8 path[512];
+  snprintf(path, 512, "%s/lib.HC", g_dir);
+  FileWrite(path, LIB_HC, StrLen(LIB_HC));
+  snprintf(path, 512, "%s/sub/deep.HC", g_dir);
+  FileWrite(path, DEEP_HC, StrLen(DEEP_HC));
+  snprintf(path, 512, "%s/main.HC", g_dir);
+  FileWrite(path, MAIN_HC, StrLen(MAIN_HC));
+  snprintf(path, 512, "%s/bad.HC", g_dir);
+  FileWrite(path, BAD_INCLUDE_HC, StrLen(BAD_INCLUDE_HC));
+  snprintf(path, 512, "%s/broken.HC", g_dir);
+  FileWrite(path, BROKEN_HC, StrLen(BROKEN_HC));
+  snprintf(path, 512, "%s/crash.HC", g_dir);
+  FileWrite(path, CRASHER_HC, StrLen(CRASHER_HC));
+
+  "hcc -lsp tests (%s)\n", g_hcc;
+  TestHandshake();
+  TestSync();
+  TestDefinition();
+  TestHoverCompletion();
+  TestDebounce();
+  TestSurvival();
+
+  snprintf(cmd, 256, "rm -rf %s", tmp);
+  System(cmd);
+
+  if (g_fail == 0) {
+    "\033[0;32mlsp: %d/%d passed\033[0;0m\n", g_pass, g_pass + g_fail;
+    return 0;
+  }
+  "\033[0;31mlsp: %d/%d passed\033[0;0m\n", g_pass, g_pass + g_fail;
+  return 1;
+}

--- a/src/x86_64-jit.c
+++ b/src/x86_64-jit.c
@@ -1603,7 +1603,9 @@ static int jitCompileFunction(HccJit *jit, Ast *ast, IrCtx *ir_ctx) {
             asm_define_label(&jit->enc, ln, NULL);
         }
         listForEach(block->instructions) {
-            jitEmitInstr(&ctx, (IrInstr *)it->value);
+            IrInstr *in = (IrInstr *)it->value;
+            hccJitNoteLine(jit, in->line);
+            jitEmitInstr(&ctx, in);
         }
     }
     setRelease(referenced);


### PR DESCRIPTION
Basic LSP functionality that I've tested with neovim

- Fixes for AArch64 assembler
- Add line and column to `Ast` & `AstType`
- Numerous fixes to the parser to account for the fact the LSP would cause it to segfault repeatedly 