### PR TITLE
Fix relax newline after function definition and remove `#` prefixing ints

### DIFF
--- a/src/holyc-lib/memory.HC
+++ b/src/holyc-lib/memory.HC
@@ -125,6 +125,7 @@ _MEMCPY::
 
 #ifdef __aarch64__
 asm {
+
 _MALLOC::
     STP    X29, X30, [SP, -16]! // save FP/LR - we make a call
     STR    X0, [SP, -16]!       // save size across the call (X1 is caller-saved)
@@ -142,7 +143,7 @@ _FREE::
     SUB    X0, X0, 8
     BL     free
 @@1:
-    LDP    X29, X30, [SP], #16
+    LDP    X29, X30, [SP], 16
     RET
 
 _MSIZE::

--- a/src/holyc-lib/strings.HC
+++ b/src/holyc-lib/strings.HC
@@ -307,15 +307,15 @@ _STRLEN_FAST::
 _STRNCMP::
     CBZ     X2, @@2
 @@1:
-    LDRB    W4, [X0], #1
-    LDRB    W5, [X1], #1
+    LDRB    W4, [X0], 1
+    LDRB    W5, [X1], 1
     SUBS    W6, W4, W5
     B.NE    @@3
     CBZ     W4, @@2
-    SUBS    X2, X2, #1
+    SUBS    X2, X2, 1
     B.NE    @@1
 @@2:
-    MOV     X0, #0
+    MOV     X0, 0
     RET
 @@3:
     SXTW    X0, W6
@@ -326,26 +326,26 @@ _STRNCMP::
 _STRNICMP::
     CBZ     X2, @@2
 @@1:
-    LDRB    W4, [X0], #1
-    LDRB    W5, [X1], #1
+    LDRB    W4, [X0], 1
+    LDRB    W5, [X1], 1
     // Lowercase W4 if it's in 'A'..'Z'
-    SUB     W7, W4, #0x41
-    CMP     W7, #25
-    ADD     W8, W4, #0x20
+    SUB     W7, W4, 0x41
+    CMP     W7, 25
+    ADD     W8, W4, 0x20
     CSEL    W4, W8, W4, LS
     // Lowercase W5 the same way
-    SUB     W7, W5, #0x41
-    CMP     W7, #25
-    ADD     W8, W5, #0x20
+    SUB     W7, W5, 0x41
+    CMP     W7, 25
+    ADD     W8, W5, 0x20
     CSEL    W5, W8, W5, LS
 
     SUBS    W6, W4, W5
     B.NE    @@3
     CBZ     W4, @@2
-    SUBS    X2, X2, #1
+    SUBS    X2, X2, 1
     B.NE    @@1
 @@2:
-    MOV     X0, #0
+    MOV     X0, 0
     RET
 @@3:
     SXTW    X0, W6
@@ -353,12 +353,12 @@ _STRNICMP::
 
 _STRCMP::
 @@1:
-    LDRB    W4, [X0], #1
-    LDRB    W5, [X1], #1
+    LDRB    W4, [X0], 1
+    LDRB    W5, [X1], 1
     SUBS    W6, W4, W5
     B.NE    @@2
     CBNZ    W4, @@1
-    MOV     X0, #0
+    MOV     X0, 0
     RET
 @@2:
     SXTW    X0, W6
@@ -367,8 +367,8 @@ _STRCMP::
 _STRCPY::
     MOV     X2, X0
 @@1:
-    LDRB    W3, [X1], #1
-    STRB    W3, [X0], #1
+    LDRB    W3, [X1], 1
+    STRB    W3, [X0], 1
     CBNZ    W3, @@1
     MOV     X0, X2
     RET

--- a/src/prsasm.c
+++ b/src/prsasm.c
@@ -214,7 +214,6 @@ Ast *prsAsm(Cctrl *cc, int parse_one) {
             Lexeme *next = cctrlTokenPeek(cc);
             if (tokenPunctIs(next, TK_DBL_COLON) || tokenPunctIs(next, ':')) {
                 cctrlAsmTokenGet(cc);
-                cctrlTokenExpect(cc, '\n');
                 prsAsmFlushFunc(cc, funcs, curfunc, cur, func_line);
                 curfunc = aoStrDupRaw(tok->start, tok->len);
                 cc->tmp_asm_fname = curfunc;


### PR DESCRIPTION
- `\n` does not need to follow an assembly function.
- removed `#<int>` from library files... for some reason the preprocessor was picking them up and saying invalid directive... That needs to be investigated but this fix gets things moving again