### PR TITLE
Fix: for returning a struct where the function also has an argument

### DIFF
--- a/src/aarch64-emit.h
+++ b/src/aarch64-emit.h
@@ -93,14 +93,17 @@ static inline void a64EmitCall(A64CallEmitter *e, IrInstr *instr,
     u64 n = args ? args->size : 0;
     int ngrn = 0, nsrn = 0;
 
-    /* A <=16-byte aggregate return comes back in registers, so its
-     * destination buffer (args[0]) is NOT an ABI argument: skip it in the
-     * arg passing and copy the result registers into it after the call. A
-     * >16-byte (INDIRECT) return keeps args[0] as the hidden out-pointer. */
+    /* args[0] of an aggregate-returning call is the destination buffer,
+     * and it is never one of the x0-x7 arguments: a <=16-byte return
+     * comes back in registers (copy them into the buffer after the
+     * call), a >16-byte (INDIRECT) return passes the buffer address in
+     * x8, AAPCS64's dedicated indirect-result register. Skip it in the
+     * arg passing either way. */
     AstType *ret_st = (instr->flags & IRCG_CALL_AGG_RETURN) && instr->dst
                       ? instr->dst->byval_struct_type : NULL;
     int reg_ret = ret_st && ret_st->size <= 16;
-    u64 a0 = reg_ret ? 1 : 0;
+    int ind_ret = ret_st && ret_st->size > 16;
+    u64 a0 = ret_st ? 1 : 0;
 
     /* Pre-pass: size the stack-arg area (nsaa_total) and the INDIRECT copy
      * area (indirect_bytes). */
@@ -131,19 +134,25 @@ static inline void a64EmitCall(A64CallEmitter *e, IrInstr *instr,
             }
         }
     }
-    /* Reserve 8 bytes above the arg/copy regions to save the register-return
+    /* Reserve 8 bytes above the arg/copy regions to save the return
      * destination pointer across the call (x9 is caller-saved). */
     int dest_save_off = nsaa_total + indirect_bytes;
-    int total = (nsaa_total + indirect_bytes + (reg_ret ? 16 : 0) + 15) & ~15;
+    int total = (nsaa_total + indirect_bytes + (ret_st ? 16 : 0) + 15) & ~15;
     if (total > 0) e->sub_sp(e->be, total);
     int nsaa = 0, copy_off = 0, copy_base = nsaa_total;
 
-    if (reg_ret) {
+    if (ret_st) {
         /* Compute the destination buffer address into x9 (before the arg
          * loop clobbers x9) and stash it across the call. */
         e->load_struct_addr(e->be, vecGet(IrValue *, args, 0));
         e->stash_dest(e->be, dest_save_off);
     }
+    /* AAPCS64: an INDIRECT return buffer's address goes in x8, the
+     * dedicated indirect-result register (not x0 - that's SysV's rdi
+     * rule). Load it BEFORE the arg loop: args[0] may live in an arg
+     * register (a forwarded LEA), which the loop is about to overwrite;
+     * nothing in the loop touches x8. */
+    if (ind_ret) e->scalar_to_reg(e->be, vecGet(IrValue *, args, 0), 0, 8);
 
     for (u64 i = a0; i < n; ++i) {
         IrValue *a = vecGet(IrValue *, args, i);
@@ -223,14 +232,19 @@ static inline void a64EmitCall(A64CallEmitter *e, IrInstr *instr,
                 e->ret_chunk_store(e->be, 0, k, off, rem >= 8 ? 8 : rem);
             }
         }
+    } else if (ind_ret) {
+        /* The call's dst is the buffer address, but unlike SysV the
+         * callee does NOT return it in x0: reload the stashed copy
+         * while sp is still lowered. */
+        e->unstash_dest(e->be, dest_save_off);   /* x9 = dest buffer */
     }
 
     if (total > 0) e->add_sp(e->be, total);
 
