### PR TITLE
Fix: AOT & JIT run files with args are compatible

### DIFF
--- a/src/cli.c
+++ b/src/cli.c
@@ -280,12 +280,14 @@ __noreturn void cliPrintUsage(void) {
 
 AoStr *cliConcatArgv(CliArgs *args) {
     AoStr *s = aoStrNew();
-    for (u64 i = 0; i < args->argv->size; ++i) {
-        if (i + 1 == args->argv->size) {
-            aoStrCatFmt(s, "%s", args->argv->entries[i]);
+    int i = 0;
+    listForEach(args->argv) {
+        if (i + 1 == args->argc) {
+            aoStrCatFmt(s, "%s", it->value);
         } else {
-            aoStrCatFmt(s, "%s, ", args->argv->entries[i]);
+            aoStrCatFmt(s, "%s, ", it->value);
         }
+        i++;
     }
     return s;
 }
@@ -423,7 +425,8 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
             } else {
                 /* Collect arbitrary command line arguments as they could be 
                  * for the jit */
-                vecPush(args->argv, strdup(arg));
+                args->argc++;
+                listAppend(args->argv, strdup(arg));
                 continue;
             }
         }
@@ -525,7 +528,7 @@ int cliParseArgs(CliArgs *args, int argc, char **argv) {
                  "printing assembly to stdout\n");
     }
 
-    if (args->argv->size > 0 && !args->jit && !args->run) {
+    if (args->argc > 0 && !args->jit && !args->run) {
         AoStr *s = cliConcatArgv(args);
         cliPanic("Unknown commandline options: %s\n", s->data);
     }
@@ -544,7 +547,7 @@ void cliArgsInit(CliArgs *args) {
     args->defines_list = NULL;
     args->object_files = NULL;
     args->shared_object_files = NULL;
-    args->argv = vecNew(&vec_cstring_owned_type);
+    args->argv = listNew();
 
     /* We make a stab at trying to guess the target from what we have
      * discovered in the config file */

--- a/src/cli.h
+++ b/src/cli.h
@@ -111,7 +111,8 @@ typedef struct CliArgs {
     List *defines_list;
     List *object_files;
     List *shared_object_files;
-    Vec *argv;
+    int argc;
+    List *argv;
 } CliArgs;
 
 void cliArgsInit(CliArgs *args);

--- a/src/main.c
+++ b/src/main.c
@@ -533,8 +533,16 @@ int main(int argc, char **argv) {
             memoryRelease();
             return 1;
         }
-        int rc = hccJitRunMain(jit, args.argv->size,
-                                    (char **)args.argv->entries);
+
+        listPrepend(args.argv, args.infile);
+        args.argc++;
+
+        char **jit_argv = malloc(sizeof(char *) * args.argc);
+        int i = 0;
+        listForEach(args.argv) {
+            jit_argv[i++] = it->value;
+        }
+        int rc = hccJitRunMain(jit, args.argc, jit_argv);
         if (args.memsafe) memsafeReportLeaks(stderr);
         hccJitFree(jit);
         memoryRelease();


### PR DESCRIPTION
In AOT the first command line argument in `argv` is the name of the program. In JIT the first argument is now the name of the file. This means `argv[0]` is set similarly and thus the rest of the command line arguments filter through correctly. Saves having to do an `#ifjit` which seems a bit needless.