### PR TITLE
fix: check for array index bounds

### DIFF
--- a/src/prslib.c
+++ b/src/prslib.c
@@ -1216,7 +1216,18 @@ Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast) {
     }
     cctrlTokenExpect(cc, ']');
     Ast *binop = parseCreateBinaryOp(cc, AST_BIN_OP_ADD, ast, subscript);
-    //binop->type = ast->type;
+    
+    if (ast->type->kind == AST_TYPE_ARRAY && ast->type->len > 0 && astIsIntType(subscript->type)) {
+        int ok = 1;
+        const s64 idx = evalIntConstExprOrErr(subscript, &ok);
+        if (ok && (idx < 0 || idx >= ast->type->len)) {
+            cctrlWarningFromTo(cc, "Valid indexes are 0 to the array length minus one",
+                '[', ']',
+                "Array index %ld is out of bounds for an array of length %d",
+                idx, ast->type->len);
+        }
+    }
+
     return astUnaryOperator(binop->type->ptr, AST_UN_OP_DEREF, binop);
 }
 

--- a/src/prslib.c
+++ b/src/prslib.c
@@ -1216,10 +1216,20 @@ Ast *parseSubscriptExpr(Cctrl *cc, Ast *ast) {
     }
     cctrlTokenExpect(cc, ']');
     Ast *binop = parseCreateBinaryOp(cc, AST_BIN_OP_ADD, ast, subscript);
-    
-    if (ast->type->kind == AST_TYPE_ARRAY && ast->type->len > 0 && astIsIntType(subscript->type)) {
+
+    if (!astIsIntType(subscript->type)) {
+        cctrlRaiseExceptionFromTo(cc, "Subscript expressions must evaluate to an integer type",
+            '[', ']',
+            "Cannot subscript `%s` with a %s of type `%s`",
+            astTypeToString(ast->type),
+            astKindToHumanReadable(subscript),
+            astTypeToString(subscript->type));
+    }
+
+    if (astTypeIsArray(ast->type) && ast->type->len > 0) {
         int ok = 1;
         const s64 idx = evalIntConstExprOrErr(subscript, &ok);
+
         if (ok && (idx < 0 || idx >= ast->type->len)) {
             cctrlWarningFromTo(cc, "Valid indexes are 0 to the array length minus one",
                 '[', ']',

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef VERSION__
 #define VERSION__
 
-#define HCC_VERSION ("v0.0.16-beta")
+#define HCC_VERSION ("v0.0.15-beta")
 
 static inline const char *cctrlGetVersion(void) {
     return HCC_VERSION;

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef VERSION__
 #define VERSION__
 
-#define HCC_VERSION ("v0.0.15-beta")
+#define HCC_VERSION ("v0.0.16-beta")
 
 static inline const char *cctrlGetVersion(void) {
     return HCC_VERSION;


### PR DESCRIPTION
Added a compile-time warning when indexing a fixed-size array with a subscript that is a compile-time-constant integer expression falling outside of [0, len), e.g.: arr[5] on an I64 arr[5]

It uses ```cctrlWarningFromTo```, so it's a warning and not an hard error. It only escalates as a hard error under the -Werror flag

Also bumped ```HCC_VERSION``` to ```v0.0.16-beta```