-    if (reg_ret) {
+    if (ret_st) {
         e->spill_struct_dst(e->be, instr);  /* dst = buffer address (x9) */
     } else if (instr->dst && instr->dst->type != IR_TYPE_VOID) {
-        /* Scalar return, or INDIRECT struct return (x0 holds the out-ptr). */
+        /* Scalar return in x0 / d0. */
         e->spill_ret(e->be, instr, irIsFloat(instr->dst->type));
     }
 }
@@ -240,7 +254,7 @@ static inline void a64EmitCall(A64CallEmitter *e, IrInstr *instr,
  *
  * Receives by-value struct params (and register-overflow scalars) into their
  * frame slots. The shared body owns the same ABI accounting as the caller -
- * the hidden-return-pointer reservation, classification, NGRN/NSRN counters,
+ * classification, NGRN/NSRN counters,
  * the incoming-stack cursor (args start at [x29, #16]), and the
  * "unreferenced param -> no slot, still advance the cursor" rule. The backend
  * supplies leaves that store one aggregate chunk / copy a stack param /
@@ -276,10 +290,11 @@ static inline void a64EmitParamPrologue(A64ParamEmitter *e, Ast *ast,
     /* Next stack argument address */
     int nsaa = 0;
 
-    /* Only an INDIRECT (>16-byte) struct return uses a hidden out-pointer
-     * in x0; a <=16-byte aggregate comes back in registers. */
-    AstType *rt = ast->type ? ast->type->rettype : NULL;
-    if (a64IsByvalStruct(rt) && rt->size > 16) ngrn = 1;
+    /* An INDIRECT (>16-byte) struct return's hidden out-pointer arrives
+     * in x8, AAPCS64's dedicated indirect-result register, so it consumes
+     * no argument register (the IR-level arrive+store spills it); a
+     * <=16-byte aggregate comes back in registers. Either way ngrn
+     * starts at 0. */
 
     for (u64 i = 0; i < ast->params->size; ++i) {
         Ast *p = vecGet(Ast *, ast->params, i);

--- a/src/aarch64-jit.c
+++ b/src/aarch64-jit.c
@@ -1794,6 +1794,7 @@ static void jitInitRegPool(void) {
     pool.float_arg_regs   = fv;
     pool.int_return_reg   = aoStrDupRaw((char *)"x0", 2);
     pool.float_return_reg = aoStrDupRaw((char *)"d0", 2);
+    pool.sret_reg         = aoStrDupRaw((char *)"x8", 2);
     pool.scratch_regs     = sv;
     pool.variadic_on_stack = 1;
     irRegPoolSet(&pool);

--- a/src/aarch64.c
+++ b/src/aarch64.c
@@ -67,6 +67,7 @@ static void aarch64InitRegPool(void) {
     pool.float_arg_regs   = aarch64MakeAoStrVec(kFloatRegs,   n_float);
     pool.int_return_reg   = aoStrDupRaw((char *)"x0", 2);
     pool.float_return_reg = aoStrDupRaw((char *)"d0", 2);
+    pool.sret_reg         = aoStrDupRaw((char *)"x8", 2);
     pool.scratch_regs     = aarch64MakeAoStrVec(kScratchRegs, n_scratch);
     pool.variadic_on_stack = 1;
 

--- a/src/ir-regalloc.h
+++ b/src/ir-regalloc.h
@@ -27,6 +27,11 @@ typedef struct IrRegPool {
     Vec *float_arg_regs;
     /* Integer return register (rax on SysV, x0 on AAPCS64). */
     AoStr *int_return_reg;
+    /* Indirect struct-return pointer register, when the ABI dedicates
+     * one outside the argument sequence (AAPCS64: x8). NULL means the
+     * pointer is passed as the first integer argument and consumes
+     * that arg slot (x86-64 SysV: rdi). */
+    AoStr *sret_reg;
     /* Float return register (xmm0 / v0). */
     AoStr *float_return_reg;
     /* Per-instruction scratch surface: registers the codegen clobbers

--- a/src/ir.c
+++ b/src/ir.c
@@ -317,9 +317,9 @@ static int irBinOpIsCompoundAssign(AstBinOp op) {
 
 /* True when a function returns a non-intrinsic class / union by value -
  * i.e., the hidden out-pointer convention applies. The caller allocates a
- * buffer of `sizeof(rettype)`, passes its address as a hidden first arg
- * (in `rdi` on `x86_64`), and the callee writes the struct bytes there;
- * the call returns the buffer pointer in `rax`. */
+ * buffer of `sizeof(rettype)` and passes its address as a hidden arg
+ * (`rdi` on x86-64 SysV, which also returns it in `rax`; the dedicated
+ * `x8` on AAPCS64), and the callee writes the struct bytes there. */
 static int irRetTypeIsAggregate(AstType *rettype) {
     if (!rettype) return 0;
     if (rettype->kind != AST_TYPE_CLASS && rettype->kind != AST_TYPE_UNION)
@@ -2805,10 +2805,11 @@ IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
      * struct-sized return slot (the scalar-return branch below) and no
      * hidden parameter. */
     int has_hidden_out_ptr = rettype && irRetIsIndirect(rettype);
-    /* Struct-by-value return: the caller passes a hidden out-pointer
-     * in the first int-arg register. Bumps int_arg_idx so the user's
-     * first real int param lands on the second arg reg. */
-    if (has_hidden_out_ptr) int_arg_idx = 1;
+    /* Struct-by-value return: SysV passes the hidden out-pointer in the
+     * first int-arg register, so it consumes an arg slot and the user's
+     * first real int param lands on the second arg reg. An ABI with a
+     * dedicated sret register (AAPCS64: x8) leaves the arg regs alone. */
+    if (has_hidden_out_ptr && !(pool && pool->sret_reg)) int_arg_idx = 1;
 
     for (u64 i = 0; i < ast_func->params->size; ++i) {
         Ast *ast_param = vecGet(Ast *, ast_func->params, i);
@@ -2996,13 +2997,17 @@ IrFunction *irLowerFunction(IrCtx *ctx, Ast *ast_func) {
 
     IrValue *ir_return_var = NULL;
     if (has_hidden_out_ptr) {
-        /* Hidden out-pointer: arrives in int_arg_regs[0] (rdi), spilled
-         * to a slot via the same arrive+store mechanism as a normal
-         * param. func->return_value is the slot so RET sees a stable
-         * stack location. */
+        /* Hidden out-pointer: arrives in the ABI's sret register (x8 on
+         * AAPCS64, int_arg_regs[0] / rdi on SysV), spilled to a slot via
+         * the same arrive+store mechanism as a normal param.
+         * func->return_value is the slot so RET sees a stable stack
+         * location. */
         IrValue *out_arrive = irTmp(IR_TYPE_PTR, 8);
         out_arrive->kind = IR_VAL_PARAM;
-        if (pool && pool->int_arg_regs->size > 0) {
+        if (pool && pool->sret_reg) {
+            out_arrive->loc.kind = IR_LOC_REG;
+            out_arrive->loc.as.reg = pool->sret_reg;
+        } else if (pool && pool->int_arg_regs->size > 0) {
             out_arrive->loc.kind = IR_LOC_REG;
             out_arrive->loc.as.reg =
                 vecGet(AoStr *, pool->int_arg_regs, 0);

--- a/src/tests/64_sret_x8.HC
+++ b/src/tests/64_sret_x8.HC
@@ -1,0 +1,62 @@
+"Test - indirect struct return C interop: ";
+#include "testhelper.HC"
+
+/* A >16-byte struct return crosses the C boundary via the hidden
+ * out-pointer, and on AArch64 that pointer travels in x8 (AAPCS64's
+ * dedicated indirect-result register) - NOT as a first argument the
+ * way SysV uses rdi. hcc used to apply the SysV rule on arm64: the
+ * callee's real first argument shifted into x1 and the buffer address
+ * sat in x0, so calling any clang-compiled function returning a
+ * >16-byte struct (e.g. raylib's LoadTexture) scrambled every
+ * argument and wrote the result through a stale x8.
+ *
+ * Two-stage test against a genuinely clang-compiled callee/caller:
+ * build a C shared library, then compile a HolyC program that
+ * exercises both directions of the boundary (HolyC caller -> C callee,
+ * and C caller -> HolyC callback) with both the AOT and JIT backends.
+ * No strings or `%` in the generated sources keeps the shell printf
+ * simple (same trick as 60_link.HC). */
+
+I64 correct = 0;
+I64 tests = 3;
+
+if (System("printf '"
+           "typedef struct T { unsigned id; int w; int h; int mip; int fmt; } T;\n"
+           "typedef struct B { long a; long b; long c; } B;\n"
+           "T CMakeTex(int seed) { T t; t.id = seed; t.w = 640; t.h = 480; t.mip = 1; t.fmt = 7; return t; }\n"
+           "long CCallsBack(B (*fn)(long)) { B b = fn(10); return b.a + b.b + b.c; }\n"
+           "' > /tmp/hcc-64-sret.c && "
+           "cc -shared -fPIC /tmp/hcc-64-sret.c -o /tmp/hcc-64-sret.so") == 0) {
+  correct++;
+}
+
+System("printf '"
+       "#link \"/tmp/hcc-64-sret.so\"\n"
+       "class T { U32 id; I32 w, h, mip, fmt; };\n"
+       "class B { I64 a, b, c; };\n"
+       "extern \"c\" T CMakeTex(I32 seed);\n"
+       "extern \"c\" I64 CCallsBack(U0 *fn);\n"
+       "B HcMakeBig(I64 n) { B b; b.a = n; b.b = n * 2; b.c = n * 3; return b; }\n"
+       "I32 Main() {\n"
+       "  T t = CMakeTex(8);\n"
+       "  if (t.id != 8 || t.w != 640 || t.h != 480 || t.mip != 1 || t.fmt != 7) return 1;\n"
+       "  if (CCallsBack((&HcMakeBig)(U0 *)) != 60) return 2;\n"
+       "  return 0;\n"
+       "}\n"
+       "' > /tmp/hcc-64-sret.HC");
+
+if (System("../../hcc /tmp/hcc-64-sret.HC -o /tmp/hcc-64-sret && "
+           "/tmp/hcc-64-sret") == 0) {
+  correct++;
+}
+
+if (System("../../hcc -jit /tmp/hcc-64-sret.HC") == 0) {
+  correct++;
+}
+
+System("rm -f /tmp/hcc-64-sret.c /tmp/hcc-64-sret.so"
+       " /tmp/hcc-64-sret.HC /tmp/hcc-64-sret");
+
+PrintResult(correct, tests);
+'===\n';
+Exit(0);

--- a/src/x86_64-jit.c
+++ b/src/x86_64-jit.c
@@ -1669,6 +1669,7 @@ static void jitInitRegPool(void) {
     pool.float_arg_regs   = fv;
     pool.int_return_reg   = aoStrDupRaw((char *)"rax", 3);
     pool.float_return_reg = aoStrDupRaw((char *)"xmm0", 4);
+    pool.sret_reg         = NULL; /* SysV: sret ptr is the first int arg */
     pool.scratch_regs     = sv;
     pool.variadic_on_stack = 0;
     irRegPoolSet(&pool);

--- a/src/x86_64.c
+++ b/src/x86_64.c
@@ -65,6 +65,7 @@ static void x86_64InitRegPool(void) {
     pool.float_arg_regs   = x86_64MakeAoStrVec(kXmmRegs,     n_float);
     pool.int_return_reg   = aoStrDupRaw((char *)"rax", 3);
     pool.float_return_reg = aoStrDupRaw((char *)"xmm0", 4);
+    pool.sret_reg         = NULL; /* SysV: sret ptr is the first int arg */
     pool.scratch_regs     = x86_64MakeAoStrVec(kScratchRegs, n_scratch);
 
     irRegPoolSet(&pool);


### PR DESCRIPTION
Fixing my incorrect implementation of AAPCS64. Test against `C` to ensure compatibility.